### PR TITLE
Import sm 8.2 LINSTOR fixes on 8.3

### DIFF
--- a/SOURCES/0019-feat-LinstorSR-import-all-8.2-changes.patch
+++ b/SOURCES/0019-feat-LinstorSR-import-all-8.2-changes.patch
@@ -1,4 +1,4 @@
-From d806026ef5aa1ca03de0af0914c148115d3b8378 Mon Sep 17 00:00:00 2001
+From 8a9cc0778b7a11ac20ea6d4e48be602868c0b44d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 20 Nov 2020 16:42:52 +0100
 Subject: [PATCH 19/22] feat(LinstorSR): import all 8.2 changes
@@ -6,7 +6,7 @@ Subject: [PATCH 19/22] feat(LinstorSR): import all 8.2 changes
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
  Makefile                                      |   10 +
- drivers/LinstorSR.py                          | 1320 ++++++++---
+ drivers/LinstorSR.py                          | 1328 ++++++++---
  drivers/blktap2.py                            |   23 +-
  drivers/cleanup.py                            |  168 +-
  drivers/linstor-manager                       |  785 ++++++-
@@ -24,7 +24,7 @@ Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
  scripts/linstor-kv-tool                       |   78 +
  scripts/safe-umount                           |   39 +
  tests/test_on_slave.py                        |   10 +-
- 19 files changed, 4376 insertions(+), 870 deletions(-)
+ 19 files changed, 4383 insertions(+), 871 deletions(-)
  create mode 100644 etc/systemd/system/linstor-satellite.service.d/override.conf
  create mode 100644 etc/systemd/system/var-lib-linstor.service
  create mode 100755 scripts/fork-log-daemon
@@ -74,7 +74,7 @@ index 9cba307..30d1b79 100755
  	install -m 755 scripts/check-device-sharing $(SM_STAGING)$(LIBEXEC)
  	install -m 755 scripts/usb_change $(SM_STAGING)$(LIBEXEC)
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index a72d43e..77f5683 100755
+index a72d43e..9cb4ed4 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
 @@ -19,8 +19,11 @@ from constants import CBTLOG_TAG
@@ -196,7 +196,16 @@ index a72d43e..77f5683 100755
              image_type
          )
  
-@@ -160,32 +183,45 @@ def detach_thin(session, linstor, sr_uuid, vdi_uuid):
+@@ -152,7 +175,7 @@ def attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid):
+         lock.release()
+ 
+ 
+-def detach_thin(session, linstor, sr_uuid, vdi_uuid):
++def detach_thin_impl(session, linstor, sr_uuid, vdi_uuid):
+     volume_metadata = linstor.get_volume_metadata(vdi_uuid)
+     image_type = volume_metadata.get(VDI_TYPE_TAG)
+     if image_type == vhdutil.VDI_TYPE_RAW:
+@@ -160,36 +183,55 @@ def detach_thin(session, linstor, sr_uuid, vdi_uuid):
  
      lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
      try:
@@ -236,11 +245,7 @@ index a72d43e..77f5683 100755
 +
 +        # We can have multiple VBDs attached to a VDI during a VM-template clone.
 +        # So we use a timeout to ensure that we can detach the volume properly.
-+        try:
-+            util.retry(check_vbd_count, maxretry=20, period=1)
-+        except Exception:
-+            # In this case we can't deflate the volume.
-+            return
++        util.retry(check_vbd_count, maxretry=10, period=1)
  
          device_path = linstor.get_device_path(vdi_uuid)
          new_volume_size = LinstorVolumeManager.round_up_volume_size(
@@ -259,7 +264,21 @@ index a72d43e..77f5683 100755
      finally:
          lock.release()
  
-@@ -197,7 +233,7 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
+ 
++def detach_thin(session, linstor, sr_uuid, vdi_uuid):
++    # This function must always return without errors.
++    # Otherwise it could cause errors in the XAPI regarding the state of the VDI.
++    # It's why we use this `try` block.
++    try:
++        detach_thin_impl(session, linstor, sr_uuid, vdi_uuid)
++    except Exception as e:
++        util.SMlog('Failed to detach properly VDI {}: {}'.format(vdi_uuid, e))
++
++
+ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
+     # Only inflate if the LINSTOR volume capacity is not enough.
+     new_size = LinstorVolumeManager.round_up_volume_size(new_size)
+@@ -197,7 +239,7 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
          return
  
      util.SMlog(
@@ -268,7 +287,7 @@ index a72d43e..77f5683 100755
          .format(vdi_uuid, new_size, old_size)
      )
  
-@@ -206,8 +242,15 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
+@@ -206,8 +248,15 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
      )
      linstor.resize_volume(vdi_uuid, new_size)
  
