### PR TITLE
Sync patches with our latest 2.30.8-8.2 branch

### DIFF
--- a/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
+++ b/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
@@ -1,7 +1,7 @@
 From ca464c9f43c5e52420b75f37854cf5db826a929c Mon Sep 17 00:00:00 2001
 From: Mark Syms <mark.syms@citrix.com>
 Date: Thu, 20 May 2021 17:40:06 +0100
-Subject: [PATCH 01/14] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
+Subject: [PATCH 01/16] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
  CA-354692: check for device parameter in create/probe calls
 
 Signed-off-by: Mark Syms <mark.syms@citrix.com>
@@ -87,5 +87,5 @@ index 3311e55..ad28649 100755
  def registerSR(SRClass):
      """Register SR with handler. All SR subclasses should call this in 
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From 618d0f65369b2dd5b6243aae937cca516355205c Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 02/14] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 02/16] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.
@@ -21,5 +21,5 @@ index 99cb313..609c6ef 100644
  Conflicts=shutdown.target
  RefuseManualStop=yes
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0003-Add-TrueNAS-multipath-config.patch
+++ b/SOURCES/0003-Add-TrueNAS-multipath-config.patch
@@ -1,7 +1,7 @@
 From 37b279a8daca22aae97862bed2a3976132b218bd Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:26:43 +0200
-Subject: [PATCH 03/14] Add TrueNAS multipath config
+Subject: [PATCH 03/16] Add TrueNAS multipath config
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.
@@ -26,5 +26,5 @@ index aaf45e5..1073faa 100644
 +	}
  }
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
+++ b/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
@@ -1,7 +1,7 @@
 From 21ad2a6035dca5e2dc889880a90020348be52dd8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 04/14] feat(drivers): add CephFS, GlusterFS and XFS drivers
+Subject: [PATCH 04/16] feat(drivers): add CephFS, GlusterFS and XFS drivers
 
 ---
  Makefile               |   3 +
@@ -888,5 +888,5 @@ index 97c332c..ad1ee86 100755
      if not type in SR.TYPES:
          raise util.SMException("Unsupported SR type: %s" % type)
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From 9cb3f6724c62bfda5eaf5a29952c4d0b83dcffdf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 05/14] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 05/16] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---
@@ -201,5 +201,5 @@ index ad1ee86..327103f 100755
          type = SR.TYPE_FILE
      if not type in SR.TYPES:
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
+++ b/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
@@ -1,7 +1,7 @@
 From ece61a8594f7337fb86bb1ea4893d43d8c554fec Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 17:10:12 +0200
-Subject: [PATCH 06/14] Re-add the ext4 driver for users who need to transition
+Subject: [PATCH 06/16] Re-add the ext4 driver for users who need to transition
 
 The driver is needed to transition to the ext driver.
 Users who upgrade from XCP-ng <= 8.0 need a working driver so that they
@@ -287,5 +287,5 @@ index 327103f..867c789 100755
          type = SR.TYPE_FILE
      if not type in SR.TYPES:
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From dec7d21fc5380fc6c2866fbfe8dcece9e937071c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 07/14] feat(drivers): add LinstorSR driver
+Subject: [PATCH 07/16] feat(drivers): add LinstorSR driver
 
 Some important points:
 
@@ -5675,5 +5675,5 @@ diff --git a/tests/mocks/linstor/__init__.py b/tests/mocks/linstor/__init__.py
 new file mode 100644
 index 0000000..e69de29
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From 5f4ae6317d4505fcab4ed7e959f11389a4d7a442 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 08/14] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 08/16] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages
@@ -205,5 +205,5 @@ index 0000000..6f8040d
 +            failed = True
 +        self.assertTrue(failed)
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
+++ b/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
@@ -1,7 +1,7 @@
 From a53beccf65c329a7f1af25c330c20f770252b7fd Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Thu, 25 Feb 2021 09:54:52 +0100
-Subject: [PATCH 09/14] If no NFS ACLs provided, assume everyone:
+Subject: [PATCH 09/16] If no NFS ACLs provided, assume everyone:
 
 Some QNAP devices do not provide ACL when fetching NFS mounts.
 In this case the assumed ACL should be: "*".
@@ -71,5 +71,5 @@ index 71800ab..cef414f 100644
 +        self.assertEqual(len(pread2.mock_calls), 1)
 +        pread2.assert_called_with(['/usr/sbin/showmount', '--no-headers', '-e', 'aServer'])
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From c1483fc0d2394cf297ff304ee09faafd2b2b2143 Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 10/14] Added SM Driver for MooseFS
+Subject: [PATCH 10/16] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
@@ -386,5 +386,5 @@ index 0000000..5a61cf5
 +        mfssr.detach('asr_uuid')
 +        self.assertTrue(mfssr.attached)
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From fc0e53774691db631e3bfadfabe4e8de81d686bd Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 11/14] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 11/16] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir
@@ -103,5 +103,5 @@ index 914b961..a5b3290 100644
  class TestISOSR_overNFS(unittest.TestCase):
  
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From 037e7181a8faf00d01cda4813d3c833e81296279 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 12/14] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 12/16] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior
@@ -126,5 +126,5 @@ index be5112c..ab72f4e 100755
              self.detach(sr_uuid)
              if inst.code != errno.ENOENT:
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From ad8693df57172278677a61607cecc057efc729a1 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 13/14] Fix is_open call for many drivers (#25)
+Subject: [PATCH 13/16] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.
@@ -104,5 +104,5 @@ index 0d60d96..534e6c9 100755
  
      driver = SR.driver(srType)
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From 32be9cfcd581a06075c549f68aff3ed709affcad Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 14/14] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 14/16] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.
@@ -56,5 +56,5 @@ index ab72f4e..212f1ad 100755
                  "VDI_UPDATE", "VDI_CLONE", "VDI_SNAPSHOT", "VDI_RESIZE", "VDI_MIRROR",
                  "VDI_GENERATE_CONFIG",
 -- 
-2.39.2
+2.41.0
 

--- a/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
+++ b/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
@@ -1,0 +1,28 @@
+From 1167204e6869853c63c9a0daa0b7582bccac0fc4 Mon Sep 17 00:00:00 2001
+From: BenjiReis <benjamin.reis@vates.fr>
+Date: Fri, 4 Aug 2023 12:10:08 +0200
+Subject: [PATCH 15/16] Remove `SR_PROBE` from ZFS capabilities (#37)
+
+The probe method is not implemented so we
+shouldn't advertise it.
+
+Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ drivers/ZFSSR.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/ZFSSR.py b/drivers/ZFSSR.py
+index d375210..b803211 100644
+--- a/drivers/ZFSSR.py
++++ b/drivers/ZFSSR.py
+@@ -23,7 +23,6 @@ import util
+ import xs_errors
+ 
+ CAPABILITIES = [
+-    'SR_PROBE',
+     'SR_UPDATE',
+     'VDI_CREATE',
+     'VDI_DELETE',
+-- 
+2.41.0
+

--- a/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,0 +1,36 @@
+From 3bf41acc381c3d89e0bd0e017fd1653076987ae9 Mon Sep 17 00:00:00 2001
+From: Guillaume <guillaume.thouvenin@vates.tech>
+Date: Wed, 16 Aug 2023 13:42:21 +0200
+Subject: [PATCH 16/16] Fix vdi-ref when static vdis are used
+
+When static vdis are used there is no snapshots and we don't want to
+call method from XAPI.
+
+Signed-off-by: Guillaume <guillaume.thouvenin@vates.tech>
+---
+ drivers/LVHDSR.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/LVHDSR.py b/drivers/LVHDSR.py
+index dd8e20b..6ac3f80 100755
+--- a/drivers/LVHDSR.py
++++ b/drivers/LVHDSR.py
+@@ -1532,10 +1532,11 @@ class LVHDVDI(VDI.VDI):
+         elif self.sr.provision == "thick":
+             needDeflate = False
+             # except for snapshots, which are always deflated
+-            vdi_ref = self.sr.srcmd.params['vdi_ref']
+-            snap = self.session.xenapi.VDI.get_is_a_snapshot(vdi_ref)
+-            if snap:
+-                needDeflate = True
++            if self.sr.srcmd.cmd != 'vdi_detach_from_config':
++                vdi_ref = self.sr.srcmd.params['vdi_ref']
++                snap = self.session.xenapi.VDI.get_is_a_snapshot(vdi_ref)
++                if snap:
++                    needDeflate = True
+ 
+         if needDeflate:
+             try:
+-- 
+2.41.0
+

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 2.30.8
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -86,6 +86,8 @@ Patch1011: 0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
 Patch1012: 0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
 Patch1013: 0013-Fix-is_open-call-for-many-drivers-25.patch
 Patch1014: 0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+Patch1015: 0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
+Patch1016: 0016-Fix-vdi-ref-when-static-vdis-are-used.patch
 
 %description
 This package contains storage backends used in XCP
@@ -463,6 +465,11 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
+* Tue Aug 22 2023 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 2.30.8-2.2
+- Fix issues when running quicktest on ZFS and LVMoISCSI
+- Add 0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
+- Add 0016-Fix-vdi-ref-when-static-vdis-are-used.patch
+
 * Tue Apr 25 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 2.30.8-2.1
 - Sync with hotfix XS82ECU1022
 - Sync patches with our latest 2.30.8-8.2 branch


### PR DESCRIPTION
These two patches fix issues when running quicktest on ZFS and LVMoISCI
    - Add 0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
    - Add 0016-Fix-vdi-ref-when-static-vdis-are-used.patch