### PR TITLE
Add fixes for ZFS, Linstor and static vdis

### DIFF
--- a/SOURCES/0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From 07c144eaff5c2b547c38c7c3854dc5dcce9094ca Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 01/22] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 01/24] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0002-Add-TrueNAS-multipath-config.patch
+++ b/SOURCES/0002-Add-TrueNAS-multipath-config.patch
@@ -1,7 +1,7 @@
 From 943b5ff2a957235c79cd06a8a11b324bea1d782f Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:26:43 +0200
-Subject: [PATCH 02/22] Add TrueNAS multipath config
+Subject: [PATCH 02/24] Add TrueNAS multipath config
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0003-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
+++ b/SOURCES/0003-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
@@ -1,7 +1,7 @@
 From f613140b17a7d5efebf1ab511a693f0b01f6df13 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 03/22] feat(drivers): add CephFS and GlusterFS drivers
+Subject: [PATCH 03/24] feat(drivers): add CephFS and GlusterFS drivers
 
 ---
  Makefile               |   2 +

--- a/SOURCES/0004-feat-drivers-add-XFS-driver.patch
+++ b/SOURCES/0004-feat-drivers-add-XFS-driver.patch
@@ -1,7 +1,7 @@
 From cf480ecb48d156f3efcc7179ff9c54895773921d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 04/22] feat(drivers): add XFS driver
+Subject: [PATCH 04/24] feat(drivers): add XFS driver
 
 Originally-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 

--- a/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From b1f4dd1bd94e163f0c181e88ae228291ad6107ee Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 05/22] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 05/24] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---

--- a/SOURCES/0006-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0006-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From 4cd515127f947e1478813cba4ce979baebe8c756 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 06/22] feat(drivers): add LinstorSR driver
+Subject: [PATCH 06/24] feat(drivers): add LinstorSR driver
 
 Some important points:
 

--- a/SOURCES/0007-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0007-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From 1b0835c01be487aa71c462cb8d067c63e41f6e01 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 07/22] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 07/24] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages

--- a/SOURCES/0008-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0008-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From d05e4d21a3a40f36977f989173bec3272d121354 Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 08/22] Added SM Driver for MooseFS
+Subject: [PATCH 08/24] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>

--- a/SOURCES/0009-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0009-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From 76e113a07379011092bc990b2545217e563c4bd0 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 09/22] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 09/24] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir

--- a/SOURCES/0010-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0010-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From d8b9287e1992b3a50307697dfb2e04ad9789e176 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 10/22] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 10/24] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior

--- a/SOURCES/0011-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0011-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From ad1b55cc509b6be593f5b7343bc3423d9504211d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 11/22] Fix is_open call for many drivers (#25)
+Subject: [PATCH 11/24] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.

--- a/SOURCES/0012-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0012-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From 95f6b4896a68b3d0f0bacc0486994586bc6205bf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 12/22] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 12/24] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.

--- a/SOURCES/0013-Fix-code-coverage-regarding-MooseFSSR-and-ZFSSR-29.patch
+++ b/SOURCES/0013-Fix-code-coverage-regarding-MooseFSSR-and-ZFSSR-29.patch
@@ -1,7 +1,7 @@
 From a000cb12acbc44fe1020c1f62d1247a0841a6aa9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 19 Sep 2022 10:31:00 +0200