@@ -285,7 +304,7 @@ index a72d43e..77f5683 100755
          vhdutil.VHD_FOOTER_SIZE
      ):
          raise xs_errors.XenError(
-@@ -215,11 +258,11 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
+@@ -215,11 +264,11 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
              opterr='Failed to zero out VHD footer {}'.format(vdi_path)
          )
  
@@ -299,7 +318,7 @@ index a72d43e..77f5683 100755
      new_size = LinstorVolumeManager.round_up_volume_size(new_size)
      if new_size >= old_size:
          return
-@@ -229,16 +272,86 @@ def deflate(vdi_uuid, vdi_path, new_size, old_size):
+@@ -229,16 +278,86 @@ def deflate(vdi_uuid, vdi_path, new_size, old_size):
          .format(vdi_uuid, new_size, old_size)
      )
  
@@ -388,7 +407,7 @@ index a72d43e..77f5683 100755
  # device-config:group-name=vg_loop device-config:redundancy=2
  
  
-@@ -250,6 +363,11 @@ class LinstorSR(SR.SR):
+@@ -250,6 +369,11 @@ class LinstorSR(SR.SR):
  
      MANAGER_PLUGIN = 'linstor-manager'
  
@@ -400,7 +419,7 @@ index a72d43e..77f5683 100755
      # --------------------------------------------------------------------------
      # SR methods.
      # --------------------------------------------------------------------------
-@@ -265,8 +383,6 @@ class LinstorSR(SR.SR):
+@@ -265,8 +389,6 @@ class LinstorSR(SR.SR):
              )
  
          # Check parameters.
@@ -409,7 +428,7 @@ index a72d43e..77f5683 100755
          if 'group-name' not in self.dconf or not self.dconf['group-name']:
              raise xs_errors.XenError('LinstorConfigGroupNameMissing')
          if 'redundancy' not in self.dconf or not self.dconf['redundancy']:
-@@ -289,6 +405,10 @@ class LinstorSR(SR.SR):
+@@ -289,6 +411,10 @@ class LinstorSR(SR.SR):
          else:
              self._provisioning = self.PROVISIONING_DEFAULT
  
@@ -420,7 +439,7 @@ index a72d43e..77f5683 100755
          # Note: We don't have access to the session field if the
          # 'vdi_attach_from_config' command is executed.
          self._has_session = self.sr_ref and self.session is not None
-@@ -307,8 +427,8 @@ class LinstorSR(SR.SR):
+@@ -307,8 +433,8 @@ class LinstorSR(SR.SR):
          self.lock = Lock(vhdutil.LOCK_TYPE_SR, self.uuid)
          self.sr_vditype = SR.DEFAULT_TAP
  
@@ -431,17 +450,17 @@ index a72d43e..77f5683 100755
          self._linstor = None  # Ensure that LINSTOR attribute exists.
          self._journaler = None
  
-@@ -317,46 +437,75 @@ class LinstorSR(SR.SR):
+@@ -317,46 +443,75 @@ class LinstorSR(SR.SR):
              self._is_master = True
          self._group_name = self.dconf['group-name']
  
 -        self._master_uri = None
 -        self._vdi_shared_locked = False
 +        self._vdi_shared_time = 0
++
++        self._init_status = self.INIT_STATUS_NOT_SET
  
 -        self._initialized = False
-+        self._init_status = self.INIT_STATUS_NOT_SET
-+
 +        self._vdis_loaded = False
 +        self._all_volume_info_cache = None
 +        self._all_volume_metadata_cache = None
@@ -486,15 +505,15 @@ index a72d43e..77f5683 100755
 +                            uri,
                              self._group_name,
 -                            logger=util.SMlog
--                        )
++                            logger=util.SMlog,
++                            attempt_count=attempt_count
+                         )
 -                        return
 -                    except Exception as e:
 -                        util.SMlog(
 -                            'Ignore exception. Failed to build LINSTOR '
 -                            'instance without session: {}'.format(e)
-+                            logger=util.SMlog,
-+                            attempt_count=attempt_count
-                         )
+-                        )
 -                return
 +                        # Only required if we are attaching from config using a non-special VDI.
 +                        # I.e. not an HA volume.
@@ -538,12 +557,13 @@ index a72d43e..77f5683 100755
  
              if not self._is_master:
                  if self.cmd in [
-@@ -374,37 +523,12 @@ class LinstorSR(SR.SR):
+@@ -374,37 +529,12 @@ class LinstorSR(SR.SR):
                  # behaviors if the GC is executed during an action on a slave.
                  if self.cmd.startswith('vdi_'):
                      self._shared_lock_vdi(self.srcmd.params['vdi_uuid'])
 -                    self._vdi_shared_locked = True
--
++                    self._vdi_shared_time = time.time()
+ 
 -            self._journaler = LinstorJournaler(
 -                self._master_uri, self._group_name, logger=util.SMlog
 -            )
@@ -553,8 +573,7 @@ index a72d43e..77f5683 100755
 -            if self.srcmd.cmd == 'sr_create':
 -                # TODO: Disable if necessary
 -                self._enable_linstor_on_all_hosts(status=True)
-+                    self._vdi_shared_time = time.time()
- 
+-
 -            try:
 -                # Try to open SR if exists.
 -                self._linstor = LinstorVolumeManager(
@@ -581,7 +600,7 @@ index a72d43e..77f5683 100755
                      raise xs_errors.XenError('SRUnavailable', opterr=str(e))
  
              if self._linstor:
-@@ -416,41 +540,87 @@ class LinstorSR(SR.SR):
+@@ -416,41 +546,87 @@ class LinstorSR(SR.SR):
                  if hosts:
                      util.SMlog('Failed to join node(s): {}'.format(hosts))
  
@@ -678,7 +697,7 @@ index a72d43e..77f5683 100755
              raise xs_errors.XenError(
                  'LinstorSRCreate',
                  opterr='Redundancy greater than host count'
-@@ -472,15 +642,45 @@ class LinstorSR(SR.SR):
+@@ -472,15 +648,45 @@ class LinstorSR(SR.SR):
                          opterr='group name must be unique'
                      )
  
@@ -726,7 +745,7 @@ index a72d43e..77f5683 100755
                  logger=util.SMlog
              )
              self._vhdutil = LinstorVhdUtil(self.session, self._linstor)
-@@ -488,30 +688,83 @@ class LinstorSR(SR.SR):
+@@ -488,30 +694,83 @@ class LinstorSR(SR.SR):
              util.SMlog('Failed to create LINSTOR SR: {}'.format(e))
              raise xs_errors.XenError('LinstorSRCreate', opterr=str(e))
  
@@ -763,9 +782,7 @@ index a72d43e..77f5683 100755
 +                'LinstorSRDelete',
 +                opterr='Cannot get controller node name'
 +            )
- 
--            # TODO: Maybe remove all volumes unused by the SMAPI.
--            # We must ensure it's a safe idea...
++
 +        host = None
 +        if node_name == 'localhost':
 +            host = util.get_this_host_ref(self.session)
@@ -784,13 +801,15 @@ index a72d43e..77f5683 100755
 +                )
 +            )
  
--            self._linstor.destroy()
--            Lock.cleanupAll(self.uuid)
+-            # TODO: Maybe remove all volumes unused by the SMAPI.
+-            # We must ensure it's a safe idea...
 +        try:
 +            self._update_drbd_reactor_on_all_hosts(
 +                controller_node_name=node_name, enabled=False
 +            )
-+
+ 
+-            self._linstor.destroy()
+-            Lock.cleanupAll(self.uuid)
 +            args = {
 +                'groupName': self._group_name,
 +            }
@@ -818,7 +837,7 @@ index a72d43e..77f5683 100755
      @_locked_load
      def update(self, uuid):
          util.SMlog('LinstorSR.update for {}'.format(self.uuid))
-@@ -558,6 +811,9 @@ class LinstorSR(SR.SR):
+@@ -558,6 +817,9 @@ class LinstorSR(SR.SR):
  
      @_locked_load
      def scan(self, uuid):
@@ -828,7 +847,7 @@ index a72d43e..77f5683 100755
          util.SMlog('LinstorSR.scan for {}'.format(self.uuid))
          if not self._linstor:
              raise xs_errors.XenError(
-@@ -565,6 +821,9 @@ class LinstorSR(SR.SR):
+@@ -565,6 +827,9 @@ class LinstorSR(SR.SR):
                  opterr='no such volume group: {}'.format(self._group_name)
              )
  
@@ -838,7 +857,7 @@ index a72d43e..77f5683 100755
          self._update_physical_size()
  
          for vdi_uuid in self.vdis.keys():
-@@ -588,10 +847,9 @@ class LinstorSR(SR.SR):
+@@ -588,10 +853,9 @@ class LinstorSR(SR.SR):
      # --------------------------------------------------------------------------
  
      def _shared_lock_vdi(self, vdi_uuid, locked=True):
@@ -851,7 +870,7 @@ index a72d43e..77f5683 100755
          args = {
              'groupName': self._group_name,
              'srUuid': self.uuid,
-@@ -599,48 +857,128 @@ class LinstorSR(SR.SR):
+@@ -599,48 +863,128 @@ class LinstorSR(SR.SR):
              'locked': str(locked)
          }
  