-Subject: [PATCH 13/22] Fix code coverage regarding MooseFSSR and ZFSSR (#29)
+Subject: [PATCH 13/24] Fix code coverage regarding MooseFSSR and ZFSSR (#29)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0014-py3-simple-changes-from-futurize-on-XCP-ng-drivers.patch
+++ b/SOURCES/0014-py3-simple-changes-from-futurize-on-XCP-ng-drivers.patch
@@ -1,7 +1,7 @@
 From 0190bca54fa3ba669c53838624d97e0dfff6ef72 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:13:18 +0100
-Subject: [PATCH 14/22] py3: simple changes from futurize on XCP-ng drivers
+Subject: [PATCH 14/24] py3: simple changes from futurize on XCP-ng drivers
 
 * `except` syntax fixes
 * drop `has_key()` usage

--- a/SOURCES/0015-py3-futurize-fix-of-xmlrpc-calls-for-CephFS-GlusterF.patch
+++ b/SOURCES/0015-py3-futurize-fix-of-xmlrpc-calls-for-CephFS-GlusterF.patch
@@ -1,7 +1,7 @@
 From 72f8637e18bcfb8f928b86971c1198bde5faf7ee Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:28:10 +0100
-Subject: [PATCH 15/22] py3: futurize fix of xmlrpc calls for CephFS,
+Subject: [PATCH 15/24] py3: futurize fix of xmlrpc calls for CephFS,
  GlusterFS, MooseFS, Linstore
 
 Signed-off-by: Yann Dirson <yann.dirson@vates.fr>

--- a/SOURCES/0016-py3-use-of-integer-division-operator.patch
+++ b/SOURCES/0016-py3-use-of-integer-division-operator.patch
@@ -1,7 +1,7 @@
 From 0bd27047cabc40bfeb0affe5be8853022e9afc5b Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:32:37 +0100
-Subject: [PATCH 16/22] py3: use of integer division operator
+Subject: [PATCH 16/24] py3: use of integer division operator
 
 Guided by futurize's "old_div" use
 

--- a/SOURCES/0017-test_on_slave-allow-to-work-with-SR-using-absolute-P.patch
+++ b/SOURCES/0017-test_on_slave-allow-to-work-with-SR-using-absolute-P.patch
@@ -1,7 +1,7 @@
 From f395ccb05bae57bed51413f2e59d09c5b505313f Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 13:53:21 +0100
-Subject: [PATCH 17/22] test_on_slave: allow to work with SR using absolute
+Subject: [PATCH 17/24] test_on_slave: allow to work with SR using absolute
  PROBE_MOUNTPOINT
 
 PROBE_MOUNTPOINT in a some drivers is a relative path, which is resolved

--- a/SOURCES/0018-py3-switch-interpreter-to-python3.patch
+++ b/SOURCES/0018-py3-switch-interpreter-to-python3.patch
@@ -1,7 +1,7 @@
 From 70058156f4f0c38c2c79725c94201efbe550ea28 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Mon, 27 Mar 2023 15:30:46 +0200
-Subject: [PATCH 18/22] py3: switch interpreter to python3
+Subject: [PATCH 18/24] py3: switch interpreter to python3
 
 ---
  drivers/CephFSSR.py             | 2 +-

--- a/SOURCES/0019-Support-recent-version-of-coverage-tool.patch
+++ b/SOURCES/0019-Support-recent-version-of-coverage-tool.patch
@@ -1,7 +1,7 @@
 From 1c1b3bf866bb9cb51de19147f4733099cc07183f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 4 May 2023 10:24:22 +0200
-Subject: [PATCH 19/22] Support recent version of coverage tool (coverage
+Subject: [PATCH 19/24] Support recent version of coverage tool (coverage
  7.2.5)
 
 Without these changes many warns/errors are emitted:

--- a/SOURCES/0020-Fix-blktap-error-mapping-in-python3.patch
+++ b/SOURCES/0020-Fix-blktap-error-mapping-in-python3.patch
@@ -1,7 +1,7 @@
 From 0ab24af4e6a2cd9075fda7f7e02658acf7169d06 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 5 Jul 2023 11:41:41 +0200
-Subject: [PATCH 20/22] Fix blktap error mapping in python3
+Subject: [PATCH 20/24] Fix blktap error mapping in python3
 
 ```
     def _errmsg(self):

--- a/SOURCES/0021-feat-LinstorSR-import-all-8.2-changes.patch
+++ b/SOURCES/0021-feat-LinstorSR-import-all-8.2-changes.patch
@@ -1,7 +1,7 @@
 From bdb879ac3c9d54d928166fe530df9be76cb7c75d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 20 Nov 2020 16:42:52 +0100
-Subject: [PATCH 21/22] feat(LinstorSR): import all 8.2 changes
+Subject: [PATCH 21/24] feat(LinstorSR): import all 8.2 changes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0022-feat-LinstorSR-is-now-compatible-with-python-3.patch
+++ b/SOURCES/0022-feat-LinstorSR-is-now-compatible-with-python-3.patch
@@ -1,7 +1,7 @@
 From ee506590b8497ddad1a29c0c9d05a73f9c877fa6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 30 Jun 2023 12:41:43 +0200
-Subject: [PATCH 22/22] feat(LinstorSR): is now compatible with python 3
+Subject: [PATCH 22/24] feat(LinstorSR): is now compatible with python 3
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0023-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
+++ b/SOURCES/0023-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
@@ -1,0 +1,28 @@
+From a92d85c6ba952d25b8008c4f92e5f65612f82060 Mon Sep 17 00:00:00 2001
+From: BenjiReis <benjamin.reis@vates.fr>
+Date: Fri, 4 Aug 2023 12:10:37 +0200
+Subject: [PATCH 23/24] Remove `SR_PROBE` from ZFS capabilities (#36)
+
+The probe method is not implemented so we
+shouldn't advertise it.
+
+Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ drivers/ZFSSR.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/ZFSSR.py b/drivers/ZFSSR.py
+index 354ca90..5301d5e 100644
+--- a/drivers/ZFSSR.py
++++ b/drivers/ZFSSR.py
+@@ -23,7 +23,6 @@ import util
+ import xs_errors
+ 
+ CAPABILITIES = [
+-    'SR_PROBE',
+     'SR_UPDATE',
+     'VDI_CREATE',
+     'VDI_DELETE',
+-- 
+2.41.0
+

--- a/SOURCES/0024-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0024-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,0 +1,37 @@
+From 943677ab9173541505aedbb0ec8667cca6c1bfe4 Mon Sep 17 00:00:00 2001
+From: Guillaume <guillaume.thouvenin@vates.tech>
+Date: Wed, 16 Aug 2023 13:42:21 +0200
+Subject: [PATCH 24/24] Fix vdi-ref when static vdis are used
+
+When static vdis are used there is no snapshots and we don't want to
+call method from XAPI.
+Upstream PR: https://github.com/xapi-project/sm/pull/631
+
+Signed-off-by: Guillaume <guillaume.thouvenin@vates.tech>
+---
+ drivers/LVHDSR.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/LVHDSR.py b/drivers/LVHDSR.py
+index 94d1d45..9791c59 100755
+--- a/drivers/LVHDSR.py
++++ b/drivers/LVHDSR.py
+@@ -1510,10 +1510,11 @@ class LVHDVDI(VDI.VDI):
+         elif self.sr.provision == "thick":
+             needDeflate = False
+             # except for snapshots, which are always deflated
+-            vdi_ref = self.sr.srcmd.params['vdi_ref']
+-            snap = self.session.xenapi.VDI.get_is_a_snapshot(vdi_ref)
+-            if snap:
+-                needDeflate = True
++            if self.sr.srcmd.cmd != 'vdi_detach_from_config':
++                vdi_ref = self.sr.srcmd.params['vdi_ref']
++                snap = self.session.xenapi.VDI.get_is_a_snapshot(vdi_ref)
++                if snap:
++                    needDeflate = True
+ 
+         if needDeflate:
+             try:
+-- 
+2.41.0
+

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -5,7 +5,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.0.3
-Release: 1.4%{?xsrel}%{?dist}
+Release: 1.5%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -66,6 +66,8 @@ Patch1019: 0019-Support-recent-version-of-coverage-tool.patch
 Patch1020: 0020-Fix-blktap-error-mapping-in-python3.patch
 Patch1021: 0021-feat-LinstorSR-import-all-8.2-changes.patch
 Patch1022: 0022-feat-LinstorSR-is-now-compatible-with-python-3.patch
+Patch1023: 0023-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
+Patch1028: 0024-Fix-vdi-ref-when-static-vdis-are-used.patch
 
 %description
 This package contains storage backends used in XCP
@@ -312,6 +314,11 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
+* Tue Aug 22 2023 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 3.0.3-1.5
+- Fix issues when running quicktest on ZFS and LVMoISCSI
+- Add 0023-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
+- Add 0024-Fix-vdi-ref-when-static-vdis-are-used.patch
+
 * Mon Jul 31 2023 Benjamin Reis <benjamin.reis@vates.fr> - 3.0.3-1.4
 - Drop 0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
 


### PR DESCRIPTION
This adds fixes for ZFS, Linstor and static vdis
  - 0023-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
  - 0024-Fix-vdi-ref-when-static-vdis-are-used.patch