@@ -1007,7 +1026,7 @@ index a72d43e..77f5683 100755
  
      # --------------------------------------------------------------------------
      # Metadata.
-@@ -653,7 +991,7 @@ class LinstorSR(SR.SR):
+@@ -653,7 +997,7 @@ class LinstorSR(SR.SR):
  
              # Now update the VDI information in the metadata if required.
              xenapi = self.session.xenapi
@@ -1016,7 +1035,7 @@ index a72d43e..77f5683 100755
              for vdi_uuid, volume_metadata in volumes_metadata.items():
                  try:
                      vdi_ref = xenapi.VDI.get_by_uuid(vdi_uuid)
-@@ -708,36 +1046,43 @@ class LinstorSR(SR.SR):
+@@ -708,36 +1052,43 @@ class LinstorSR(SR.SR):
          # Update size attributes of the SR parent class.
          self.virtual_allocation = valloc + virt_alloc_delta
  
@@ -1075,7 +1094,7 @@ index a72d43e..77f5683 100755
          # 1. Get existing VDIs in XAPI.
          xenapi = self.session.xenapi
          xapi_vdi_uuids = set()
-@@ -745,8 +1090,8 @@ class LinstorSR(SR.SR):
+@@ -745,8 +1096,8 @@ class LinstorSR(SR.SR):
              xapi_vdi_uuids.add(xenapi.VDI.get_uuid(vdi))
  
          # 2. Get volumes info.
@@ -1086,7 +1105,7 @@ index a72d43e..77f5683 100755
  
          # 3. Get CBT vdis.
          # See: https://support.citrix.com/article/CTX230619
-@@ -758,7 +1103,8 @@ class LinstorSR(SR.SR):
+@@ -758,7 +1109,8 @@ class LinstorSR(SR.SR):
  
          introduce = False
  
@@ -1096,7 +1115,7 @@ index a72d43e..77f5683 100755
              has_clone_entries = list(self._journaler.get_all(
                  LinstorJournaler.CLONE
              ).items())
-@@ -782,6 +1128,9 @@ class LinstorSR(SR.SR):
+@@ -782,6 +1134,9 @@ class LinstorSR(SR.SR):
                  if not introduce:
                      continue
  
@@ -1106,7 +1125,7 @@ index a72d43e..77f5683 100755
                  volume_metadata = volumes_metadata.get(vdi_uuid)
                  if not volume_metadata:
                      util.SMlog(
-@@ -836,10 +1185,10 @@ class LinstorSR(SR.SR):
+@@ -836,10 +1191,10 @@ class LinstorSR(SR.SR):
  
                  util.SMlog(
                      'Introducing VDI {} '.format(vdi_uuid) +
@@ -1119,7 +1138,7 @@ index a72d43e..77f5683 100755
                      )
                  )
  
-@@ -857,7 +1206,7 @@ class LinstorSR(SR.SR):
+@@ -857,7 +1212,7 @@ class LinstorSR(SR.SR):
                      sm_config,
                      managed,
                      str(volume_info.virtual_size),
@@ -1128,7 +1147,7 @@ index a72d43e..77f5683 100755
                  )
  
                  is_a_snapshot = volume_metadata.get(IS_A_SNAPSHOT_TAG)
-@@ -881,9 +1230,11 @@ class LinstorSR(SR.SR):
+@@ -881,9 +1236,11 @@ class LinstorSR(SR.SR):
              vdi = self.vdi(vdi_uuid)
              self.vdis[vdi_uuid] = vdi
  
@@ -1142,7 +1161,7 @@ index a72d43e..77f5683 100755
  
              # 4.c. Update CBT status of disks either just added
              # or already in XAPI.
-@@ -940,7 +1291,7 @@ class LinstorSR(SR.SR):
+@@ -940,7 +1297,7 @@ class LinstorSR(SR.SR):
                  else:
                      geneology[vdi.parent] = [vdi_uuid]
              if not vdi.hidden:
@@ -1151,7 +1170,7 @@ index a72d43e..77f5683 100755
  
          # 9. Remove all hidden leaf nodes to avoid introducing records that
          # will be GC'ed.
-@@ -1014,13 +1365,18 @@ class LinstorSR(SR.SR):
+@@ -1014,13 +1371,18 @@ class LinstorSR(SR.SR):
              util.SMlog('Cannot deflate missing VDI {}'.format(vdi_uuid))
              return
  
@@ -1172,7 +1191,7 @@ index a72d43e..77f5683 100755
  
      def _handle_interrupted_clone(
          self, vdi_uuid, clone_info, force_undo=False
-@@ -1033,7 +1389,7 @@ class LinstorSR(SR.SR):
+@@ -1033,7 +1395,7 @@ class LinstorSR(SR.SR):
          base_uuid, snap_uuid = clone_info.split('_')
  
          # Use LINSTOR data because new VDIs may not be in the XAPI.
@@ -1181,7 +1200,7 @@ index a72d43e..77f5683 100755
  
          # Check if we don't have a base VDI. (If clone failed at startup.)
          if base_uuid not in volume_names:
-@@ -1089,7 +1445,7 @@ class LinstorSR(SR.SR):
+@@ -1089,7 +1451,7 @@ class LinstorSR(SR.SR):
          if base_type == vhdutil.VDI_TYPE_VHD:
              vhd_info = self._vhdutil.get_vhd_info(base_uuid, False)
              if vhd_info.hidden:
@@ -1190,7 +1209,7 @@ index a72d43e..77f5683 100755
          elif base_type == vhdutil.VDI_TYPE_RAW and \
                  base_metadata.get(HIDDEN_TAG):
              self._linstor.update_volume_metadata(
-@@ -1099,10 +1455,6 @@ class LinstorSR(SR.SR):
+@@ -1099,10 +1461,6 @@ class LinstorSR(SR.SR):
          # Remove the child nodes.
          if snap_uuid and snap_uuid in volume_names:
              util.SMlog('Destroying snap {}...'.format(snap_uuid))
@@ -1201,7 +1220,7 @@ index a72d43e..77f5683 100755
  
              try:
                  self._linstor.destroy_volume(snap_uuid)
-@@ -1150,10 +1502,64 @@ class LinstorSR(SR.SR):
+@@ -1150,10 +1508,64 @@ class LinstorSR(SR.SR):
  
          util.SMlog('*** INTERRUPTED CLONE OP: rollback success')
  
@@ -1266,7 +1285,7 @@ index a72d43e..77f5683 100755
      def _ensure_space_available(self, amount_needed):
          space_available = self._linstor.max_volume_size_allowed
          if (space_available < amount_needed):
-@@ -1233,7 +1639,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1233,7 +1645,7 @@ class LinstorVDI(VDI.VDI):
              if (
                  self.sr.srcmd.cmd == 'vdi_attach_from_config' or
                  self.sr.srcmd.cmd == 'vdi_detach_from_config'
@@ -1275,7 +1294,7 @@ index a72d43e..77f5683 100755
                  self.vdi_type = vhdutil.VDI_TYPE_RAW
                  self.path = self.sr.srcmd.params['vdi_path']
              else:
-@@ -1297,11 +1703,11 @@ class LinstorVDI(VDI.VDI):
+@@ -1297,11 +1709,11 @@ class LinstorVDI(VDI.VDI):
  
          # 2. Compute size and check space available.
          size = vhdutil.validate_and_round_vhd_size(int(size))
@@ -1291,7 +1310,7 @@ index a72d43e..77f5683 100755
          self.sr._ensure_space_available(volume_size)
  
          # 3. Set sm_config attribute of VDI parent class.
-@@ -1310,8 +1716,15 @@ class LinstorVDI(VDI.VDI):
+@@ -1310,8 +1722,15 @@ class LinstorVDI(VDI.VDI):
          # 4. Create!
          failed = False
          try:
@@ -1308,7 +1327,7 @@ index a72d43e..77f5683 100755
              )
              volume_info = self._linstor.get_volume_info(self.uuid)
  
-@@ -1320,16 +1733,16 @@ class LinstorVDI(VDI.VDI):
+@@ -1320,16 +1739,16 @@ class LinstorVDI(VDI.VDI):
              if self.vdi_type == vhdutil.VDI_TYPE_RAW:
                  self.size = volume_info.virtual_size
              else:
@@ -1328,7 +1347,7 @@ index a72d43e..77f5683 100755
              volume_info = self._linstor.get_volume_info(self.uuid)
  
              volume_metadata = {
-@@ -1344,6 +1757,13 @@ class LinstorVDI(VDI.VDI):
+@@ -1344,6 +1763,13 @@ class LinstorVDI(VDI.VDI):
                  METADATA_OF_POOL_TAG: ''
              }
              self._linstor.set_volume_metadata(self.uuid, volume_metadata)
@@ -1342,7 +1361,7 @@ index a72d43e..77f5683 100755
              self._linstor.mark_volume_as_persistent(self.uuid)
          except util.CommandException as e:
              failed = True
-@@ -1364,11 +1784,11 @@ class LinstorVDI(VDI.VDI):
+@@ -1364,11 +1790,11 @@ class LinstorVDI(VDI.VDI):
                          '{}'.format(e)
                      )
  
@@ -1356,7 +1375,7 @@ index a72d43e..77f5683 100755
  
          return VDI.VDI.get_params(self)
  
-@@ -1407,14 +1827,15 @@ class LinstorVDI(VDI.VDI):
+@@ -1407,14 +1833,15 @@ class LinstorVDI(VDI.VDI):
              del self.sr.vdis[self.uuid]
  
          # TODO: Check size after delete.
@@ -1374,13 +1393,16 @@ index a72d43e..77f5683 100755
              self.sr.srcmd.params['vdi_uuid'] != self.uuid
          ) and self.sr._journaler.has_entries(self.uuid):
              raise xs_errors.XenError(
-@@ -1423,50 +1844,62 @@ class LinstorVDI(VDI.VDI):
+@@ -1423,50 +1850,62 @@ class LinstorVDI(VDI.VDI):
                  'scan SR first to trigger auto-repair'
              )
  
 -        writable = 'args' not in self.sr.srcmd.params or \
 -            self.sr.srcmd.params['args'][0] == 'true'
--
++        if not attach_from_config or self.sr._is_master:
++            writable = 'args' not in self.sr.srcmd.params or \
++                self.sr.srcmd.params['args'][0] == 'true'
+ 
 -        # We need to inflate the volume if we don't have enough place
 -        # to mount the VHD image. I.e. the volume capacity must be greater
 -        # than the VHD size + bitmap size.
@@ -1388,10 +1410,7 @@ index a72d43e..77f5683 100755
 -        if self.vdi_type == vhdutil.VDI_TYPE_RAW or not writable or \
 -                self.capacity >= compute_volume_size(self.size, self.vdi_type):
 -            need_inflate = False
-+        if not attach_from_config or self.sr._is_master:
-+            writable = 'args' not in self.sr.srcmd.params or \
-+                self.sr.srcmd.params['args'][0] == 'true'
- 
+-
 -        if need_inflate:
 -            try:
 -                self._prepare_thin(True)
@@ -1467,7 +1486,7 @@ index a72d43e..77f5683 100755
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
              return
  
-@@ -1503,9 +1936,23 @@ class LinstorVDI(VDI.VDI):
+@@ -1503,9 +1942,23 @@ class LinstorVDI(VDI.VDI):
  
      def resize(self, sr_uuid, vdi_uuid, size):
          util.SMlog('LinstorVDI.resize for {}'.format(self.uuid))
@@ -1491,7 +1510,7 @@ index a72d43e..77f5683 100755
          if size < self.size:
              util.SMlog(
                  'vdi_resize: shrinking not supported: '
-@@ -1513,18 +1960,13 @@ class LinstorVDI(VDI.VDI):
+@@ -1513,18 +1966,13 @@ class LinstorVDI(VDI.VDI):
              )
              raise xs_errors.XenError('VDISize', opterr='shrinking not allowed')
  
@@ -1511,7 +1530,7 @@ index a72d43e..77f5683 100755
              if self.sr._provisioning == 'thin':
                  # VDI is currently deflated, so keep it deflated.
                  new_volume_size = old_volume_size
-@@ -1533,7 +1975,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1533,7 +1981,7 @@ class LinstorVDI(VDI.VDI):
          space_needed = new_volume_size - old_volume_size
          self.sr._ensure_space_available(space_needed)
  
@@ -1520,7 +1539,7 @@ index a72d43e..77f5683 100755
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
              self._linstor.resize(self.uuid, new_volume_size)
          else:
-@@ -1542,7 +1984,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1542,7 +1990,7 @@ class LinstorVDI(VDI.VDI):
                      self.sr._journaler, self._linstor, self.uuid, self.path,
                      new_volume_size, old_volume_size
                  )
@@ -1529,7 +1548,7 @@ index a72d43e..77f5683 100755
  
          # Reload size attributes.
          self._load_this()
-@@ -1552,7 +1994,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1552,7 +2000,7 @@ class LinstorVDI(VDI.VDI):
          self.session.xenapi.VDI.set_physical_utilisation(
              vdi_ref, str(self.utilisation)
          )
@@ -1538,7 +1557,7 @@ index a72d43e..77f5683 100755
          return VDI.VDI.get_params(self)
  
      def clone(self, sr_uuid, vdi_uuid):
-@@ -1574,8 +2016,8 @@ class LinstorVDI(VDI.VDI):
+@@ -1574,8 +2022,8 @@ class LinstorVDI(VDI.VDI):
          if not blktap2.VDI.tap_pause(self.session, self.sr.uuid, self.uuid):
              raise util.SMException('Failed to pause VDI {}'.format(self.uuid))
          try:
@@ -1549,7 +1568,7 @@ index a72d43e..77f5683 100755
              self.sr.session.xenapi.VDI.set_managed(
                  self.sr.srcmd.params['args'][0], False
              )
-@@ -1598,25 +2040,40 @@ class LinstorVDI(VDI.VDI):
+@@ -1598,25 +2046,40 @@ class LinstorVDI(VDI.VDI):
  
          util.SMlog('LinstorVDI.generate_config for {}'.format(self.uuid))
  
@@ -1602,7 +1621,7 @@ index a72d43e..77f5683 100755
          config = xmlrpc.client.dumps(tuple([resp]), 'vdi_attach_from_config')
          return xmlrpc.client.dumps((config,), "", True)
  
-@@ -1652,19 +2109,28 @@ class LinstorVDI(VDI.VDI):
+@@ -1652,19 +2115,28 @@ class LinstorVDI(VDI.VDI):
                  .format(self.uuid)
              )
  
@@ -1636,7 +1655,7 @@ index a72d43e..77f5683 100755
          self.capacity = volume_info.virtual_size
  
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
-@@ -1691,7 +2157,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1691,7 +2163,7 @@ class LinstorVDI(VDI.VDI):
              return
  
          if self.vdi_type == vhdutil.VDI_TYPE_VHD:
@@ -1645,7 +1664,7 @@ index a72d43e..77f5683 100755
          else:
              self._linstor.update_volume_metadata(self.uuid, {
                  HIDDEN_TAG: hidden
-@@ -1739,25 +2205,14 @@ class LinstorVDI(VDI.VDI):
+@@ -1739,25 +2211,14 @@ class LinstorVDI(VDI.VDI):
          else:
              fn = 'attach' if attach else 'detach'
  
@@ -1674,7 +1693,7 @@ index a72d43e..77f5683 100755
  
          # Reload size attrs after inflate or deflate!
          self._load_this()
-@@ -1807,9 +2262,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1807,9 +2268,7 @@ class LinstorVDI(VDI.VDI):
                  'VDIUnavailable',
                  opterr='failed to get vdi_type in metadata'
              )
@@ -1685,7 +1704,7 @@ index a72d43e..77f5683 100755
  
      def _update_device_name(self, device_name):
          self._device_name = device_name
-@@ -1832,7 +2285,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1832,7 +2291,7 @@ class LinstorVDI(VDI.VDI):
  
          # 2. Write the snapshot content.
          is_raw = (self.vdi_type == vhdutil.VDI_TYPE_RAW)
@@ -1694,7 +1713,7 @@ index a72d43e..77f5683 100755
              snap_path, self.path, is_raw, self.MAX_METADATA_VIRT_SIZE
          )
  
-@@ -1862,7 +2315,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1862,7 +2321,7 @@ class LinstorVDI(VDI.VDI):
          volume_info = self._linstor.get_volume_info(snap_uuid)
  
          snap_vdi.size = self.sr._vhdutil.get_size_virt(snap_uuid)
@@ -1703,7 +1722,7 @@ index a72d43e..77f5683 100755
  
          # 6. Update sm config.
          snap_vdi.sm_config = {}
-@@ -1932,6 +2385,9 @@ class LinstorVDI(VDI.VDI):
+@@ -1932,6 +2391,9 @@ class LinstorVDI(VDI.VDI):
          elif depth >= vhdutil.MAX_CHAIN_SIZE:
              raise xs_errors.XenError('SnapshotChainTooLong')
  
@@ -1713,7 +1732,7 @@ index a72d43e..77f5683 100755
          volume_path = self.path
          if not util.pathexists(volume_path):
              raise xs_errors.XenError(
-@@ -2057,7 +2513,7 @@ class LinstorVDI(VDI.VDI):
+@@ -2057,7 +2519,7 @@ class LinstorVDI(VDI.VDI):
                      raise
  
              if snap_type != VDI.SNAPSHOT_INTERNAL:
@@ -1722,7 +1741,7 @@ index a72d43e..77f5683 100755
  
              # 10. Return info on the new user-visible leaf VDI.
              ret_vdi = snap_vdi
-@@ -2088,10 +2544,318 @@ class LinstorVDI(VDI.VDI):
+@@ -2088,10 +2550,318 @@ class LinstorVDI(VDI.VDI):
  
          return ret_vdi.get_params()
  

--- a/SOURCES/0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
+++ b/SOURCES/0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
@@ -1,4 +1,4 @@
-From 7f961824a2eac4224cd75a721c885c5bc86aa199 Mon Sep 17 00:00:00 2001
+From 650edc6d5f8a131acdc4986cea91cbdb7c0ef1a9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 30 Jun 2023 12:41:43 +0200
 Subject: [PATCH 20/22] feat(LinstorSR): is now compatible with python 3
@@ -17,10 +17,10 @@ Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
  9 files changed, 35 insertions(+), 39 deletions(-)
 
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index 77f5683..4cbfe6d 100755
+index 9cb4ed4..b9616fb 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
-@@ -826,7 +826,7 @@ class LinstorSR(SR.SR):
+@@ -832,7 +832,7 @@ class LinstorSR(SR.SR):
          self._load_vdis()
          self._update_physical_size()
  
@@ -29,7 +29,7 @@ index 77f5683..4cbfe6d 100755
              if self.vdis[vdi_uuid].deleted:
                  del self.vdis[vdi_uuid]
  
-@@ -944,7 +944,7 @@ class LinstorSR(SR.SR):
+@@ -950,7 +950,7 @@ class LinstorSR(SR.SR):
          secondary_hosts = []
  
          hosts = self.session.xenapi.host.get_all_records()
@@ -38,7 +38,7 @@ index 77f5683..4cbfe6d 100755
              hostname = host_rec['hostname']
              if controller_node_name == hostname:
                  controller_host = host_ref
-@@ -1055,7 +1055,7 @@ class LinstorSR(SR.SR):
+@@ -1061,7 +1061,7 @@ class LinstorSR(SR.SR):
          # We use the size of the smallest disk, this is an approximation that
          # ensures the displayed physical size is reachable by the user.
          (min_physical_size, pool_count) = self._linstor.get_min_physical_size()
@@ -47,7 +47,7 @@ index 77f5683..4cbfe6d 100755
              self._linstor.redundancy
  
          self.physical_utilisation = self._linstor.allocated_volume_size
-@@ -1295,7 +1295,7 @@ class LinstorSR(SR.SR):
+@@ -1301,7 +1301,7 @@ class LinstorSR(SR.SR):
  
          # 9. Remove all hidden leaf nodes to avoid introducing records that
          # will be GC'ed.
@@ -56,7 +56,7 @@ index 77f5683..4cbfe6d 100755
              if vdi_uuid not in geneology and self.vdis[vdi_uuid].hidden:
                  util.SMlog(
                      'Scan found hidden leaf ({}), ignoring'.format(vdi_uuid)
-@@ -1507,17 +1507,16 @@ class LinstorSR(SR.SR):
+@@ -1513,17 +1513,16 @@ class LinstorSR(SR.SR):
      # --------------------------------------------------------------------------
  
      def _create_linstor_cache(self):
@@ -78,7 +78,7 @@ index 77f5683..4cbfe6d 100755
                  raise e
  
          self._all_volume_metadata_cache = \
-@@ -2659,7 +2658,7 @@ class LinstorVDI(VDI.VDI):
+@@ -2665,7 +2664,7 @@ class LinstorVDI(VDI.VDI):
                  '--nbd-name',
                  volume_name,
                  '--urls',

--- a/SOURCES/0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
+++ b/SOURCES/0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
@@ -1,4 +1,4 @@
-From 1df4dbc37498daeaa4c2969fc86db03f9a142705 Mon Sep 17 00:00:00 2001
+From 9b51ea2d170524c77dd100fdb5ec5f8a6648b309 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Fri, 4 Aug 2023 12:10:37 +0200
 Subject: [PATCH 21/22] Remove `SR_PROBE` from ZFS capabilities (#36)

--- a/SOURCES/0022-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0022-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,4 +1,4 @@
-From 94751d41ac40a366c03428ed1e182b205dcdafe6 Mon Sep 17 00:00:00 2001
+From e05967859f781b7eb85e5a66f7ba40340526e0f3 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Wed, 16 Aug 2023 13:42:21 +0200
 Subject: [PATCH 22/22] Fix vdi-ref when static vdis are used

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -6,7 +6,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.0.10
-Release: 1.1%{?xsrel}%{?dist}
+Release: 1.2%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -339,6 +339,14 @@ The package contains a fake key lookup plugin for system tests
 /opt/xensource/sm/plugins/keymanagerutil.py*
 
 %changelog
+* Tue Sep 19 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 3.0.10-1.2
+- Import sm 8.2 LINSTOR fixes on 8.3:
+- Ensure we always have a device path during leaf-coalesce calls
+- Always use lock.acquire() during attach/detach
+- Make sure hostnames are unique at SR creation
+- Ensure we can attach non-special static VDIs
+- Ensure we can detach when deflate call is not possible
+
 * Tue Sep 19 2023 Samuel Verschelde <stormi-xcp@ylix.fr> - 3.0.10-1.1
 - Rebase on 3.0.10-1
 - Drop 0002-Add-TrueNAS-multipath-config.patch


### PR DESCRIPTION
- Ensure we always have a device path during leaf-coalesce calls
- Always use lock.acquire() during attach/detach
- Make sure hostnames are unique at SR creation
- Ensure we can attach non-special static VDIs
- Ensure we can detach when deflate call is not possible