### PR TITLE
Import sm 8.2 LINSTOR fixes + IPv6 support (Cepth/NFS) on 8.3

### DIFF
--- a/SOURCES/0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From f47f96aad61714c778ebfac65002709f2cf9fd11 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 01/22] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 01/25] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.
@@ -21,5 +21,5 @@ index 99cb313..609c6ef 100644
  Conflicts=shutdown.target
  RefuseManualStop=yes
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0002-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
+++ b/SOURCES/0002-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
@@ -1,7 +1,7 @@
 From 402bd56c7c3af5ba90a9ad472ee760fd83d87366 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 02/22] feat(drivers): add CephFS and GlusterFS drivers
+Subject: [PATCH 02/25] feat(drivers): add CephFS and GlusterFS drivers
 
 ---
  Makefile               |   2 +
@@ -636,5 +636,5 @@ index a4a5d01..f26c0bd 100755
      if not type in SR.TYPES:
          raise util.SMException("Unsupported SR type: %s" % type)
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0003-feat-drivers-add-XFS-driver.patch
+++ b/SOURCES/0003-feat-drivers-add-XFS-driver.patch
@@ -1,7 +1,7 @@
 From 8bff840ffbe18f9ede692087485595137125c933 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 03/22] feat(drivers): add XFS driver
+Subject: [PATCH 03/25] feat(drivers): add XFS driver
 
 Originally-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 
@@ -300,5 +300,5 @@ index f26c0bd..9e2353f 100755
          type = SR.TYPE_FILE
      if not type in SR.TYPES:
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0004-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0004-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From 66ded63ca8dc481991e151c49bb1cb9564b2ffdb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 04/22] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 04/25] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---
@@ -201,5 +201,5 @@ index 9e2353f..ef72ab5 100755
          type = SR.TYPE_FILE
      if not type in SR.TYPES:
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0005-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0005-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From 9cbec26536ced42c7284652057855d17049dec33 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 05/22] feat(drivers): add LinstorSR driver
+Subject: [PATCH 05/25] feat(drivers): add LinstorSR driver
 
 Some important points:
 
@@ -5658,5 +5658,5 @@ diff --git a/tests/mocks/linstor/__init__.py b/tests/mocks/linstor/__init__.py
 new file mode 100644
 index 0000000..e69de29
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0006-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0006-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From 16d668efe51bcb23c57229cf0b34fc0a9fdf1b21 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 06/22] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 06/25] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages
@@ -208,5 +208,5 @@ index 0000000..c477fa3
 +            failed = True
 +        self.assertTrue(failed)
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0007-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0007-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From d56fc523ebbb125876dff2e8bf406a738c10d7fc Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 07/22] Added SM Driver for MooseFS
+Subject: [PATCH 07/25] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
@@ -388,5 +388,5 @@ index 0000000..3349a44
 +        mfssr.detach('asr_uuid')
 +        self.assertTrue(mfssr.attached)
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0008-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0008-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From 0cce6d8161d7e5af5ba04396175671afdfb7bfa8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 08/22] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 08/25] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir
@@ -99,5 +99,5 @@ index db72e39..38f97c0 100644
  class TestISOSR_overNFS(unittest.TestCase):
  
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0009-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0009-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From 9da6f5a2b8e5d7bd7888928c229c2b8014534fd8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 09/22] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 09/25] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior
@@ -126,5 +126,5 @@ index be5112c..ab72f4e 100755
              self.detach(sr_uuid)
              if inst.code != errno.ENOENT:
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0010-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0010-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From e298c1240b2e88b6e73d55fb54a9bd0fda8fe9f2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 10/22] Fix is_open call for many drivers (#25)
+Subject: [PATCH 10/25] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.
@@ -101,5 +101,5 @@ index b4f33de..bb3f5db 100755
  
      driver = SR.driver(srType)
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0011-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0011-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From 910df4dfcfd2df19be48425a0f46e4d7851c340e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 11/22] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 11/25] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.
@@ -56,5 +56,5 @@ index ab72f4e..212f1ad 100755
                  "VDI_UPDATE", "VDI_CLONE", "VDI_SNAPSHOT", "VDI_RESIZE", "VDI_MIRROR",
                  "VDI_GENERATE_CONFIG",
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0012-Fix-code-coverage-regarding-MooseFSSR-and-ZFSSR-29.patch
+++ b/SOURCES/0012-Fix-code-coverage-regarding-MooseFSSR-and-ZFSSR-29.patch
@@ -1,7 +1,7 @@
 From b405c43b0d3ed86253ff0339416d2c2bece3d0fc Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 19 Sep 2022 10:31:00 +0200
-Subject: [PATCH 12/22] Fix code coverage regarding MooseFSSR and ZFSSR (#29)
+Subject: [PATCH 12/25] Fix code coverage regarding MooseFSSR and ZFSSR (#29)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
@@ -58,5 +58,5 @@ index c477fa3..e95ab7e 100644
 +            failed = e.errno == 47
          self.assertTrue(failed)
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0013-py3-simple-changes-from-futurize-on-XCP-ng-drivers.patch
+++ b/SOURCES/0013-py3-simple-changes-from-futurize-on-XCP-ng-drivers.patch
@@ -1,7 +1,7 @@
 From 6b9512386d1d54f2915749c58f66380f62145c3d Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:13:18 +0100
-Subject: [PATCH 13/22] py3: simple changes from futurize on XCP-ng drivers
+Subject: [PATCH 13/25] py3: simple changes from futurize on XCP-ng drivers
 
 * `except` syntax fixes
 * drop `has_key()` usage
@@ -327,5 +327,5 @@ index d400421..dca9645 100755
                  'Unable to create SR `{}`. It already exists on node(s): {}'
                  .format(group_name, existing_node_names)
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0014-py3-futurize-fix-of-xmlrpc-calls-for-CephFS-GlusterF.patch
+++ b/SOURCES/0014-py3-futurize-fix-of-xmlrpc-calls-for-CephFS-GlusterF.patch
@@ -1,7 +1,7 @@
 From 030d09a038184d11c81050bfc8d5469a1a71812f Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:28:10 +0100
-Subject: [PATCH 14/22] py3: futurize fix of xmlrpc calls for CephFS,
+Subject: [PATCH 14/25] py3: futurize fix of xmlrpc calls for CephFS,
  GlusterFS, MooseFS, Linstore
 
 Signed-off-by: Yann Dirson <yann.dirson@vates.fr>
@@ -118,5 +118,5 @@ index 8860fdf..febb559 100755
      def attach_from_config(self, sr_uuid, vdi_uuid):
          try:
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0015-py3-use-of-integer-division-operator.patch
+++ b/SOURCES/0015-py3-use-of-integer-division-operator.patch
@@ -1,7 +1,7 @@
 From 8aaacd43e9e2d5d79bfa0b940b558d1304733233 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:32:37 +0100
-Subject: [PATCH 15/22] py3: use of integer division operator
+Subject: [PATCH 15/25] py3: use of integer division operator
 
 Guided by futurize's "old_div" use
 
@@ -33,5 +33,5 @@ index dca9645..1b86a43 100755
          error_str = self._get_error_str(result)
          if error_str:
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0016-test_on_slave-allow-to-work-with-SR-using-absolute-P.patch
+++ b/SOURCES/0016-test_on_slave-allow-to-work-with-SR-using-absolute-P.patch
@@ -1,7 +1,7 @@
 From b26bacc1229bcd1aba0ba3d8133909d5fba91841 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 13:53:21 +0100
-Subject: [PATCH 16/22] test_on_slave: allow to work with SR using absolute
+Subject: [PATCH 16/25] test_on_slave: allow to work with SR using absolute
  PROBE_MOUNTPOINT
 
 PROBE_MOUNTPOINT in a some drivers is a relative path, which is resolved
@@ -48,5 +48,5 @@ index 5d5bc60..1aad363 100644
          self.mock_blktap2 = mock.MagicMock()
          self.mocks['blktap2'] = self.mock_blktap2
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0017-py3-switch-interpreter-to-python3.patch
+++ b/SOURCES/0017-py3-switch-interpreter-to-python3.patch
@@ -1,7 +1,7 @@
 From 6db92be201efa0695b6aa2bc1d2a6c65643a8cd0 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Mon, 27 Mar 2023 15:30:46 +0200
-Subject: [PATCH 17/22] py3: switch interpreter to python3
+Subject: [PATCH 17/25] py3: switch interpreter to python3
 
 ---
  drivers/CephFSSR.py             | 2 +-
@@ -95,5 +95,5 @@ index 1b86a43..182b889 100755
  # Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
  #
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0018-Support-recent-version-of-coverage-tool.patch
+++ b/SOURCES/0018-Support-recent-version-of-coverage-tool.patch
@@ -1,7 +1,7 @@
 From 029e06d6f93b2ca0a67de906109bd2a0670cbb37 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 4 May 2023 10:24:22 +0200
-Subject: [PATCH 18/22] Support recent version of coverage tool (coverage
+Subject: [PATCH 18/25] Support recent version of coverage tool (coverage
  7.2.5)
 
 Without these changes many warns/errors are emitted:
@@ -29,5 +29,5 @@ index 38f97c0..876d5da 100644
  
  
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0019-feat-LinstorSR-import-all-8.2-changes.patch
+++ b/SOURCES/0019-feat-LinstorSR-import-all-8.2-changes.patch
@@ -1,30 +1,32 @@
-From 8a9cc0778b7a11ac20ea6d4e48be602868c0b44d Mon Sep 17 00:00:00 2001
+From d5207d60e872aa0be5c03be89d89310875700fd5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 20 Nov 2020 16:42:52 +0100
-Subject: [PATCH 19/22] feat(LinstorSR): import all 8.2 changes
+Subject: [PATCH 19/25] feat(LinstorSR): import all 8.2 changes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
- Makefile                                      |   10 +
- drivers/LinstorSR.py                          | 1328 ++++++++---
+ Makefile                                      |   13 +
+ drivers/LinstorSR.py                          | 1440 ++++++++---
  drivers/blktap2.py                            |   23 +-
- drivers/cleanup.py                            |  168 +-
- drivers/linstor-manager                       |  785 ++++++-
+ drivers/cleanup.py                            |  341 ++-
+ drivers/linstor-manager                       |  932 ++++++-
  drivers/linstorjournaler.py                   |   48 +-
- drivers/linstorvhdutil.py                     |  370 +++-
- drivers/linstorvolumemanager.py               | 1973 ++++++++++++++---
+ drivers/linstorvhdutil.py                     |  476 +++-
+ drivers/linstorvolumemanager.py               | 2151 ++++++++++++++---
  drivers/on_slave.py                           |   23 +-
  drivers/tapdisk-pause                         |    8 +-
  drivers/util.py                               |  125 +-
  drivers/vhdutil.py                            |    5 +-
+ .../drbd-reactor.service.d/override.conf      |    7 +
  .../linstor-satellite.service.d/override.conf |    5 +
  etc/systemd/system/var-lib-linstor.service    |   21 +
  linstor/linstor-monitord.c                    |  199 +-
  scripts/fork-log-daemon                       |   36 +
- scripts/linstor-kv-tool                       |   78 +
+ scripts/linstor-kv-tool                       |   84 +
  scripts/safe-umount                           |   39 +
  tests/test_on_slave.py                        |   10 +-
- 19 files changed, 4383 insertions(+), 871 deletions(-)
+ 20 files changed, 5014 insertions(+), 972 deletions(-)
+ create mode 100644 etc/systemd/system/drbd-reactor.service.d/override.conf
  create mode 100644 etc/systemd/system/linstor-satellite.service.d/override.conf
  create mode 100644 etc/systemd/system/var-lib-linstor.service
  create mode 100755 scripts/fork-log-daemon
@@ -32,7 +34,7 @@ Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
  create mode 100755 scripts/safe-umount
 
 diff --git a/Makefile b/Makefile
-index 9cba307..30d1b79 100755
+index 9cba307..cea5650 100755
 --- a/Makefile
 +++ b/Makefile
 @@ -84,6 +84,7 @@ PLUGIN_SCRIPT_DEST := /etc/xapi.d/plugins/
@@ -43,19 +45,22 @@ index 9cba307..30d1b79 100755
  SYSTEMD_SERVICE_DIR := /usr/lib/systemd/system/
  INIT_DIR := /etc/rc.d/init.d/
  MPATH_CONF_DIR := /etc/multipath.xenserver/
-@@ -138,6 +139,8 @@ install: precheck
+@@ -138,6 +139,9 @@ install: precheck
  	mkdir -p $(SM_STAGING)$(UDEV_RULES_DIR)
  	mkdir -p $(SM_STAGING)$(UDEV_SCRIPTS_DIR)
  	mkdir -p $(SM_STAGING)$(INIT_DIR)
 +	mkdir -p $(SM_STAGING)$(SYSTEMD_CONF_DIR)
++	mkdir -p $(SM_STAGING)$(SYSTEMD_CONF_DIR)/drbd-reactor.service.d
 +	mkdir -p $(SM_STAGING)$(SYSTEMD_CONF_DIR)/linstor-satellite.service.d
  	mkdir -p $(SM_STAGING)$(SYSTEMD_SERVICE_DIR)
  	mkdir -p $(SM_STAGING)$(MPATH_CONF_DIR)
  	mkdir -p $(SM_STAGING)$(MODPROBE_DIR)
-@@ -163,6 +166,10 @@ install: precheck
+@@ -163,6 +167,12 @@ install: precheck
  	  $(SM_STAGING)/$(SM_DEST)
  	install -m 644 etc/logrotate.d/$(SMLOG_CONF) \
  	  $(SM_STAGING)/$(LOGROTATE_DIR)
++	install -m 644 etc/systemd/system/drbd-reactor.service.d/override.conf \
++	  $(SM_STAGING)/$(SYSTEMD_CONF_DIR)/drbd-reactor.service.d/
 +	install -m 644 etc/systemd/system/linstor-satellite.service.d/override.conf \
 +	  $(SM_STAGING)/$(SYSTEMD_CONF_DIR)/linstor-satellite.service.d/
 +	install -m 644 etc/systemd/system/var-lib-linstor.service \
@@ -63,7 +68,7 @@ index 9cba307..30d1b79 100755
  	install -m 644 etc/make-dummy-sr.service \
  	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
  	install -m 644 systemd/xs-sm.service \
-@@ -210,6 +217,9 @@ install: precheck
+@@ -210,6 +220,9 @@ install: precheck
  	install -m 755 drivers/iscsilib.py $(SM_STAGING)$(SM_DEST)
  	install -m 755 drivers/fcoelib.py $(SM_STAGING)$(SM_DEST)
  	mkdir -p $(SM_STAGING)$(LIBEXEC)
@@ -74,10 +79,10 @@ index 9cba307..30d1b79 100755
  	install -m 755 scripts/check-device-sharing $(SM_STAGING)$(LIBEXEC)
  	install -m 755 scripts/usb_change $(SM_STAGING)$(LIBEXEC)
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index a72d43e..9cb4ed4 100755
+index a72d43e..5f143e7 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
-@@ -19,8 +19,11 @@ from constants import CBTLOG_TAG
+@@ -19,25 +19,39 @@ from constants import CBTLOG_TAG
  try:
      from linstorjournaler import LinstorJournaler
      from linstorvhdutil import LinstorVhdUtil
@@ -87,11 +92,14 @@ index a72d43e..9cb4ed4 100755
 +    from linstorvolumemanager import get_controller_node_name
 +    from linstorvolumemanager import LinstorVolumeManager
 +    from linstorvolumemanager import LinstorVolumeManagerError
++    from linstorvolumemanager import PERSISTENT_PREFIX
 +
      LINSTOR_AVAILABLE = True
  except ImportError:
++    PERSISTENT_PREFIX = 'unknown'
++
      LINSTOR_AVAILABLE = False
-@@ -28,16 +31,24 @@ except ImportError:
+ 
  from lock import Lock
  import blktap2
  import cleanup
@@ -116,7 +124,7 @@ index a72d43e..9cb4ed4 100755
  import xmlrpc.client
  import xs_errors
  
-@@ -48,6 +59,23 @@ from srmetadata import \
+@@ -48,6 +62,27 @@ from srmetadata import \
  
  HIDDEN_TAG = 'hidden'
  
@@ -137,10 +145,14 @@ index a72d43e..9cb4ed4 100755
 +# Enable/Disable VHD key hash support.
 +USE_KEY_HASH = False
 +
++# Special volumes.
++HA_VOLUME_NAME = PERSISTENT_PREFIX + 'ha-statefile'
++REDO_LOG_VOLUME_NAME = PERSISTENT_PREFIX + 'redo-log'
++
  # ==============================================================================
  
  # TODO: Supports 'VDI_INTRODUCE', 'VDI_RESET_ON_BOOT/2', 'SR_TRIM',
-@@ -72,9 +100,9 @@ CAPABILITIES = [
+@@ -72,9 +107,9 @@ CAPABILITIES = [
  
  CONFIGURATION = [
      ['group-name', 'LVM group name'],
@@ -152,7 +164,7 @@ index a72d43e..9cb4ed4 100755
  ]
  
  DRIVER_INFO = {
-@@ -92,7 +120,8 @@ DRIVER_CONFIG = {'ATTACH_FROM_CONFIG_WITH_TAPDISK': False}
+@@ -92,7 +127,8 @@ DRIVER_CONFIG = {'ATTACH_FROM_CONFIG_WITH_TAPDISK': False}
  
  OPS_EXCLUSIVE = [
      'sr_create', 'sr_delete', 'sr_attach', 'sr_detach', 'sr_scan',
@@ -162,10 +174,23 @@ index a72d43e..9cb4ed4 100755
  ]
  
  # ==============================================================================
-@@ -113,14 +142,6 @@ def compute_volume_size(virtual_size, image_type):
-     return LinstorVolumeManager.round_up_volume_size(virtual_size)
+@@ -100,68 +136,39 @@ OPS_EXCLUSIVE = [
+ # ==============================================================================
  
  
+-def compute_volume_size(virtual_size, image_type):
+-    if image_type == vhdutil.VDI_TYPE_VHD:
+-        # All LINSTOR VDIs have the metadata area preallocated for
+-        # the maximum possible virtual size (for fast online VDI.resize).
+-        meta_overhead = vhdutil.calcOverheadEmpty(LinstorVDI.MAX_SIZE)
+-        bitmap_overhead = vhdutil.calcOverheadBitmap(virtual_size)
+-        virtual_size += meta_overhead + bitmap_overhead
+-    elif image_type != vhdutil.VDI_TYPE_RAW:
+-        raise Exception('Invalid image type: {}'.format(image_type))
+-
+-    return LinstorVolumeManager.round_up_volume_size(virtual_size)
+-
+-
 -def try_lock(lock):
 -    for i in range(20):
 -        if lock.acquireNoblock():
@@ -177,27 +202,47 @@ index a72d43e..9cb4ed4 100755
  def attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid):
      volume_metadata = linstor.get_volume_metadata(vdi_uuid)
      image_type = volume_metadata.get(VDI_TYPE_TAG)
-@@ -129,14 +150,16 @@ def attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid):
+     if image_type == vhdutil.VDI_TYPE_RAW:
+         return
  
-     lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
-     try:
+-    lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
+-    try:
 -        try_lock(lock)
-+        lock.acquire()
+-
+-        device_path = linstor.get_device_path(vdi_uuid)
++    device_path = linstor.get_device_path(vdi_uuid)
  
-         device_path = linstor.get_device_path(vdi_uuid)
- 
-         # If the virtual VHD size is lower than the LINSTOR volume size,
-         # there is nothing to do.
-         vhd_size = compute_volume_size(
+-        # If the virtual VHD size is lower than the LINSTOR volume size,
+-        # there is nothing to do.
+-        vhd_size = compute_volume_size(
 -            LinstorVhdUtil(session, linstor).get_size_virt(vdi_uuid),
-+            # TODO: Replace pylint comment with this feature when possible:
-+            # https://github.com/PyCQA/pylint/pull/2926
-+            LinstorVhdUtil(session, linstor).get_size_virt(vdi_uuid),  # pylint: disable = E1120
-             image_type
-         )
+-            image_type
+-        )
++    # If the virtual VHD size is lower than the LINSTOR volume size,
++    # there is nothing to do.
++    vhd_size = LinstorVhdUtil.compute_volume_size(
++        # TODO: Replace pylint comment with this feature when possible:
++        # https://github.com/PyCQA/pylint/pull/2926
++        LinstorVhdUtil(session, linstor).get_size_virt(vdi_uuid),  # pylint: disable = E1120
++        image_type
++    )
  
-@@ -152,7 +175,7 @@ def attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid):
-         lock.release()
+-        volume_info = linstor.get_volume_info(vdi_uuid)
+-        volume_size = volume_info.virtual_size
++    volume_info = linstor.get_volume_info(vdi_uuid)
++    volume_size = volume_info.virtual_size
+ 
+-        if vhd_size > volume_size:
+-            inflate(
+-                journaler, linstor, vdi_uuid, device_path,
+-                vhd_size, volume_size
+-            )
+-    finally:
+-        lock.release()
++    if vhd_size > volume_size:
++        LinstorVhdUtil(session, linstor).inflate(
++            journaler, vdi_uuid, device_path, vhd_size, volume_size
++        )
  
  
 -def detach_thin(session, linstor, sr_uuid, vdi_uuid):
@@ -205,66 +250,55 @@ index a72d43e..9cb4ed4 100755
      volume_metadata = linstor.get_volume_metadata(vdi_uuid)
      image_type = volume_metadata.get(VDI_TYPE_TAG)
      if image_type == vhdutil.VDI_TYPE_RAW:
-@@ -160,36 +183,55 @@ def detach_thin(session, linstor, sr_uuid, vdi_uuid):
+         return
  
-     lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
-     try:
+-    lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
+-    try:
 -        try_lock(lock)
-+        lock.acquire()
+-
++    def check_vbd_count():
+         vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
+         vbds = session.xenapi.VBD.get_all_records_where(
+             'field "VDI" = "{}"'.format(vdi_ref)
+@@ -178,67 +185,103 @@ def detach_thin(session, linstor, sr_uuid, vdi_uuid):
+                         'at least 2 VBDs'.format(vdi_uuid)
+                     )
  
--        vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
--        vbds = session.xenapi.VBD.get_all_records_where(
--            'field "VDI" = "{}"'.format(vdi_ref)
--        )
-+        def check_vbd_count():
-+            vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
-+            vbds = session.xenapi.VBD.get_all_records_where(
-+                'field "VDI" = "{}"'.format(vdi_ref)
-+            )
- 
--        num_plugged = 0
--        for vbd_rec in vbds.values():
--            if vbd_rec['currently_attached']:
--                num_plugged += 1
--                if num_plugged > 1:
--                    raise xs_errors.XenError(
--                        'VDIUnavailable',
--                        opterr='Cannot deflate VDI {}, already used by '
--                        'at least 2 VBDs'.format(vdi_uuid)
--                    )
-+            num_plugged = 0
-+            for vbd_rec in vbds.values():
-+                if vbd_rec['currently_attached']:
-+                    num_plugged += 1
-+                    if num_plugged > 1:
-+                        raise xs_errors.XenError(
-+                            'VDIUnavailable',
-+                            opterr='Cannot deflate VDI {}, already used by '
-+                            'at least 2 VBDs'.format(vdi_uuid)
-+                        )
-+
-+        # We can have multiple VBDs attached to a VDI during a VM-template clone.
-+        # So we use a timeout to ensure that we can detach the volume properly.
-+        util.retry(check_vbd_count, maxretry=10, period=1)
- 
-         device_path = linstor.get_device_path(vdi_uuid)
-         new_volume_size = LinstorVolumeManager.round_up_volume_size(
+-        device_path = linstor.get_device_path(vdi_uuid)
+-        new_volume_size = LinstorVolumeManager.round_up_volume_size(
 -            LinstorVhdUtil(session, linstor).get_size_phys(device_path)
-+            # TODO: Replace pylint comment with this feature when possible:
-+            # https://github.com/PyCQA/pylint/pull/2926
-+            LinstorVhdUtil(session, linstor).get_size_phys(vdi_uuid)  # pylint: disable = E1120
-         )
+-        )
++    # We can have multiple VBDs attached to a VDI during a VM-template clone.
++    # So we use a timeout to ensure that we can detach the volume properly.
++    util.retry(check_vbd_count, maxretry=10, period=1)
  
-         volume_info = linstor.get_volume_info(vdi_uuid)
-         old_volume_size = volume_info.virtual_size
+-        volume_info = linstor.get_volume_info(vdi_uuid)
+-        old_volume_size = volume_info.virtual_size
 -        deflate(vdi_uuid, device_path, new_volume_size, old_volume_size)
-+        deflate(
-+            linstor, vdi_uuid, device_path, new_volume_size, old_volume_size
-+        )
-     finally:
-         lock.release()
+-    finally:
+-        lock.release()
++    device_path = linstor.get_device_path(vdi_uuid)
++    vhdutil_inst = LinstorVhdUtil(session, linstor)
++    new_volume_size = LinstorVolumeManager.round_up_volume_size(
++        # TODO: Replace pylint comment with this feature when possible:
++        # https://github.com/PyCQA/pylint/pull/2926
++        vhdutil_inst.get_size_phys(vdi_uuid)  # pylint: disable = E1120
++    )
  
++    volume_info = linstor.get_volume_info(vdi_uuid)
++    old_volume_size = volume_info.virtual_size
++    vhdutil_inst.deflate(device_path, new_volume_size, old_volume_size)
  
+-def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
+-    # Only inflate if the LINSTOR volume capacity is not enough.
+-    new_size = LinstorVolumeManager.round_up_volume_size(new_size)
+-    if new_size <= old_size:
+-        return
+ 
+-    util.SMlog(
+-        'Inflate {} (new VHD size={}, previous={})'
+-        .format(vdi_uuid, new_size, old_size)
+-    )
 +def detach_thin(session, linstor, sr_uuid, vdi_uuid):
 +    # This function must always return without errors.
 +    # Otherwise it could cause errors in the XAPI regarding the state of the VDI.
@@ -273,67 +307,20 @@ index a72d43e..9cb4ed4 100755
 +        detach_thin_impl(session, linstor, sr_uuid, vdi_uuid)
 +    except Exception as e:
 +        util.SMlog('Failed to detach properly VDI {}: {}'.format(vdi_uuid, e))
-+
-+
- def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
-     # Only inflate if the LINSTOR volume capacity is not enough.
-     new_size = LinstorVolumeManager.round_up_volume_size(new_size)
-@@ -197,7 +239,7 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
-         return
  
-     util.SMlog(
--        'Inflate {} (new VHD size={}, previous={})'
-+        'Inflate {} (size={}, previous={})'
-         .format(vdi_uuid, new_size, old_size)
-     )
+-    journaler.create(
+-        LinstorJournaler.INFLATE, vdi_uuid, old_size
+-    )
+-    linstor.resize_volume(vdi_uuid, new_size)
  
-@@ -206,8 +248,15 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
-     )
-     linstor.resize_volume(vdi_uuid, new_size)
- 
-+    result_size = linstor.get_volume_size(vdi_uuid)
-+    if result_size < new_size:
-+        util.SMlog(
-+            'WARNING: Cannot inflate volume to {}B, result size: {}B'
-+            .format(new_size, result_size)
-+        )
-+
-     if not util.zeroOut(
+-    if not util.zeroOut(
 -        vdi_path, new_size - vhdutil.VHD_FOOTER_SIZE,
-+        vdi_path, result_size - vhdutil.VHD_FOOTER_SIZE,
-         vhdutil.VHD_FOOTER_SIZE
-     ):
-         raise xs_errors.XenError(
-@@ -215,11 +264,11 @@ def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
-             opterr='Failed to zero out VHD footer {}'.format(vdi_path)
-         )
- 
--    vhdutil.setSizePhys(vdi_path, new_size, False)
-+    LinstorVhdUtil(None, linstor).set_size_phys(vdi_path, result_size, False)
-     journaler.remove(LinstorJournaler.INFLATE, vdi_uuid)
- 
- 
--def deflate(vdi_uuid, vdi_path, new_size, old_size):
-+def deflate(linstor, vdi_uuid, vdi_path, new_size, old_size):
-     new_size = LinstorVolumeManager.round_up_volume_size(new_size)
-     if new_size >= old_size:
-         return
-@@ -229,16 +278,86 @@ def deflate(vdi_uuid, vdi_path, new_size, old_size):
-         .format(vdi_uuid, new_size, old_size)
-     )
- 
--    vhdutil.setSizePhys(vdi_path, new_size)
-+    LinstorVhdUtil(None, linstor).set_size_phys(vdi_path, new_size)
-     # TODO: Change the LINSTOR volume size using linstor.resize_volume.
- 
- 
-+IPS_XHA_CACHE = None
-+
-+
+-        vhdutil.VHD_FOOTER_SIZE
+-    ):
+-        raise xs_errors.XenError(
+-            'EIO',
+-            opterr='Failed to zero out VHD footer {}'.format(vdi_path)
 +def get_ips_from_xha_config_file():
-+    if IPS_XHA_CACHE:
-+        return IPS_XHA_CACHE
-+
 +    ips = dict()
 +    host_id = None
 +    try:
@@ -343,7 +330,7 @@ index a72d43e..9cb4ed4 100755
 +            lambda: xml_parser.parse(XHA_CONFIG_PATH),
 +            maxretry=10,
 +            period=1
-+        )
+         )
 +    except:
 +        return (None, ips)
 +
@@ -358,7 +345,10 @@ index a72d43e..9cb4ed4 100755
 +                current_id = sub_node.text
 +            else:
 +                continue
-+
+ 
+-    vhdutil.setSizePhys(vdi_path, new_size, False)
+-    journaler.remove(LinstorJournaler.INFLATE, vdi_uuid)
+-
 +            if current_id and current_ip:
 +                ips[current_id] = current_ip
 +                return
@@ -383,13 +373,23 @@ index a72d43e..9cb4ed4 100755
 +            host_id = parse_local_config(ips, node)
 +        else:
 +            continue
-+
+ 
+-def deflate(vdi_uuid, vdi_path, new_size, old_size):
+-    new_size = LinstorVolumeManager.round_up_volume_size(new_size)
+-    if new_size >= old_size:
+-        return
 +        if ips and host_id:
 +            break
-+
+ 
+-    util.SMlog(
+-        'Deflate {} (new size={}, previous={})'
+-        .format(vdi_uuid, new_size, old_size)
+-    )
 +    return (host_id and ips.get(host_id), ips)
-+
-+
+ 
+-    vhdutil.setSizePhys(vdi_path, new_size)
+-    # TODO: Change the LINSTOR volume size using linstor.resize_volume.
+ 
 +def activate_lvm_group(group_name):
 +    path = group_name.split('/')
 +    assert path and len(path) <= 2
@@ -397,7 +397,7 @@ index a72d43e..9cb4ed4 100755
 +        lvutil.setActiveVG(path[0], True)
 +    except Exception as e:
 +        util.SMlog('Cannot active VG `{}`: {}'.format(path[0], e))
-+
+ 
  # ==============================================================================
  
  # Usage example:
@@ -407,7 +407,7 @@ index a72d43e..9cb4ed4 100755
  # device-config:group-name=vg_loop device-config:redundancy=2
  
  
-@@ -250,6 +369,11 @@ class LinstorSR(SR.SR):
+@@ -250,6 +293,11 @@ class LinstorSR(SR.SR):
  
      MANAGER_PLUGIN = 'linstor-manager'
  
@@ -419,7 +419,7 @@ index a72d43e..9cb4ed4 100755
      # --------------------------------------------------------------------------
      # SR methods.
      # --------------------------------------------------------------------------
-@@ -265,8 +389,6 @@ class LinstorSR(SR.SR):
+@@ -265,8 +313,6 @@ class LinstorSR(SR.SR):
              )
  
          # Check parameters.
@@ -428,7 +428,7 @@ index a72d43e..9cb4ed4 100755
          if 'group-name' not in self.dconf or not self.dconf['group-name']:
              raise xs_errors.XenError('LinstorConfigGroupNameMissing')
          if 'redundancy' not in self.dconf or not self.dconf['redundancy']:
-@@ -289,6 +411,10 @@ class LinstorSR(SR.SR):
+@@ -289,6 +335,10 @@ class LinstorSR(SR.SR):
          else:
              self._provisioning = self.PROVISIONING_DEFAULT
  
@@ -439,7 +439,7 @@ index a72d43e..9cb4ed4 100755
          # Note: We don't have access to the session field if the
          # 'vdi_attach_from_config' command is executed.
          self._has_session = self.sr_ref and self.session is not None
-@@ -307,8 +433,8 @@ class LinstorSR(SR.SR):
+@@ -307,8 +357,8 @@ class LinstorSR(SR.SR):
          self.lock = Lock(vhdutil.LOCK_TYPE_SR, self.uuid)
          self.sr_vditype = SR.DEFAULT_TAP
  
@@ -450,17 +450,17 @@ index a72d43e..9cb4ed4 100755
          self._linstor = None  # Ensure that LINSTOR attribute exists.
          self._journaler = None
  
-@@ -317,46 +443,75 @@ class LinstorSR(SR.SR):
+@@ -317,46 +367,75 @@ class LinstorSR(SR.SR):
              self._is_master = True
          self._group_name = self.dconf['group-name']
  
 -        self._master_uri = None
 -        self._vdi_shared_locked = False
 +        self._vdi_shared_time = 0
-+
-+        self._init_status = self.INIT_STATUS_NOT_SET
  
 -        self._initialized = False
++        self._init_status = self.INIT_STATUS_NOT_SET
++
 +        self._vdis_loaded = False
 +        self._all_volume_info_cache = None
 +        self._all_volume_metadata_cache = None
@@ -505,15 +505,15 @@ index a72d43e..9cb4ed4 100755
 +                            uri,
                              self._group_name,
 -                            logger=util.SMlog
-+                            logger=util.SMlog,
-+                            attempt_count=attempt_count
-                         )
+-                        )
 -                        return
 -                    except Exception as e:
 -                        util.SMlog(
 -                            'Ignore exception. Failed to build LINSTOR '
 -                            'instance without session: {}'.format(e)
--                        )
++                            logger=util.SMlog,
++                            attempt_count=attempt_count
+                         )
 -                return
 +                        # Only required if we are attaching from config using a non-special VDI.
 +                        # I.e. not an HA volume.
@@ -557,13 +557,12 @@ index a72d43e..9cb4ed4 100755
  
              if not self._is_master:
                  if self.cmd in [
-@@ -374,37 +529,12 @@ class LinstorSR(SR.SR):
+@@ -374,37 +453,12 @@ class LinstorSR(SR.SR):
                  # behaviors if the GC is executed during an action on a slave.
                  if self.cmd.startswith('vdi_'):
                      self._shared_lock_vdi(self.srcmd.params['vdi_uuid'])
 -                    self._vdi_shared_locked = True
-+                    self._vdi_shared_time = time.time()
- 
+-
 -            self._journaler = LinstorJournaler(
 -                self._master_uri, self._group_name, logger=util.SMlog
 -            )
@@ -573,7 +572,8 @@ index a72d43e..9cb4ed4 100755
 -            if self.srcmd.cmd == 'sr_create':
 -                # TODO: Disable if necessary
 -                self._enable_linstor_on_all_hosts(status=True)
--
++                    self._vdi_shared_time = time.time()
+ 
 -            try:
 -                # Try to open SR if exists.
 -                self._linstor = LinstorVolumeManager(
@@ -600,7 +600,7 @@ index a72d43e..9cb4ed4 100755
                      raise xs_errors.XenError('SRUnavailable', opterr=str(e))
  
              if self._linstor:
-@@ -416,41 +546,87 @@ class LinstorSR(SR.SR):
+@@ -416,41 +470,87 @@ class LinstorSR(SR.SR):
                  if hosts:
                      util.SMlog('Failed to join node(s): {}'.format(hosts))
  
@@ -697,7 +697,7 @@ index a72d43e..9cb4ed4 100755
              raise xs_errors.XenError(
                  'LinstorSRCreate',
                  opterr='Redundancy greater than host count'
-@@ -472,15 +648,45 @@ class LinstorSR(SR.SR):
+@@ -472,15 +572,45 @@ class LinstorSR(SR.SR):
                          opterr='group name must be unique'
                      )
  
@@ -745,7 +745,7 @@ index a72d43e..9cb4ed4 100755
                  logger=util.SMlog
              )
              self._vhdutil = LinstorVhdUtil(self.session, self._linstor)
-@@ -488,30 +694,83 @@ class LinstorSR(SR.SR):
+@@ -488,30 +618,83 @@ class LinstorSR(SR.SR):
              util.SMlog('Failed to create LINSTOR SR: {}'.format(e))
              raise xs_errors.XenError('LinstorSRCreate', opterr=str(e))
  
@@ -837,7 +837,7 @@ index a72d43e..9cb4ed4 100755
      @_locked_load
      def update(self, uuid):
          util.SMlog('LinstorSR.update for {}'.format(self.uuid))
-@@ -558,6 +817,9 @@ class LinstorSR(SR.SR):
+@@ -558,6 +741,9 @@ class LinstorSR(SR.SR):
  
      @_locked_load
      def scan(self, uuid):
@@ -847,7 +847,7 @@ index a72d43e..9cb4ed4 100755
          util.SMlog('LinstorSR.scan for {}'.format(self.uuid))
          if not self._linstor:
              raise xs_errors.XenError(
-@@ -565,6 +827,9 @@ class LinstorSR(SR.SR):
+@@ -565,12 +751,30 @@ class LinstorSR(SR.SR):
                  opterr='no such volume group: {}'.format(self._group_name)
              )
  
@@ -857,7 +857,28 @@ index a72d43e..9cb4ed4 100755
          self._update_physical_size()
  
          for vdi_uuid in self.vdis.keys():
-@@ -588,10 +853,9 @@ class LinstorSR(SR.SR):
+             if self.vdis[vdi_uuid].deleted:
+                 del self.vdis[vdi_uuid]
+ 
++        # Security to prevent VDIs from being forgotten if the controller
++        # is started without a shared and mounted /var/lib/linstor path.
++        try:
++            self._linstor.get_database_path()
++        except Exception:
++            # Failed to get database path, ensure we don't have
++            # VDIs in the XAPI database...
++            if self.session.xenapi.SR.get_VDIs(
++                self.session.xenapi.SR.get_by_uuid(self.uuid)
++            ):
++                raise xs_errors.XenError(
++                    'SRUnavailable',
++                    opterr='Database is not mounted'
++                )
++
+         # Update the database before the restart of the GC to avoid
+         # bad sync in the process if new VDIs have been introduced.
+         ret = super(LinstorSR, self).scan(self.uuid)
+@@ -588,10 +792,9 @@ class LinstorSR(SR.SR):
      # --------------------------------------------------------------------------
  
      def _shared_lock_vdi(self, vdi_uuid, locked=True):
@@ -870,7 +891,7 @@ index a72d43e..9cb4ed4 100755
          args = {
              'groupName': self._group_name,
              'srUuid': self.uuid,
-@@ -599,48 +863,128 @@ class LinstorSR(SR.SR):
+@@ -599,48 +802,128 @@ class LinstorSR(SR.SR):
              'locked': str(locked)
          }
  
@@ -1026,7 +1047,7 @@ index a72d43e..9cb4ed4 100755
  
      # --------------------------------------------------------------------------
      # Metadata.
-@@ -653,7 +997,7 @@ class LinstorSR(SR.SR):
+@@ -653,7 +936,7 @@ class LinstorSR(SR.SR):
  
              # Now update the VDI information in the metadata if required.
              xenapi = self.session.xenapi
@@ -1035,7 +1056,7 @@ index a72d43e..9cb4ed4 100755
              for vdi_uuid, volume_metadata in volumes_metadata.items():
                  try:
                      vdi_ref = xenapi.VDI.get_by_uuid(vdi_uuid)
-@@ -708,36 +1052,43 @@ class LinstorSR(SR.SR):
+@@ -708,36 +991,43 @@ class LinstorSR(SR.SR):
          # Update size attributes of the SR parent class.
          self.virtual_allocation = valloc + virt_alloc_delta
  
@@ -1094,7 +1115,7 @@ index a72d43e..9cb4ed4 100755
          # 1. Get existing VDIs in XAPI.
          xenapi = self.session.xenapi
          xapi_vdi_uuids = set()
-@@ -745,8 +1096,8 @@ class LinstorSR(SR.SR):
+@@ -745,8 +1035,8 @@ class LinstorSR(SR.SR):
              xapi_vdi_uuids.add(xenapi.VDI.get_uuid(vdi))
  
          # 2. Get volumes info.
@@ -1105,7 +1126,7 @@ index a72d43e..9cb4ed4 100755
  
          # 3. Get CBT vdis.
          # See: https://support.citrix.com/article/CTX230619
-@@ -758,7 +1109,8 @@ class LinstorSR(SR.SR):
+@@ -758,7 +1048,8 @@ class LinstorSR(SR.SR):
  
          introduce = False
  
@@ -1115,7 +1136,7 @@ index a72d43e..9cb4ed4 100755
              has_clone_entries = list(self._journaler.get_all(
                  LinstorJournaler.CLONE
              ).items())
-@@ -782,6 +1134,9 @@ class LinstorSR(SR.SR):
+@@ -782,6 +1073,9 @@ class LinstorSR(SR.SR):
                  if not introduce:
                      continue
  
@@ -1125,7 +1146,7 @@ index a72d43e..9cb4ed4 100755
                  volume_metadata = volumes_metadata.get(vdi_uuid)
                  if not volume_metadata:
                      util.SMlog(
-@@ -836,10 +1191,10 @@ class LinstorSR(SR.SR):
+@@ -836,10 +1130,10 @@ class LinstorSR(SR.SR):
  
                  util.SMlog(
                      'Introducing VDI {} '.format(vdi_uuid) +
@@ -1138,7 +1159,7 @@ index a72d43e..9cb4ed4 100755
                      )
                  )
  
-@@ -857,7 +1212,7 @@ class LinstorSR(SR.SR):
+@@ -857,7 +1151,7 @@ class LinstorSR(SR.SR):
                      sm_config,
                      managed,
                      str(volume_info.virtual_size),
@@ -1147,7 +1168,7 @@ index a72d43e..9cb4ed4 100755
                  )
  
                  is_a_snapshot = volume_metadata.get(IS_A_SNAPSHOT_TAG)
-@@ -881,9 +1236,11 @@ class LinstorSR(SR.SR):
+@@ -881,9 +1175,11 @@ class LinstorSR(SR.SR):
              vdi = self.vdi(vdi_uuid)
              self.vdis[vdi_uuid] = vdi
  
@@ -1161,7 +1182,7 @@ index a72d43e..9cb4ed4 100755
  
              # 4.c. Update CBT status of disks either just added
              # or already in XAPI.
-@@ -940,7 +1297,7 @@ class LinstorSR(SR.SR):
+@@ -940,7 +1236,7 @@ class LinstorSR(SR.SR):
                  else:
                      geneology[vdi.parent] = [vdi_uuid]
              if not vdi.hidden:
@@ -1170,28 +1191,27 @@ index a72d43e..9cb4ed4 100755
  
          # 9. Remove all hidden leaf nodes to avoid introducing records that
          # will be GC'ed.
-@@ -1014,13 +1371,18 @@ class LinstorSR(SR.SR):
+@@ -1014,13 +1310,12 @@ class LinstorSR(SR.SR):
              util.SMlog('Cannot deflate missing VDI {}'.format(vdi_uuid))
              return
  
 -        current_size = self._linstor.get_volume_info(self.uuid).virtual_size
+-        util.zeroOut(
+-            vdi.path,
+-            current_size - vhdutil.VHD_FOOTER_SIZE,
+-            vhdutil.VHD_FOOTER_SIZE
+-        )
+-        deflate(vdi_uuid, vdi.path, old_size, current_size)
 +        assert not self._all_volume_info_cache
 +        volume_info = self._linstor.get_volume_info(vdi_uuid)
 +
 +        current_size = volume_info.virtual_size
 +        assert current_size > 0
-+
-         util.zeroOut(
-             vdi.path,
-             current_size - vhdutil.VHD_FOOTER_SIZE,
-             vhdutil.VHD_FOOTER_SIZE
-         )
--        deflate(vdi_uuid, vdi.path, old_size, current_size)
-+        deflate(self._linstor, vdi_uuid, vdi.path, old_size, current_size)
++        self._vhdutil.force_deflate(vdi.path, old_size, current_size, zeroize=True)
  
      def _handle_interrupted_clone(
          self, vdi_uuid, clone_info, force_undo=False
-@@ -1033,7 +1395,7 @@ class LinstorSR(SR.SR):
+@@ -1033,7 +1328,7 @@ class LinstorSR(SR.SR):
          base_uuid, snap_uuid = clone_info.split('_')
  
          # Use LINSTOR data because new VDIs may not be in the XAPI.
@@ -1200,7 +1220,7 @@ index a72d43e..9cb4ed4 100755
  
          # Check if we don't have a base VDI. (If clone failed at startup.)
          if base_uuid not in volume_names:
-@@ -1089,7 +1451,7 @@ class LinstorSR(SR.SR):
+@@ -1089,7 +1384,7 @@ class LinstorSR(SR.SR):
          if base_type == vhdutil.VDI_TYPE_VHD:
              vhd_info = self._vhdutil.get_vhd_info(base_uuid, False)
              if vhd_info.hidden:
@@ -1209,7 +1229,7 @@ index a72d43e..9cb4ed4 100755
          elif base_type == vhdutil.VDI_TYPE_RAW and \
                  base_metadata.get(HIDDEN_TAG):
              self._linstor.update_volume_metadata(
-@@ -1099,10 +1461,6 @@ class LinstorSR(SR.SR):
+@@ -1099,10 +1394,6 @@ class LinstorSR(SR.SR):
          # Remove the child nodes.
          if snap_uuid and snap_uuid in volume_names:
              util.SMlog('Destroying snap {}...'.format(snap_uuid))
@@ -1220,7 +1240,20 @@ index a72d43e..9cb4ed4 100755
  
              try:
                  self._linstor.destroy_volume(snap_uuid)
-@@ -1150,10 +1508,64 @@ class LinstorSR(SR.SR):
+@@ -1136,9 +1427,9 @@ class LinstorSR(SR.SR):
+         # Inflate to the right size.
+         if base_type == vhdutil.VDI_TYPE_VHD:
+             vdi = self.vdi(vdi_uuid)
+-            volume_size = compute_volume_size(vdi.size, vdi.vdi_type)
+-            inflate(
+-                self._journaler, self._linstor, vdi_uuid, vdi.path,
++            volume_size = LinstorVhdUtil.compute_volume_size(vdi.size, vdi.vdi_type)
++            self._vhdutil.inflate(
++                self._journaler, vdi_uuid, vdi.path,
+                 volume_size, vdi.capacity
+             )
+             self.vdis[vdi_uuid] = vdi
+@@ -1150,10 +1441,64 @@ class LinstorSR(SR.SR):
  
          util.SMlog('*** INTERRUPTED CLONE OP: rollback success')
  
@@ -1285,7 +1318,16 @@ index a72d43e..9cb4ed4 100755
      def _ensure_space_available(self, amount_needed):
          space_available = self._linstor.max_volume_size_allowed
          if (space_available < amount_needed):
-@@ -1233,7 +1645,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1199,8 +1544,6 @@ class LinstorVDI(VDI.VDI):
+     TYPE_RAW = 'raw'
+     TYPE_VHD = 'vhd'
+ 
+-    MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024  # Max VHD size.
+-
+     # Metadata size given to the "S" param of vhd-util create.
+     # "-S size (MB) for metadata preallocation".
+     # Increase the performance when resize is called.
+@@ -1233,7 +1576,7 @@ class LinstorVDI(VDI.VDI):
              if (
                  self.sr.srcmd.cmd == 'vdi_attach_from_config' or
                  self.sr.srcmd.cmd == 'vdi_detach_from_config'
@@ -1294,7 +1336,7 @@ index a72d43e..9cb4ed4 100755
                  self.vdi_type = vhdutil.VDI_TYPE_RAW
                  self.path = self.sr.srcmd.params['vdi_path']
              else:
-@@ -1297,11 +1709,11 @@ class LinstorVDI(VDI.VDI):
+@@ -1297,11 +1640,11 @@ class LinstorVDI(VDI.VDI):
  
          # 2. Compute size and check space available.
          size = vhdutil.validate_and_round_vhd_size(int(size))
@@ -1302,7 +1344,8 @@ index a72d43e..9cb4ed4 100755
 -            self.vdi_type, size
 -        ))
 -
-         volume_size = compute_volume_size(size, self.vdi_type)
+-        volume_size = compute_volume_size(size, self.vdi_type)
++        volume_size = LinstorVhdUtil.compute_volume_size(size, self.vdi_type)
 +        util.SMlog(
 +            'LinstorVDI.create: type={}, vhd-size={}, volume-size={}'
 +            .format(self.vdi_type, size, volume_size)
@@ -1310,15 +1353,15 @@ index a72d43e..9cb4ed4 100755
          self.sr._ensure_space_available(volume_size)
  
          # 3. Set sm_config attribute of VDI parent class.
-@@ -1310,8 +1722,15 @@ class LinstorVDI(VDI.VDI):
+@@ -1310,8 +1653,15 @@ class LinstorVDI(VDI.VDI):
          # 4. Create!
          failed = False
          try:
 +            volume_name = None
 +            if self.ty == 'ha_statefile':
-+                volume_name = 'xcp-persistent-ha-statefile'
++                volume_name = HA_VOLUME_NAME
 +            elif self.ty == 'redo_log':
-+                volume_name = 'xcp-persistent-redo-log'
++                volume_name = REDO_LOG_VOLUME_NAME
 +
              self._linstor.create_volume(
 -                self.uuid, volume_size, persistent=False
@@ -1327,7 +1370,7 @@ index a72d43e..9cb4ed4 100755
              )
              volume_info = self._linstor.get_volume_info(self.uuid)
  
-@@ -1320,16 +1739,16 @@ class LinstorVDI(VDI.VDI):
+@@ -1320,16 +1670,16 @@ class LinstorVDI(VDI.VDI):
              if self.vdi_type == vhdutil.VDI_TYPE_RAW:
                  self.size = volume_info.virtual_size
              else:
@@ -1347,7 +1390,7 @@ index a72d43e..9cb4ed4 100755
              volume_info = self._linstor.get_volume_info(self.uuid)
  
              volume_metadata = {
-@@ -1344,6 +1763,13 @@ class LinstorVDI(VDI.VDI):
+@@ -1344,6 +1694,13 @@ class LinstorVDI(VDI.VDI):
                  METADATA_OF_POOL_TAG: ''
              }
              self._linstor.set_volume_metadata(self.uuid, volume_metadata)
@@ -1361,7 +1404,7 @@ index a72d43e..9cb4ed4 100755
              self._linstor.mark_volume_as_persistent(self.uuid)
          except util.CommandException as e:
              failed = True
-@@ -1364,11 +1790,11 @@ class LinstorVDI(VDI.VDI):
+@@ -1364,11 +1721,11 @@ class LinstorVDI(VDI.VDI):
                          '{}'.format(e)
                      )
  
@@ -1375,7 +1418,7 @@ index a72d43e..9cb4ed4 100755
  
          return VDI.VDI.get_params(self)
  
-@@ -1407,14 +1833,15 @@ class LinstorVDI(VDI.VDI):
+@@ -1407,14 +1764,15 @@ class LinstorVDI(VDI.VDI):
              del self.sr.vdis[self.uuid]
  
          # TODO: Check size after delete.
@@ -1393,16 +1436,13 @@ index a72d43e..9cb4ed4 100755
              self.sr.srcmd.params['vdi_uuid'] != self.uuid
          ) and self.sr._journaler.has_entries(self.uuid):
              raise xs_errors.XenError(
-@@ -1423,50 +1850,62 @@ class LinstorVDI(VDI.VDI):
+@@ -1423,56 +1781,87 @@ class LinstorVDI(VDI.VDI):
                  'scan SR first to trigger auto-repair'
              )
  
 -        writable = 'args' not in self.sr.srcmd.params or \
 -            self.sr.srcmd.params['args'][0] == 'true'
-+        if not attach_from_config or self.sr._is_master:
-+            writable = 'args' not in self.sr.srcmd.params or \
-+                self.sr.srcmd.params['args'][0] == 'true'
- 
+-
 -        # We need to inflate the volume if we don't have enough place
 -        # to mount the VHD image. I.e. the volume capacity must be greater
 -        # than the VHD size + bitmap size.
@@ -1410,7 +1450,10 @@ index a72d43e..9cb4ed4 100755
 -        if self.vdi_type == vhdutil.VDI_TYPE_RAW or not writable or \
 -                self.capacity >= compute_volume_size(self.size, self.vdi_type):
 -            need_inflate = False
--
++        if not attach_from_config or self.sr._is_master:
++            writable = 'args' not in self.sr.srcmd.params or \
++                self.sr.srcmd.params['args'][0] == 'true'
+ 
 -        if need_inflate:
 -            try:
 -                self._prepare_thin(True)
@@ -1427,7 +1470,7 @@ index a72d43e..9cb4ed4 100755
 +            if (
 +                self.vdi_type == vhdutil.VDI_TYPE_RAW or
 +                not writable or
-+                self.capacity >= compute_volume_size(self.size, self.vdi_type)
++                self.capacity >= LinstorVhdUtil.compute_volume_size(self.size, self.vdi_type)
 +            ):
 +                need_inflate = False
  
@@ -1447,15 +1490,12 @@ index a72d43e..9cb4ed4 100755
  
          if not hasattr(self, 'xenstore_data'):
              self.xenstore_data = {}
--
++        self.xenstore_data['storage-type'] = LinstorSR.DRIVER_TYPE
+ 
 -        # TODO: Is it useful?
 -        self.xenstore_data.update(scsiutil.update_XS_SCSIdata(
 -            self.uuid, scsiutil.gen_synthetic_page_data(self.uuid)
 -        ))
--
-         self.xenstore_data['storage-type'] = LinstorSR.DRIVER_TYPE
- 
--        self.attached = True
 +        if (
 +            USE_HTTP_NBD_SERVERS and
 +            attach_from_config and
@@ -1470,9 +1510,30 @@ index a72d43e..9cb4ed4 100755
 +                raise xs_errors.XenError(
 +                    'VDIUnavailable', opterr='Could not find: {}'.format(path)
 +                )
+ 
+-        self.xenstore_data['storage-type'] = LinstorSR.DRIVER_TYPE
++            # Diskless path can be created on the fly, ensure we can open it.
++            def check_volume_usable():
++                while True:
++                    try:
++                        with open(path, 'r+'):
++                            pass
++                    except IOError as e:
++                        if e.errno == errno.ENODATA:
++                            time.sleep(2)
++                            continue
++                        if e.errno == errno.EROFS:
++                            util.SMlog('Volume not attachable because RO. Openers: {}'.format(
++                                self.sr._linstor.get_volume_openers(vdi_uuid)
++                            ))
++                        raise
++                    break
++            util.retry(check_volume_usable, 15, 2)
++
 +            vdi_uuid = self.sr._vhdutil.get_vhd_info(vdi_uuid).parentUuid
  
-+        self.attached = True
+         self.attached = True
+-
          return VDI.VDI.attach(self, self.sr.uuid, self.uuid)
  
      def detach(self, sr_uuid, vdi_uuid):
@@ -1486,8 +1547,37 @@ index a72d43e..9cb4ed4 100755
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
              return
  
-@@ -1503,9 +1942,23 @@ class LinstorVDI(VDI.VDI):
+         # The VDI is already deflated if the VHD image size + metadata is
+         # equal to the LINSTOR volume size.
+-        volume_size = compute_volume_size(self.size, self.vdi_type)
++        volume_size = LinstorVhdUtil.compute_volume_size(self.size, self.vdi_type)
+         already_deflated = self.capacity <= volume_size
  
+         if already_deflated:
+@@ -1501,11 +1890,45 @@ class LinstorVDI(VDI.VDI):
+                     .format(e)
+                 )
+ 
++        # We remove only on slaves because the volume can be used by the GC.
++        if self.sr._is_master:
++            return
++
++        while vdi_uuid:
++            try:
++                path = self._linstor.build_device_path(self._linstor.get_volume_name(vdi_uuid))
++                parent_vdi_uuid = self.sr._vhdutil.get_vhd_info(vdi_uuid).parentUuid
++            except Exception:
++                break
++
++            if util.pathexists(path):
++                try:
++                    self._linstor.remove_volume_if_diskless(vdi_uuid)
++                except Exception as e:
++                    # Ensure we can always detach properly.
++                    # I don't want to corrupt the XAPI info.
++                    util.SMlog('Failed to clean VDI {} during detach: {}'.format(vdi_uuid, e))
++            vdi_uuid = parent_vdi_uuid
++
      def resize(self, sr_uuid, vdi_uuid, size):
          util.SMlog('LinstorVDI.resize for {}'.format(self.uuid))
 +        if not self.sr._is_master:
@@ -1501,7 +1591,7 @@ index a72d43e..9cb4ed4 100755
  
 +        # Compute the virtual VHD and DRBD volume size.
 +        size = vhdutil.validate_and_round_vhd_size(int(size))
-+        volume_size = compute_volume_size(size, self.vdi_type)
++        volume_size = LinstorVhdUtil.compute_volume_size(size, self.vdi_type)
 +        util.SMlog(
 +            'LinstorVDI.resize: type={}, vhd-size={}, volume-size={}'
 +            .format(self.vdi_type, size, volume_size)
@@ -1510,7 +1600,7 @@ index a72d43e..9cb4ed4 100755
          if size < self.size:
              util.SMlog(
                  'vdi_resize: shrinking not supported: '
-@@ -1513,18 +1966,13 @@ class LinstorVDI(VDI.VDI):
+@@ -1513,36 +1936,34 @@ class LinstorVDI(VDI.VDI):
              )
              raise xs_errors.XenError('VDISize', opterr='shrinking not allowed')
  
@@ -1524,13 +1614,17 @@ index a72d43e..9cb4ed4 100755
 -        new_volume_size = compute_volume_size(size, self.vdi_type)
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
              old_volume_size = self.size
++            new_volume_size = LinstorVolumeManager.round_up_volume_size(size)
          else:
 -            old_volume_size = self.capacity
 +            old_volume_size = self.utilisation
              if self.sr._provisioning == 'thin':
                  # VDI is currently deflated, so keep it deflated.
                  new_volume_size = old_volume_size
-@@ -1533,7 +1981,7 @@ class LinstorVDI(VDI.VDI):
++            else:
++                new_volume_size = LinstorVhdUtil.compute_volume_size(size, self.vdi_type)
+         assert new_volume_size >= old_volume_size
+ 
          space_needed = new_volume_size - old_volume_size
          self.sr._ensure_space_available(space_needed)
  
@@ -1539,7 +1633,9 @@ index a72d43e..9cb4ed4 100755
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
              self._linstor.resize(self.uuid, new_volume_size)
          else:
-@@ -1542,7 +1990,7 @@ class LinstorVDI(VDI.VDI):
+             if new_volume_size != old_volume_size:
+-                inflate(
++                self.sr._vhdutil.inflate(
                      self.sr._journaler, self._linstor, self.uuid, self.path,
                      new_volume_size, old_volume_size
                  )
@@ -1548,7 +1644,7 @@ index a72d43e..9cb4ed4 100755
  
          # Reload size attributes.
          self._load_this()
-@@ -1552,7 +2000,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1552,7 +1973,7 @@ class LinstorVDI(VDI.VDI):
          self.session.xenapi.VDI.set_physical_utilisation(
              vdi_ref, str(self.utilisation)
          )
@@ -1557,7 +1653,7 @@ index a72d43e..9cb4ed4 100755
          return VDI.VDI.get_params(self)
  
      def clone(self, sr_uuid, vdi_uuid):
-@@ -1574,8 +2022,8 @@ class LinstorVDI(VDI.VDI):
+@@ -1574,8 +1995,8 @@ class LinstorVDI(VDI.VDI):
          if not blktap2.VDI.tap_pause(self.session, self.sr.uuid, self.uuid):
              raise util.SMException('Failed to pause VDI {}'.format(self.uuid))
          try:
@@ -1568,7 +1664,7 @@ index a72d43e..9cb4ed4 100755
              self.sr.session.xenapi.VDI.set_managed(
                  self.sr.srcmd.params['args'][0], False
              )
-@@ -1598,25 +2046,40 @@ class LinstorVDI(VDI.VDI):
+@@ -1598,25 +2019,40 @@ class LinstorVDI(VDI.VDI):
  
          util.SMlog('LinstorVDI.generate_config for {}'.format(self.uuid))
  
@@ -1600,7 +1696,7 @@ index a72d43e..9cb4ed4 100755
 +        # instead.
 +        volume_name = self._linstor.get_volume_name(self.uuid)
 +        if not USE_HTTP_NBD_SERVERS or volume_name not in [
-+            'xcp-persistent-ha-statefile', 'xcp-persistent-redo-log'
++            HA_VOLUME_NAME, REDO_LOG_VOLUME_NAME
 +        ]:
 +            if not self.path or not util.pathexists(self.path):
 +                available = False
@@ -1621,7 +1717,7 @@ index a72d43e..9cb4ed4 100755
          config = xmlrpc.client.dumps(tuple([resp]), 'vdi_attach_from_config')
          return xmlrpc.client.dumps((config,), "", True)
  
-@@ -1652,19 +2115,28 @@ class LinstorVDI(VDI.VDI):
+@@ -1652,19 +2088,28 @@ class LinstorVDI(VDI.VDI):
                  .format(self.uuid)
              )
  
@@ -1655,7 +1751,7 @@ index a72d43e..9cb4ed4 100755
          self.capacity = volume_info.virtual_size
  
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
-@@ -1691,7 +2163,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1691,7 +2136,7 @@ class LinstorVDI(VDI.VDI):
              return
  
          if self.vdi_type == vhdutil.VDI_TYPE_VHD:
@@ -1664,7 +1760,7 @@ index a72d43e..9cb4ed4 100755
          else:
              self._linstor.update_volume_metadata(self.uuid, {
                  HIDDEN_TAG: hidden
-@@ -1739,25 +2211,14 @@ class LinstorVDI(VDI.VDI):
+@@ -1739,25 +2184,19 @@ class LinstorVDI(VDI.VDI):
          else:
              fn = 'attach' if attach else 'detach'
  
@@ -1689,11 +1785,16 @@ index a72d43e..9cb4ed4 100755
 -                    'VDIUnavailable',
 -                    opterr='Plugin {} failed'.format(self.sr.MANAGER_PLUGIN)
 -                )
-+            self.sr._exec_manager_command(master, fn, args, 'VDIUnavailable')
++
++            try:
++                self.sr._exec_manager_command(master, fn, args, 'VDIUnavailable')
++            except Exception:
++                if fn != 'detach':
++                    raise
  
          # Reload size attrs after inflate or deflate!
          self._load_this()
-@@ -1807,9 +2268,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1807,9 +2246,7 @@ class LinstorVDI(VDI.VDI):
                  'VDIUnavailable',
                  opterr='failed to get vdi_type in metadata'
              )
@@ -1704,7 +1805,7 @@ index a72d43e..9cb4ed4 100755
  
      def _update_device_name(self, device_name):
          self._device_name = device_name
-@@ -1832,7 +2291,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1832,7 +2269,7 @@ class LinstorVDI(VDI.VDI):
  
          # 2. Write the snapshot content.
          is_raw = (self.vdi_type == vhdutil.VDI_TYPE_RAW)
@@ -1713,7 +1814,7 @@ index a72d43e..9cb4ed4 100755
              snap_path, self.path, is_raw, self.MAX_METADATA_VIRT_SIZE
          )
  
-@@ -1862,7 +2321,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1862,7 +2299,7 @@ class LinstorVDI(VDI.VDI):
          volume_info = self._linstor.get_volume_info(snap_uuid)
  
          snap_vdi.size = self.sr._vhdutil.get_size_virt(snap_uuid)
@@ -1722,7 +1823,7 @@ index a72d43e..9cb4ed4 100755
  
          # 6. Update sm config.
          snap_vdi.sm_config = {}
-@@ -1932,6 +2391,9 @@ class LinstorVDI(VDI.VDI):
+@@ -1932,6 +2369,9 @@ class LinstorVDI(VDI.VDI):
          elif depth >= vhdutil.MAX_CHAIN_SIZE:
              raise xs_errors.XenError('SnapshotChainTooLong')
  
@@ -1732,7 +1833,7 @@ index a72d43e..9cb4ed4 100755
          volume_path = self.path
          if not util.pathexists(volume_path):
              raise xs_errors.XenError(
-@@ -2057,7 +2519,7 @@ class LinstorVDI(VDI.VDI):
+@@ -2057,7 +2497,7 @@ class LinstorVDI(VDI.VDI):
                      raise
  
              if snap_type != VDI.SNAPSHOT_INTERNAL:
@@ -1741,7 +1842,7 @@ index a72d43e..9cb4ed4 100755
  
              # 10. Return info on the new user-visible leaf VDI.
              ret_vdi = snap_vdi
-@@ -2088,10 +2550,318 @@ class LinstorVDI(VDI.VDI):
+@@ -2088,10 +2528,318 @@ class LinstorVDI(VDI.VDI):
  
          return ret_vdi.get_params()
  
@@ -1751,7 +1852,7 @@ index a72d43e..9cb4ed4 100755
 +        http_server = None
 +
 +        try:
-+            if volume_name == 'xcp-persistent-ha-statefile':
++            if volume_name == HA_VOLUME_NAME:
 +                port = '8076'
 +            else:
 +                port = '8077'
@@ -1833,7 +1934,7 @@ index a72d43e..9cb4ed4 100755
 +        try:
 +            # We use a precomputed device size.
 +            # So if the XAPI is modified, we must update these values!
-+            if volume_name == 'xcp-persistent-ha-statefile':
++            if volume_name == HA_VOLUME_NAME:
 +                # See: https://github.com/xapi-project/xen-api/blob/703479fa448a8d7141954bb6e8964d8e25c4ac2e/ocaml/xapi/xha_statefile.ml#L32-L37
 +                port = '8076'
 +                device_size = 4 * 1024 * 1024
@@ -1957,7 +2058,7 @@ index a72d43e..9cb4ed4 100755
 +    def _check_http_nbd_volume_name(self):
 +        volume_name = self.path[14:]
 +        if volume_name not in [
-+            'xcp-persistent-ha-statefile', 'xcp-persistent-redo-log'
++            HA_VOLUME_NAME, REDO_LOG_VOLUME_NAME
 +        ]:
 +            raise xs_errors.XenError(
 +                'VDIUnavailable',
@@ -2026,8 +2127,8 @@ index a72d43e..9cb4ed4 100755
 +        http_service = None
 +        if drbd_path:
 +            assert(drbd_path in (
-+                '/dev/drbd/by-res/xcp-persistent-ha-statefile/0',
-+                '/dev/drbd/by-res/xcp-persistent-redo-log/0'
++                '/dev/drbd/by-res/{}/0'.format(HA_VOLUME_NAME),
++                '/dev/drbd/by-res/{}/0'.format(REDO_LOG_VOLUME_NAME)
 +            ))
 +            self._start_persistent_http_server(volume_name)
 +
@@ -2103,10 +2204,10 @@ index 2950ce2..3434a9f 100755
                          tapdisk = cls.__from_blktap(blktap)
                          node = '/sys/dev/block/%d:%d' % (tapdisk.major(), tapdisk.minor)
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index f190b1b..51f2912 100755
+index f190b1b..989068a 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
-@@ -53,8 +53,10 @@ from time import monotonic as _time
+@@ -53,8 +53,11 @@ from time import monotonic as _time
  try:
      from linstorjournaler import LinstorJournaler
      from linstorvhdutil import LinstorVhdUtil
@@ -2115,11 +2216,12 @@ index f190b1b..51f2912 100755
 +    from linstorvolumemanager import get_controller_uri
 +    from linstorvolumemanager import LinstorVolumeManager
 +    from linstorvolumemanager import LinstorVolumeManagerError
++    from linstorvolumemanager import PERSISTENT_PREFIX as LINSTOR_PERSISTENT_PREFIX
 +
      LINSTOR_AVAILABLE = True
  except ImportError:
      LINSTOR_AVAILABLE = False
-@@ -477,7 +479,7 @@ class XAPI:
+@@ -477,7 +480,7 @@ class XAPI:
  #
  #  VDI
  #
@@ -2128,7 +2230,7 @@ index f190b1b..51f2912 100755
      """Object representing a VDI of a VHD-based SR"""
  
      POLL_INTERVAL = 1
-@@ -760,6 +762,12 @@ class VDI:
+@@ -760,6 +763,12 @@ class VDI:
          lock.Lock.cleanupAll(self.uuid)
          self._clear()
  
@@ -2141,7 +2243,7 @@ index f190b1b..51f2912 100755
      def __str__(self):
          strHidden = ""
          if self.hidden:
-@@ -874,12 +882,14 @@ class VDI:
+@@ -874,12 +883,14 @@ class VDI:
              xapi.message.create(msg_name, "3", "SR", vdi.sr.uuid, msg_body)
      _reportCoalesceError = staticmethod(_reportCoalesceError)
  
@@ -2158,7 +2260,7 @@ index f190b1b..51f2912 100755
              endTime = time.time()
              vdi.sr.recordStorageSpeed(startTime, endTime, vhdSize)
          except util.CommandException as ce:
-@@ -918,12 +928,12 @@ class VDI:
+@@ -918,12 +929,12 @@ class VDI:
              # Try a repair and reraise the exception
              parent = ""
              try:
@@ -2173,7 +2275,7 @@ index f190b1b..51f2912 100755
              except Exception as e:
                  util.SMlog('(error ignored) Failed to repair parent %s ' \
                             'after failed coalesce on %s, err: %s' %
-@@ -1025,10 +1035,10 @@ class VDI:
+@@ -1025,10 +1036,10 @@ class VDI:
          self.hidden = hidden
  
      def _increaseSizeVirt(self, size, atomic=True):
@@ -2186,7 +2288,16 @@ index f190b1b..51f2912 100755
          operations. If the caller is already in the atomic context, it must
          call with atomic = False"""
          if self.sizeVirt >= size:
-@@ -1468,11 +1478,6 @@ class LinstorVDI(VDI):
+@@ -1456,8 +1467,6 @@ class LVHDVDI(VDI):
+ class LinstorVDI(VDI):
+     """Object representing a VDI in a LINSTOR SR"""
+ 
+-    MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024  # Max VHD size.
+-
+     VOLUME_LOCK_TIMEOUT = 30
+ 
+     def load(self, info=None):
+@@ -1468,11 +1477,6 @@ class LinstorVDI(VDI):
  
          self.fileName = self.sr._linstor.get_volume_name(self.uuid)
          self.path = self.sr._linstor.build_device_path(self.fileName)
@@ -2198,7 +2309,62 @@ index f190b1b..51f2912 100755
  
          if not info:
              try:
-@@ -1509,17 +1514,28 @@ class LinstorVDI(VDI):
+@@ -1485,9 +1489,53 @@ class LinstorVDI(VDI):
+ 
+         self.parentUuid = info.parentUuid
+         self.sizeVirt = info.sizeVirt
+-        self._sizeVHD = info.sizePhys
++        self._sizeVHD = -1
++        self.drbd_size = -1
+         self.hidden = info.hidden
+         self.scanError = False
++        self.vdi_type = vhdutil.VDI_TYPE_VHD
++
++    def getSizeVHD(self, fetch=False):
++        if self._sizeVHD < 0 or fetch:
++            self._sizeVHD = self.sr._vhdutil.get_size_phys(self.uuid)
++        return self._sizeVHD
++
++    def getDrbdSize(self, fetch=False):
++        if self.drbd_size < 0 or fetch:
++            self.drbd_size = self.sr._vhdutil.get_drbd_size(self.uuid)
++        return self.drbd_size
++
++    def inflate(self, size):
++        if self.raw:
++            return
++        self.sr.lock()
++        try:
++            # Ensure we use the real DRBD size and not the cached one.
++            # Why? Because this attribute can be changed if volume is resized by user.
++            self.drbd_size = self.getDrbdSize(fetch=True)
++            self.sr._vhdutil.inflate(self.sr.journaler, self.uuid, self.path, size, self.drbd_size)
++        finally:
++            self.sr.unlock()
++        self.drbd_size = -1
++        self._sizeVHD = -1
++
++    def deflate(self):
++        if self.raw:
++            return
++        self.sr.lock()
++        try:
++            # Ensure we use the real sizes and not the cached info.
++            self.drbd_size = self.getDrbdSize(fetch=True)
++            self._sizeVHD = self.getSizeVHD(fetch=True)
++            self.sr._vhdutil.force_deflate(self.path, self._sizeVHD, self.drbd_size, zeroize=False)
++        finally:
++            self.sr.unlock()
++        self.drbd_size = -1
++        self._sizeVHD = -1
++
++    def inflateFully(self):
++        if not self.raw:
++            self.inflate(LinstorVhdUtil.compute_volume_size(self.sizeVirt, self.vdi_type))
+ 
+     def rename(self, uuid):
+         Util.log('Renaming {} -> {} (path={})'.format(
+@@ -1509,17 +1557,30 @@ class LinstorVDI(VDI):
              self.sr.unlock()
          VDI.delete(self)
  
@@ -2208,7 +2374,7 @@ index f190b1b..51f2912 100755
 -        )
 -        return super(VDI).pauseVDIs(vdiList)
 +    def validate(self, fast=False):
-+        if not self.sr._vhdutil.check(self.uuid, fast=fast):
++        if not self.raw and not self.sr._vhdutil.check(self.uuid, fast=fast):
 +            raise util.SMException('VHD {} corrupted'.format(self))
  
 -    def _liveLeafCoalesce(self, vdi):
@@ -2220,6 +2386,8 @@ index f190b1b..51f2912 100755
 +        return super(LinstorVDI, self).pause(failfast)
 +
 +    def coalesce(self):
++        # Note: We raise `SMException` here to skip the current coalesce in case of failure.
++        # Using another exception we can't execute the next coalesce calls.
 +        self.sr._vhdutil.force_coalesce(self.path)
 +
 +    def getParent(self):
@@ -2235,11 +2403,12 @@ index f190b1b..51f2912 100755
  
      def _relinkSkip(self):
          abortFlag = IPCFlag(self.sr.uuid)
-@@ -1545,6 +1561,19 @@ class LinstorVDI(VDI):
+@@ -1545,6 +1606,40 @@ class LinstorVDI(VDI):
                  blktap2.VDI.tap_unpause(session, sr_uuid, vdi_uuid)
          self.children = []
  
 +    def _setParent(self, parent):
++        self.sr._linstor.get_device_path(self.uuid)
 +        self.sr._vhdutil.force_parent(self.path, parent.path)
 +        self.parent = parent
 +        self.parentUuid = parent.uuid
@@ -2252,10 +2421,80 @@ index f190b1b..51f2912 100755
 +            Util.log("Failed to update %s with vhd-parent field %s" % \
 +                     (self.uuid, self.parentUuid))
 +
++    def _doCoalesce(self):
++        try:
++            self._activateChain()
++            self.parent.validate()
++            self._inflateParentForCoalesce()
++            VDI._doCoalesce(self)
++        finally:
++            self.parent.deflate()
++
++    def _activateChain(self):
++        vdi = self
++        while vdi:
++            try:
++                p = self.sr._linstor.get_device_path(vdi.uuid)
++            except Exception as e:
++                # Use SMException to skip coalesce.
++                # Otherwise the GC is stopped...
++                raise util.SMException(str(e))
++            vdi = vdi.parent
++
      def _setHidden(self, hidden=True):
          HIDDEN_TAG = 'hidden'
  
-@@ -1563,7 +1592,7 @@ class LinstorVDI(VDI):
+@@ -1556,14 +1651,57 @@ class LinstorVDI(VDI):
+         else:
+             VDI._setHidden(self, hidden)
+ 
++    def _setSizeVirt(self, size):
++        jfile = self.uuid + '-jvhd'
++        self.sr._linstor.create_volume(
++            jfile, vhdutil.MAX_VHD_JOURNAL_SIZE, persistent=False, volume_name=jfile
++        )
++        try:
++            self.inflate(LinstorVhdUtil.compute_volume_size(size, self.vdi_type))
++            self.sr._vhdutil.set_size_virt(size, jfile)
++        finally:
++            try:
++                self.sr._linstor.destroy_volume(jfile)
++            except Exception:
++                # We can ignore it, in any case this volume is not persistent.
++                pass
++
+     def _queryVHDBlocks(self):
+         return self.sr._vhdutil.get_block_bitmap(self.uuid)
+ 
++    def _inflateParentForCoalesce(self):
++        if self.parent.raw:
++            return
++        inc = self._calcExtraSpaceForCoalescing()
++        if inc > 0:
++            self.parent.inflate(self.parent.getDrbdSize() + inc)
++
++    def _calcExtraSpaceForCoalescing(self):
++        if self.parent.raw:
++            return 0
++        size_coalesced = LinstorVhdUtil.compute_volume_size(
++            self._getCoalescedSizeData(), self.vdi_type
++        )
++        Util.log("Coalesced size = %s" % Util.num2str(size_coalesced))
++        return size_coalesced - self.parent.getDrbdSize()
++
++    def _calcExtraSpaceForLeafCoalescing(self):
++        assert self.getDrbdSize() > 0
++        assert self.getSizeVHD() > 0
++        deflate_diff = self.getDrbdSize() - LinstorVolumeManager.round_up_volume_size(self.getSizeVHD())
++        assert deflate_diff >= 0
++        return self._calcExtraSpaceForCoalescing() - deflate_diff
++
++    def _calcExtraSpaceForSnapshotCoalescing(self):
++        assert self.getSizeVHD() > 0
++        return self._calcExtraSpaceForCoalescing() + \
++            LinstorVolumeManager.round_up_volume_size(self.getSizeVHD())
++
+ ################################################################################
  #
  # SR
  #
@@ -2264,7 +2503,7 @@ index f190b1b..51f2912 100755
      class LogFilter:
          def __init__(self, sr):
              self.sr = sr
-@@ -2129,7 +2158,7 @@ class SR:
+@@ -2129,7 +2267,7 @@ class SR:
  
      def _coalesceLeaf(self, vdi):
          """Leaf-coalesce VDI vdi. Return true if we succeed, false if we cannot
@@ -2273,7 +2512,7 @@ index f190b1b..51f2912 100755
          that alter leaf-coalescibility of vdi"""
          tracker = self.CoalesceTracker(self)
          while not vdi.canLiveCoalesce(self.getStorageSpeed()):
-@@ -2345,7 +2374,7 @@ class SR:
+@@ -2345,7 +2483,7 @@ class SR:
          self.forgetVDI(origParentUuid)
          self._finishCoalesceLeaf(parent)
          self._updateSlavesOnResize(parent)
@@ -2282,7 +2521,7 @@ index f190b1b..51f2912 100755
      def _calcExtraSpaceNeeded(self, child, parent):
          assert(not parent.raw)  # raw parents not supported
          extra = child.getSizeVHD() - parent.getSizeVHD()
-@@ -2379,9 +2408,9 @@ class SR:
+@@ -2379,9 +2517,9 @@ class SR:
                  del self.vdis[uuid]
  
      def _handleInterruptedCoalesceLeaf(self):
@@ -2295,7 +2534,7 @@ index f190b1b..51f2912 100755
          finish the operation"""
          # abstract
          pass
-@@ -2462,10 +2491,10 @@ class FileSR(SR):
+@@ -2462,10 +2600,10 @@ class FileSR(SR):
              self.xapi.markCacheSRsDirty()
  
      def cleanupCache(self, maxAge=-1):
@@ -2310,7 +2549,7 @@ index f190b1b..51f2912 100755
          <maxAge> hours.
          Return number of caches removed.
          """
-@@ -2955,7 +2984,6 @@ class LinstorSR(SR):
+@@ -2955,7 +3093,6 @@ class LinstorSR(SR):
              )
  
          SR.__init__(self, uuid, xapi, createLock, force)
@@ -2318,7 +2557,7 @@ index f190b1b..51f2912 100755
          self.path = LinstorVolumeManager.DEV_ROOT_PATH
          self._reloadLinstor()
  
-@@ -2982,6 +3010,12 @@ class LinstorSR(SR):
+@@ -2982,6 +3119,12 @@ class LinstorSR(SR):
          self.logFilter.logState()
          self._handleInterruptedCoalesceLeaf()
  
@@ -2331,7 +2570,7 @@ index f190b1b..51f2912 100755
      def _reloadLinstor(self):
          session = self.xapi.session
          host_ref = util.get_this_host_ref(session)
-@@ -2994,12 +3028,13 @@ class LinstorSR(SR):
+@@ -2994,12 +3137,13 @@ class LinstorSR(SR):
          dconf = session.xenapi.PBD.get_device_config(pbd)
          group_name = dconf['group-name']
  
@@ -2347,7 +2586,7 @@ index f190b1b..51f2912 100755
              group_name,
              repair=True,
              logger=util.SMlog
-@@ -3032,8 +3067,8 @@ class LinstorSR(SR):
+@@ -3032,40 +3176,79 @@ class LinstorSR(SR):
  
          # TODO: Ensure metadata contains the right info.
  
@@ -2357,8 +2596,55 @@ index f190b1b..51f2912 100755
 +        volumes_metadata = self._linstor.get_volumes_with_metadata()
          for vdi_uuid, volume_info in all_volume_info.items():
              try:
-                 if not volume_info.name and \
-@@ -3048,7 +3083,7 @@ class LinstorSR(SR):
+-                if not volume_info.name and \
+-                        not list(volumes_metadata[vdi_uuid].items()):
++                volume_metadata = volumes_metadata[vdi_uuid]
++                if not volume_info.name and not list(volume_metadata.items()):
+                     continue  # Ignore it, probably deleted.
+ 
+-                vdi_type = volumes_metadata[vdi_uuid][VDI_TYPE_TAG]
+-                if vdi_type == vhdutil.VDI_TYPE_VHD:
++                if vdi_uuid.startswith('DELETED_'):
++                    # Assume it's really a RAW volume of a failed snap without VHD header/footer.
++                    # We must remove this VDI now without adding it in the VDI list.
++                    # Otherwise `Relinking` calls and other actions can be launched on it.
++                    # We don't want that...
++                    Util.log('Deleting bad VDI {}'.format(vdi_uuid))
++
++                    self.lock()
++                    try:
++                        self._linstor.destroy_volume(vdi_uuid)
++                        try:
++                            self.forgetVDI(vdi_uuid)
++                        except:
++                            pass
++                    except Exception as e:
++                        Util.log('Cannot delete bad VDI: {}'.format(e))
++                    finally:
++                        self.unlock()
++                    continue
++
++                vdi_type = volume_metadata.get(VDI_TYPE_TAG)
++                volume_name = self._linstor.get_volume_name(vdi_uuid)
++                if volume_name.startswith(LINSTOR_PERSISTENT_PREFIX):
++                    # Always RAW!
++                    info = None
++                elif vdi_type == vhdutil.VDI_TYPE_VHD:
+                     info = self._vhdutil.get_vhd_info(vdi_uuid)
+                 else:
+-                    info = None
++                    # Ensure it's not a VHD...
++                    try:
++                        info = self._vhdutil.get_vhd_info(vdi_uuid)
++                    except:
++                        try:
++                            self._vhdutil.force_repair(
++                                self._linstor.get_device_path(vdi_uuid)
++                            )
++                            info = self._vhdutil.get_vhd_info(vdi_uuid)
++                        except:
++                            info = None
++
              except Exception as e:
                  Util.log(
                      ' [VDI {}: failed to load VDI info]: {}'
@@ -2367,18 +2653,37 @@ index f190b1b..51f2912 100755
                  )
                  info = vhdutil.VHDInfo(vdi_uuid)
                  info.error = 1
-@@ -3064,8 +3099,8 @@ class LinstorSR(SR):
-         virtual_size = LinstorVolumeManager.round_up_volume_size(
-             parent.sizeVirt + meta_overhead + bitmap_overhead
-         )
++
+             all_vdi_info[vdi_uuid] = info
++
+         return all_vdi_info
+ 
+-    # TODO: Maybe implement _liveLeafCoalesce/_prepareCoalesceLeaf/
+-    # _finishCoalesceLeaf/_updateSlavesOnResize like LVM plugin.
++    def _prepareCoalesceLeaf(self, vdi):
++        vdi._activateChain()
++        vdi.deflate()
++        vdi._inflateParentForCoalesce()
++
++    def _finishCoalesceLeaf(self, parent):
++        if not parent.isSnapshot() or parent.isAttachedRW():
++            parent.inflateFully()
++        else:
++            parent.deflate()
+ 
+     def _calcExtraSpaceNeeded(self, child, parent):
+-        meta_overhead = vhdutil.calcOverheadEmpty(LinstorVDI.MAX_SIZE)
+-        bitmap_overhead = vhdutil.calcOverheadBitmap(parent.sizeVirt)
+-        virtual_size = LinstorVolumeManager.round_up_volume_size(
+-            parent.sizeVirt + meta_overhead + bitmap_overhead
+-        )
 -        # TODO: Check result.
 -        return virtual_size - self._linstor.get_volume_size(parent.uuid)
-+        volume_size = self._linstor.get_volume_size(parent.uuid)
-+        return virtual_size - volume_size
++        return LinstorVhdUtil.compute_volume_size(parent.sizeVirt, parent.vdi_type) - parent.getDrbdSize()
  
      def _hasValidDevicePath(self, uuid):
          try:
-@@ -3075,6 +3110,21 @@ class LinstorSR(SR):
+@@ -3075,6 +3258,16 @@ class LinstorSR(SR):
              return False
          return True
  
@@ -2392,15 +2697,10 @@ index f190b1b..51f2912 100755
 +        finally:
 +            self.unlock()
 +
-+    def _prepareCoalesceLeaf(self, vdi):
-+        # Move diskless path if necessary. We must have an access
-+        # to modify locally the volume.
-+        self._linstor.get_device_path(vdi.uuid)
-+
      def _handleInterruptedCoalesceLeaf(self):
          entries = self.journaler.get_all(VDI.JRN_LEAF)
          for uuid, parentUuid in entries.items():
-@@ -3101,7 +3151,6 @@ class LinstorSR(SR):
+@@ -3101,7 +3294,6 @@ class LinstorSR(SR):
                  'Renaming parent back: {} -> {}'.format(childUuid, parentUuid)
              )
              parent.rename(parentUuid)
@@ -2408,7 +2708,7 @@ index f190b1b..51f2912 100755
  
          child = self.getVDI(childUuid)
          if not child:
-@@ -3117,9 +3166,6 @@ class LinstorSR(SR):
+@@ -3117,9 +3309,6 @@ class LinstorSR(SR):
              Util.log('Updating the VDI record')
              child.setConfig(VDI.DB_VHD_PARENT, parentUuid)
              child.setConfig(VDI.DB_VDI_TYPE, vhdutil.VDI_TYPE_VHD)
@@ -2418,7 +2718,7 @@ index f190b1b..51f2912 100755
  
          # TODO: Maybe deflate here.
  
-@@ -3128,10 +3174,7 @@ class LinstorSR(SR):
+@@ -3128,10 +3317,7 @@ class LinstorSR(SR):
          if not parent.hidden:
              parent._setHidden(True)
          self._updateSlavesOnUndoLeafCoalesce(parent, child)
@@ -2429,7 +2729,7 @@ index f190b1b..51f2912 100755
  
      def _finishInterruptedCoalesceLeaf(self, childUuid, parentUuid):
          Util.log('*** FINISH LEAF-COALESCE')
-@@ -3144,32 +3187,21 @@ class LinstorSR(SR):
+@@ -3144,32 +3330,21 @@ class LinstorSR(SR):
          except XenAPI.Failure:
              pass
          self._updateSlavesOnResize(vdi)
@@ -2469,7 +2769,7 @@ index f190b1b..51f2912 100755
  
  ################################################################################
  #
-@@ -3465,9 +3497,9 @@ def abort(srUuid, soft=False):
+@@ -3465,9 +3640,9 @@ def abort(srUuid, soft=False):
  
  
  def gc(session, srUuid, inBackground, dryRun=False):
@@ -2483,10 +2783,10 @@ index f190b1b..51f2912 100755
      1. If we are already GC'ing in this SR, return
      2. If we are already coalescing a VDI pair:
 diff --git a/drivers/linstor-manager b/drivers/linstor-manager
-index f7ce180..45201ee 100755
+index f7ce180..6b45875 100755
 --- a/drivers/linstor-manager
 +++ b/drivers/linstor-manager
-@@ -14,32 +14,52 @@
+@@ -14,32 +14,53 @@
  # You should have received a copy of the GNU General Public License
  # along with this program.  If not, see <https://www.gnu.org/licenses/>.
  
@@ -2508,6 +2808,7 @@ index f7ce180..45201ee 100755
 -sys.path.append('/opt/xensource/sm/')
  from linstorjournaler import LinstorJournaler
 -from linstorvolumemanager import LinstorVolumeManager
++from linstorvhdutil import LinstorVhdUtil
 +from linstorvolumemanager import get_controller_uri, get_local_volume_openers, LinstorVolumeManager
  from lock import Lock
  import json
@@ -2526,29 +2827,29 @@ index f7ce180..45201ee 100755
 +DRBD_PORTS = '7000:8000'
 +
 +DRBD_REACTOR_CONF = '/etc/drbd-reactor.d/sm-linstor.toml'
-+
+ 
 +DRBD_REACTOR_CONF_CONTENT = """[[promoter]]
  
+-def get_linstor_uri(session):
+-    return 'linstor://{}'.format(util.get_master_rec(session)['address'])
 +[promoter.resources.xcp-persistent-database]
 +start = [ "var-lib-linstor.service", "linstor-controller.service" ]
 +"""
  
--def get_linstor_uri(session):
--    return 'linstor://{}'.format(util.get_master_rec(session)['address'])
 +DRBD_REACTOR_DEPS = [
 +    '/run/systemd/system/linstor-controller.service.d/reactor.conf',
 +    '/run/systemd/system/var-lib-linstor.service.d/reactor.conf'
 +]
  
- 
 -def update_port(port, open):
 -    fn = 'open' if open else 'close'
++
 +def update_linstor_port(port, open_ports):
 +    fn = 'open' if open_ports else 'close'
      args = (
          FIREWALL_PORT_SCRIPT, fn, str(port), 'tcp'
      )
-@@ -50,28 +70,238 @@ def update_port(port, open):
+@@ -50,28 +71,251 @@ def update_port(port, open):
      raise Exception('Failed to {} port: {} {}'.format(fn, out, err))
  
  
@@ -2755,9 +3056,23 @@ index f7ce180..45201ee 100755
 +    if ret:
 +        raise Exception('Failed to destroy volume: {}'.format(stderr))
 +
++
++def get_ip_addr_of_pif(session, pif_uuid):
++    pif_ref = session.xenapi.PIF.get_by_uuid(pif_uuid)
++    pif = session.xenapi.PIF.get_record(pif_ref)
++
++    if not pif['currently_attached']:
++        raise XenAPIPlugin.Failure('-1', ['PIF is not plugged'])
++
++    ip_addr = pif['IP'] if pif['primary_address_type'].lower() == 'ipv4' else pif['IPv6'].split('/')[0]
++    if ip_addr == '':
++        raise XenAPIPlugin.Failure('-1', ['PIF has no IP'])
++    return ip_addr
++
 +# ------------------------------------------------------------------------------
-+
-+
+ 
+ 
+-def enable(session, args):
 +def prepare_sr(session, args):
 +    try:
 +        LinstorSR.activate_lvm_group(args['groupName'])
@@ -2782,9 +3097,8 @@ index f7ce180..45201ee 100755
 +    except Exception as e:
 +        util.SMlog('linstor-manager:release_sr error: {}'.format(e))
 +    return str(False)
- 
- 
--def enable(session, args):
++
++
 +def update_drbd_reactor(session, args):
      try:
          enabled = distutils.util.strtobool(args['enabled'])
@@ -2800,7 +3114,7 @@ index f7ce180..45201ee 100755
      return str(False)
  
  
-@@ -81,12 +311,12 @@ def attach(session, args):
+@@ -81,12 +325,12 @@ def attach(session, args):
          vdi_uuid = args['vdiUuid']
          group_name = args['groupName']
  
@@ -2816,7 +3130,7 @@ index f7ce180..45201ee 100755
              group_name,
              logger=util.SMlog
          )
-@@ -104,7 +334,7 @@ def detach(session, args):
+@@ -104,7 +348,7 @@ def detach(session, args):
          group_name = args['groupName']
  
          linstor = LinstorVolumeManager(
@@ -2825,7 +3139,7 @@ index f7ce180..45201ee 100755
              group_name,
              logger=util.SMlog
          )
-@@ -115,10 +345,37 @@ def detach(session, args):
+@@ -115,10 +359,37 @@ def detach(session, args):
      return str(False)
  
  
@@ -2864,7 +3178,7 @@ index f7ce180..45201ee 100755
      except Exception as e:
          util.SMlog('linstor-manager:check error: {}'.format(e))
          raise
-@@ -131,7 +388,7 @@ def get_vhd_info(session, args):
+@@ -131,7 +402,7 @@ def get_vhd_info(session, args):
          include_parent = distutils.util.strtobool(args['includeParent'])
  
          linstor = LinstorVolumeManager(
@@ -2873,7 +3187,7 @@ index f7ce180..45201ee 100755
              group_name,
              logger=util.SMlog
          )
-@@ -143,7 +400,7 @@ def get_vhd_info(session, args):
+@@ -143,7 +414,7 @@ def get_vhd_info(session, args):
              )
  
          vhd_info = vhdutil.getVHDInfo(
@@ -2882,7 +3196,7 @@ index f7ce180..45201ee 100755
          )
          return json.dumps(vhd_info.__dict__)
      except Exception as e:
-@@ -166,7 +423,7 @@ def get_parent(session, args):
+@@ -166,7 +437,7 @@ def get_parent(session, args):
          group_name = args['groupName']
  
          linstor = LinstorVolumeManager(
@@ -2891,10 +3205,22 @@ index f7ce180..45201ee 100755
              group_name,
              logger=util.SMlog
          )
-@@ -228,6 +485,37 @@ def get_block_bitmap(session, args):
+@@ -228,6 +499,69 @@ def get_block_bitmap(session, args):
          raise
  
  
++def get_drbd_size(session, args):
++    try:
++        device_path = args['devicePath']
++        (ret, stdout, stderr) = util.doexec(['blockdev', '--getsize64', device_path])
++        if ret == 0:
++            return stdout.strip()
++        raise Exception('Failed to get DRBD size: {}'.format(stderr))
++    except Exception:
++        util.SMlog('linstor-manager:get_drbd_size error: {}'.format(stderr))
++        raise
++
++
 +def set_parent(session, args):
 +    try:
 +        device_path = args['devicePath']
@@ -2926,10 +3252,30 @@ index f7ce180..45201ee 100755
 +        raise
 +
 +
++def deflate(session, args):
++    try:
++        device_path = args['devicePath']
++        new_size = int(args['newSize'])
++        old_size = int(args['oldSize'])
++        zeroize = distutils.util.strtobool(args['zeroize'])
++        group_name = args['groupName']
++
++        linstor = LinstorVolumeManager(
++            get_controller_uri(),
++            group_name,
++            logger=util.SMlog
++        )
++        LinstorVhdUtil(session, linstor).deflate(device_path, new_size, old_size, zeroize)
++        return ''
++    except Exception as e:
++        util.SMlog('linstor-manager:deflate error: {}'.format(e))
++        raise
++
++
  def lock_vdi(session, args):
      lock = None
      try:
-@@ -236,10 +524,13 @@ def lock_vdi(session, args):
+@@ -236,10 +570,13 @@ def lock_vdi(session, args):
          group_name = args['groupName']
          locked = distutils.util.strtobool(args['locked'])
  
@@ -2944,7 +3290,7 @@ index f7ce180..45201ee 100755
              group_name,
              logger=util.SMlog
          )
-@@ -249,16 +540,425 @@ def lock_vdi(session, args):
+@@ -249,16 +586,514 @@ def lock_vdi(session, args):
      except Exception as e:
          util.SMlog('linstor-manager:lock_vdi error: {}'.format(e))
      finally:
@@ -3353,6 +3699,95 @@ index f7ce180..45201ee 100755
 +    return format_result()
 +
 +
++def create_node_interface(session, args):
++    group_name = args['groupName']
++    hostname = args['hostname']
++    name = args['name']
++    pif_uuid = args['pifUuid']
++
++    ip_addr = get_ip_addr_of_pif(session, pif_uuid)
++
++    linstor = LinstorVolumeManager(
++        get_controller_uri(),
++        group_name,
++        logger=util.SMlog
++    )
++    try:
++        linstor.create_node_interface(hostname, name, ip_addr)
++    except Exception as e:
++        raise XenAPIPlugin.Failure('-1', [str(e)])
++    return str(True)
++
++
++def destroy_node_interface(session, args):
++    group_name = args['groupName']
++    hostname = args['hostname']
++    name = args['name']
++
++    linstor = LinstorVolumeManager(
++        get_controller_uri(),
++        group_name,
++        logger=util.SMlog
++    )
++    try:
++        linstor.destroy_node_interface(hostname, name)
++    except Exception as e:
++        raise XenAPIPlugin.Failure('-1', [str(e)])
++    return str(True)
++
++
++def modify_node_interface(session, args):
++    group_name = args['groupName']
++    hostname = args['hostname']
++    name = args['name']
++    pif_uuid = args['pifUuid']
++
++    ip_addr = get_ip_addr_of_pif(session, pif_uuid)
++
++    linstor = LinstorVolumeManager(
++        get_controller_uri(),
++        group_name,
++        logger=util.SMlog
++    )
++    try:
++        linstor.modify_node_interface(hostname, name, ip_addr)
++    except Exception as e:
++        raise XenAPIPlugin.Failure('-1', [str(e)])
++    return str(True)
++
++
++def list_node_interfaces(session, args):
++    group_name = args['groupName']
++    hostname = args['hostname']
++
++    linstor = LinstorVolumeManager(
++        get_controller_uri(),
++        group_name,
++        logger=util.SMlog
++    )
++    try:
++        return json.dumps(linstor.list_node_interfaces(hostname))
++    except Exception as e:
++        raise XenAPIPlugin.Failure('-1', [str(e)])
++
++
++def set_node_preferred_interface(session, args):
++    group_name = args['groupName']
++    hostname = args['hostname']
++    name = args['name']
++
++    linstor = LinstorVolumeManager(
++        get_controller_uri(),
++        group_name,
++        logger=util.SMlog
++    )
++    try:
++        linstor.set_node_preferred_interface(hostname, name)
++    except Exception as e:
++        raise XenAPIPlugin.Failure('-1', [str(e)])
++    return str(True)
++
++
  if __name__ == '__main__':
      XenAPIPlugin.dispatch({
 -        'enable': enable,
@@ -3372,17 +3807,23 @@ index f7ce180..45201ee 100755
          'check': check,
          'getVHDInfo': get_vhd_info,
          'hasParent': has_parent,
-@@ -268,5 +968,22 @@ if __name__ == '__main__':
+@@ -268,5 +1103,34 @@ if __name__ == '__main__':
          'getDepth': get_depth,
          'getKeyHash': get_key_hash,
          'getBlockBitmap': get_block_bitmap,
 -        'lockVdi': lock_vdi
++
++        # Small helper to get the DRBD blockdev size.
++        'getDrbdSize': get_drbd_size,
 +
 +        # Called by cleanup.py to coalesce when a primary
 +        # is opened on a non-local host.
 +        'setParent': set_parent,
 +        'coalesce': coalesce,
 +        'repair': repair,
++
++        # Misc writters.
++        'deflate': deflate,
 +
 +        'lockVdi': lock_vdi,
 +        'hasControllerRunning': has_controller_running,
@@ -3394,7 +3835,13 @@ index f7ce180..45201ee 100755
 +        'destroyDrbdVolume': destroy_drbd_volume,
 +        'destroyDrbdVolumes': destroy_drbd_volumes,
 +        'getDrbdOpeners': get_drbd_openers,
-+        'healthCheck': health_check
++        'healthCheck': health_check,
++
++        'createNodeInterface': create_node_interface,
++        'destroyNodeInterface': destroy_node_interface,
++        'modifyNodeInterface': modify_node_interface,
++        'listNodeInterfaces': list_node_interfaces,
++        'setNodePreferredInterface': set_node_preferred_interface
      })
 diff --git a/drivers/linstorjournaler.py b/drivers/linstorjournaler.py
 index bc7cff7..a61d9f1 100755
@@ -3478,10 +3925,19 @@ index bc7cff7..a61d9f1 100755
      def _get_key(type, identifier):
          return '{}/{}'.format(type, identifier)
 diff --git a/drivers/linstorvhdutil.py b/drivers/linstorvhdutil.py
-index 7a13566..83d7f8b 100644
+index 7a13566..494b4b0 100644
 --- a/drivers/linstorvhdutil.py
 +++ b/drivers/linstorvhdutil.py
-@@ -25,9 +25,46 @@ import xs_errors
+@@ -14,6 +14,8 @@
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
++from linstorjournaler import LinstorJournaler
++from linstorvolumemanager import LinstorVolumeManager
+ import base64
+ import distutils.util
+ import errno
+@@ -25,9 +27,46 @@ import xs_errors
  
  MANAGER_PLUGIN = 'linstor-manager'
  
@@ -3489,7 +3945,7 @@ index 7a13566..83d7f8b 100644
 +EMEDIUMTYPE = 124
 +
 +
-+def call_vhd_util_on_host(session, host_ref, method, device_path, args):
++def call_remote_method(session, host_ref, method, device_path, args):
 +    try:
 +        response = session.xenapi.host.call_plugin(
 +            host_ref, MANAGER_PLUGIN, method, args
@@ -3498,7 +3954,7 @@ index 7a13566..83d7f8b 100644
 +        util.SMlog('call-plugin ({} with {}) exception: {}'.format(
 +            method, args, e
 +        ))
-+        raise
++        raise util.SMException(str(e))
 +
 +    util.SMlog('call-plugin ({} with {}) returned: {}'.format(
 +        method, args, response
@@ -3507,7 +3963,7 @@ index 7a13566..83d7f8b 100644
 +    return response
 +
 +
-+class LinstorCallException(Exception):
++class LinstorCallException(util.SMException):
 +    def __init__(self, cmd_err):
 +        self.cmd_err = cmd_err
 +
@@ -3529,7 +3985,7 @@ index 7a13566..83d7f8b 100644
          def wrapper(*args, **kwargs):
              self = args[0]
              vdi_uuid = args[1]
-@@ -41,50 +78,56 @@ def linstorhostcall(local_method, remote_method):
+@@ -41,70 +80,94 @@ def linstorhostcall(local_method, remote_method):
  
              # Try to read locally if the device is not in use or if the device
              # is up to date and not diskless.
@@ -3547,7 +4003,7 @@ index 7a13566..83d7f8b 100644
 -                if e.code != errno.EROFS and e.code != 124:
 -                    raise
 +                if not in_use_by or socket.gethostname() in node_names:
-+                    return self._call_local_vhd_util(local_method, device_path, *args[2:], **kwargs)
++                    return self._call_local_method(local_method, device_path, *args[2:], **kwargs)
 +            except ErofsLinstorCallException as e:
 +                local_e = e.cmd_err
 +            except Exception as e:
@@ -3604,7 +4060,7 @@ index 7a13566..83d7f8b 100644
 +            try:
 +                def remote_call():
 +                    host_ref = self._get_readonly_host(vdi_uuid, device_path, node_names)
-+                    return call_vhd_util_on_host(self._session, host_ref, remote_method, device_path, remote_args)
++                    return call_remote_method(self._session, host_ref, remote_method, device_path, remote_args)
 +                response = util.retry(remote_call, 5, 2)
 +            except Exception as remote_e:
 +                self._raise_openers_exception(device_path, local_e or remote_e)
@@ -3625,7 +4081,11 @@ index 7a13566..83d7f8b 100644
          return wrapper
      return decorated
  
-@@ -94,17 +137,33 @@ class LinstorVhdUtil:
+ 
+ class LinstorVhdUtil:
++    MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024  # Max VHD size.
++
+     def __init__(self, session, linstor):
          self._session = session
          self._linstor = linstor
  
@@ -3665,7 +4125,7 @@ index 7a13566..83d7f8b 100644
  
          vhd_info = vhdutil.VHDInfo(vdi_uuid)
          vhd_info.sizeVirt = obj['sizeVirt']
-@@ -118,35 +177,91 @@ class LinstorVhdUtil:
+@@ -118,35 +181,180 @@ class LinstorVhdUtil:
          return vhd_info
  
      @linstorhostcall(vhdutil.hasParent, 'hasParent')
@@ -3713,41 +4173,101 @@ index 7a13566..83d7f8b 100644
 +    def get_block_bitmap(self, vdi_uuid, response):
 +        return base64.b64decode(response)
 +
++    @linstorhostcall('_get_drbd_size', 'getDrbdSize')
++    def get_drbd_size(self, vdi_uuid, response):
++        return int(response)
++
++    def _get_drbd_size(self, path):
++        (ret, stdout, stderr) = util.doexec(['blockdev', '--getsize64', path])
++        if ret == 0:
++            return int(stdout.strip())
++        raise util.SMException('Failed to get DRBD size: {}'.format(stderr))
++
 +    # --------------------------------------------------------------------------
 +    # Setters: only used locally.
 +    # --------------------------------------------------------------------------
 +
 +    @linstormodifier()
 +    def create(self, path, size, static, msize=0):
-+        return self._call_local_vhd_util_or_fail(vhdutil.create, path, size, static, msize)
++        return self._call_local_method_or_fail(vhdutil.create, path, size, static, msize)
++
++    @linstormodifier()
++    def set_size_virt(self, path, size, jfile):
++        return self._call_local_method_or_fail(vhdutil.setSizeVirt, path, size, jfile)
 +
 +    @linstormodifier()
 +    def set_size_virt_fast(self, path, size):
-+        return self._call_local_vhd_util_or_fail(vhdutil.setSizeVirtFast, path, size)
++        return self._call_local_method_or_fail(vhdutil.setSizeVirtFast, path, size)
 +
 +    @linstormodifier()
 +    def set_size_phys(self, path, size, debug=True):
-+        return self._call_local_vhd_util_or_fail(vhdutil.setSizePhys, path, size, debug)
++        return self._call_local_method_or_fail(vhdutil.setSizePhys, path, size, debug)
 +
 +    @linstormodifier()
 +    def set_parent(self, path, parentPath, parentRaw=False):
-+        return self._call_local_vhd_util_or_fail(vhdutil.setParent, path, parentPath, parentRaw)
++        return self._call_local_method_or_fail(vhdutil.setParent, path, parentPath, parentRaw)
 +
 +    @linstormodifier()
 +    def set_hidden(self, path, hidden=True):
-+        return self._call_local_vhd_util_or_fail(vhdutil.setHidden, path, hidden)
++        return self._call_local_method_or_fail(vhdutil.setHidden, path, hidden)
 +
 +    @linstormodifier()
 +    def set_key(self, path, key_hash):
-+        return self._call_local_vhd_util_or_fail(vhdutil.setKey, path, key_hash)
++        return self._call_local_method_or_fail(vhdutil.setKey, path, key_hash)
 +
 +    @linstormodifier()
 +    def kill_data(self, path):
-+        return self._call_local_vhd_util_or_fail(vhdutil.killData, path)
++        return self._call_local_method_or_fail(vhdutil.killData, path)
 +
 +    @linstormodifier()
 +    def snapshot(self, path, parent, parentRaw, msize=0, checkEmpty=True):
-+        return self._call_local_vhd_util_or_fail(vhdutil.snapshot, path, parent, parentRaw, msize, checkEmpty)
++        return self._call_local_method_or_fail(vhdutil.snapshot, path, parent, parentRaw, msize, checkEmpty)
++
++    def inflate(self, journaler, vdi_uuid, vdi_path, new_size, old_size):
++        # Only inflate if the LINSTOR volume capacity is not enough.
++        new_size = LinstorVolumeManager.round_up_volume_size(new_size)
++        if new_size <= old_size:
++            return
++
++        util.SMlog(
++            'Inflate {} (size={}, previous={})'
++            .format(vdi_path, new_size, old_size)
++        )
++
++        journaler.create(
++            LinstorJournaler.INFLATE, vdi_uuid, old_size
++        )
++        self._linstor.resize_volume(vdi_uuid, new_size)
++
++        # TODO: Replace pylint comment with this feature when possible:
++        # https://github.com/PyCQA/pylint/pull/2926
++        result_size = self.get_drbd_size(vdi_uuid)  # pylint: disable = E1120
++        if result_size < new_size:
++            util.SMlog(
++                'WARNING: Cannot inflate volume to {}B, result size: {}B'
++                .format(new_size, result_size)
++            )
++
++        self._zeroize(vdi_path, result_size - vhdutil.VHD_FOOTER_SIZE)
++        self.set_size_phys(vdi_path, result_size, False)
++        journaler.remove(LinstorJournaler.INFLATE, vdi_uuid)
++
++    def deflate(self, vdi_path, new_size, old_size, zeroize=False):
++        if zeroize:
++            assert old_size > vhdutil.VHD_FOOTER_SIZE
++            self._zeroize(vdi_path, old_size - vhdutil.VHD_FOOTER_SIZE)
++
++        new_size = LinstorVolumeManager.round_up_volume_size(new_size)
++        if new_size >= old_size:
++            return
++
++        util.SMlog(
++            'Deflate {} (new size={}, previous={})'
++            .format(vdi_path, new_size, old_size)
++        )
++
++        self.set_size_phys(vdi_path, new_size)
++        # TODO: Change the LINSTOR volume size using linstor.resize_volume.
 +
 +    # --------------------------------------------------------------------------
 +    # Remote setters: write locally and try on another host in case of failure.
@@ -3759,19 +4279,48 @@ index 7a13566..83d7f8b 100644
 +            'parentPath': str(parentPath),
 +            'parentRaw': parentRaw
 +        }
-+        return self._call_vhd_util(vhdutil.setParent, 'setParent', path, use_parent=False, **kwargs)
++        return self._call_method(vhdutil.setParent, 'setParent', path, use_parent=False, **kwargs)
 +
 +    @linstormodifier()
 +    def force_coalesce(self, path):
-+        return self._call_vhd_util(vhdutil.coalesce, 'coalesce', path, use_parent=True)
++        return self._call_method(vhdutil.coalesce, 'coalesce', path, use_parent=True)
 +
 +    @linstormodifier()
 +    def force_repair(self, path):
-+        return self._call_vhd_util(vhdutil.repair, 'repair', path, use_parent=False)
++        return self._call_method(vhdutil.repair, 'repair', path, use_parent=False)
++
++    @linstormodifier()
++    def force_deflate(self, path, newSize, oldSize, zeroize):
++        kwargs = {
++            'newSize': newSize,
++            'oldSize': oldSize,
++            'zeroize': zeroize
++        }
++        return self._call_method('_force_deflate', 'deflate', path, use_parent=False, **kwargs)
++
++    def _force_deflate(self, path, newSize, oldSize, zeroize):
++        self.deflate(path, newSize, oldSize, zeroize)
++
++    # --------------------------------------------------------------------------
++    # Static helpers.
++    # --------------------------------------------------------------------------
++
++    @classmethod
++    def compute_volume_size(cls, virtual_size, image_type):
++        if image_type == vhdutil.VDI_TYPE_VHD:
++            # All LINSTOR VDIs have the metadata area preallocated for
++            # the maximum possible virtual size (for fast online VDI.resize).
++            meta_overhead = vhdutil.calcOverheadEmpty(cls.MAX_SIZE)
++            bitmap_overhead = vhdutil.calcOverheadBitmap(virtual_size)
++            virtual_size += meta_overhead + bitmap_overhead
++        elif image_type != vhdutil.VDI_TYPE_RAW:
++            raise Exception('Invalid image type: {}'.format(image_type))
++
++        return LinstorVolumeManager.round_up_volume_size(virtual_size)
  
      # --------------------------------------------------------------------------
      # Helpers.
-@@ -161,7 +276,7 @@ class LinstorVhdUtil:
+@@ -161,7 +369,7 @@ class LinstorVhdUtil:
      def _get_readonly_host(self, vdi_uuid, device_path, node_names):
          """
          When vhd-util is called to fetch VDI info we must find a
@@ -3780,7 +4329,7 @@ index 7a13566..83d7f8b 100644
          Why? Because when a VHD is open in RO mode, the LVM layer is used
          directly to bypass DRBD verifications (we can have only one process
          that reads/writes to disk with DRBD devices).
-@@ -170,7 +285,7 @@ class LinstorVhdUtil:
+@@ -170,7 +378,7 @@ class LinstorVhdUtil:
          if not node_names:
              raise xs_errors.XenError(
                  'VDIUnavailable',
@@ -3789,7 +4338,7 @@ index 7a13566..83d7f8b 100644
                  .format(vdi_uuid, device_path)
              )
  
-@@ -184,3 +299,134 @@ class LinstorVhdUtil:
+@@ -184,3 +392,147 @@ class LinstorVhdUtil:
              opterr='Unable to find a valid host from VDI: {} (path={})'
              .format(vdi_uuid, device_path)
          )
@@ -3802,7 +4351,6 @@ index 7a13566..83d7f8b 100644
 +        else:
 +            e_str = str(e)
 +
-+        e_with_openers = None
 +        try:
 +            volume_uuid = self._linstor.get_volume_uuid_from_device_path(
 +                device_path
@@ -3819,7 +4367,10 @@ index 7a13566..83d7f8b 100644
 +        util.SMlog('raise opener exception: {}'.format(e_wrapper))
 +        raise e_wrapper  # pylint: disable = E0702
 +
-+    def _call_local_vhd_util(self, local_method, device_path, *args, **kwargs):
++    def _call_local_method(self, local_method, device_path, *args, **kwargs):
++        if isinstance(local_method, str):
++            local_method = getattr(self, local_method)
++
 +        try:
 +            def local_call():
 +                try:
@@ -3836,22 +4387,25 @@ index 7a13566..83d7f8b 100644
 +            util.SMlog('failed to execute locally vhd-util (sys {})'.format(e.code))
 +            raise e
 +
-+    def _call_local_vhd_util_or_fail(self, local_method, device_path, *args, **kwargs):
++    def _call_local_method_or_fail(self, local_method, device_path, *args, **kwargs):
 +        try:
-+            return self._call_local_vhd_util(local_method, device_path, *args, **kwargs)
++            return self._call_local_method(local_method, device_path, *args, **kwargs)
 +        except ErofsLinstorCallException as e:
 +            # Volume is locked on a host, find openers.
 +            self._raise_openers_exception(device_path, e.cmd_err)
 +
-+    def _call_vhd_util(self, local_method, remote_method, device_path, use_parent, *args, **kwargs):
++    def _call_method(self, local_method, remote_method, device_path, use_parent, *args, **kwargs):
 +        # Note: `use_parent` exists to know if the VHD parent is used by the local/remote method.
 +        # Normally in case of failure, if the parent is unused we try to execute the method on
 +        # another host using the DRBD opener list. In the other case, if the parent is required,
 +        # we must check where this last one is open instead of the child.
 +
++        if isinstance(local_method, str):
++            local_method = getattr(self, local_method)
++
 +        # A. Try to write locally...
 +        try:
-+            return self._call_local_vhd_util(local_method, device_path, *args, **kwargs)
++            return self._call_local_method(local_method, device_path, *args, **kwargs)
 +        except Exception:
 +            pass
 +
@@ -3908,7 +4462,7 @@ index 7a13566..83d7f8b 100644
 +
 +                no_host_found = False
 +                try:
-+                    return call_vhd_util_on_host(self._session, host_ref, remote_method, device_path, remote_args)
++                    return call_remote_method(self._session, host_ref, remote_method, device_path, remote_args)
 +                except Exception:
 +                    pass
 +
@@ -3920,15 +4474,23 @@ index 7a13566..83d7f8b 100644
 +
 +            raise xs_errors.XenError(
 +                'VDIUnavailable',
-+                opterr='No valid host found to run vhd-util command `{}` (path=`{}`, openers=`{}`): {}'
-+                .format(remote_method, device_path, openers, e)
++                opterr='No valid host found to run vhd-util command `{}` (path=`{}`, openers=`{}`)'
++                .format(remote_method, device_path, openers)
 +            )
 +        return util.retry(remote_call, 5, 2)
++
++    @staticmethod
++    def _zeroize(path, size):
++        if not util.zeroOut(path, size, vhdutil.VHD_FOOTER_SIZE):
++            raise xs_errors.XenError(
++                'EIO',
++                opterr='Failed to zero out VHD footer {}'.format(path)
++            )
 diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
-index 182b889..a9f39e0 100755
+index 182b889..92fd028 100755
 --- a/drivers/linstorvolumemanager.py
 +++ b/drivers/linstorvolumemanager.py
-@@ -16,15 +16,103 @@
+@@ -16,14 +16,104 @@
  #
  
  
@@ -3946,9 +4508,11 @@ index 182b889..a9f39e0 100755
  import util
 +import uuid
  
- 
++# Persistent prefix to add to RAW persistent volumes.
++PERSISTENT_PREFIX = 'xcp-persistent-'
++
 +# Contains the data of the "/var/lib/linstor" directory.
-+DATABASE_VOLUME_NAME = 'xcp-persistent-database'
++DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 +DATABASE_SIZE = 1 << 30  # 1GB.
 +DATABASE_PATH = '/var/lib/linstor'
 +DATABASE_MKFS = 'mkfs.ext4'
@@ -4028,11 +4592,10 @@ index 182b889..a9f39e0 100755
 +
 +
 +# ==============================================================================
-+
+ 
  def round_up(value, divisor):
      assert divisor
-     divisor = int(divisor)
-@@ -37,6 +125,148 @@ def round_down(value, divisor):
+@@ -37,6 +127,148 @@ def round_down(value, divisor):
      return value - (value % int(divisor))
  
  
@@ -4181,7 +4744,7 @@ index 182b889..a9f39e0 100755
  class LinstorVolumeManagerError(Exception):
      ERR_GENERIC = 0,
      ERR_VOLUME_EXISTS = 1,
-@@ -50,6 +280,7 @@ class LinstorVolumeManagerError(Exception):
+@@ -50,6 +282,7 @@ class LinstorVolumeManagerError(Exception):
      def code(self):
          return self._code
  
@@ -4189,7 +4752,7 @@ index 182b889..a9f39e0 100755
  # ==============================================================================
  
  # Note:
-@@ -63,7 +294,17 @@ class LinstorVolumeManager(object):
+@@ -63,7 +296,17 @@ class LinstorVolumeManager(object):
      A volume in this context is a physical part of the storage layer.
      """
  
@@ -4208,7 +4771,7 @@ index 182b889..a9f39e0 100755
  
      # Default LVM extent size.
      BLOCK_SIZE = 4 * 1024 * 1024
-@@ -90,7 +331,7 @@ class LinstorVolumeManager(object):
+@@ -90,7 +333,7 @@ class LinstorVolumeManager(object):
  
      # Property namespaces.
      NAMESPACE_SR = 'xcp/sr'
@@ -4217,7 +4780,7 @@ index 182b889..a9f39e0 100755
  
      # Regex to match properties.
      REG_PROP = '^([^/]+)/{}$'
-@@ -106,6 +347,10 @@ class LinstorVolumeManager(object):
+@@ -106,6 +349,10 @@ class LinstorVolumeManager(object):
      PREFIX_SR = 'xcp-sr-'
      PREFIX_VOLUME = 'xcp-volume-'
  
@@ -4228,7 +4791,7 @@ index 182b889..a9f39e0 100755
      @staticmethod
      def default_logger(*args):
          print(args)
-@@ -117,38 +362,43 @@ class LinstorVolumeManager(object):
+@@ -117,38 +364,43 @@ class LinstorVolumeManager(object):
      class VolumeInfo(object):
          __slots__ = (
              'name',
@@ -4283,7 +4846,7 @@ index 182b889..a9f39e0 100755
          self._base_group_name = group_name
  
          # Ensure group exists.
-@@ -164,6 +414,16 @@ class LinstorVolumeManager(object):
+@@ -164,6 +416,16 @@ class LinstorVolumeManager(object):
          self._logger = logger
          self._redundancy = groups[0].select_filter.place_count
          self._group_name = group_name
@@ -4300,7 +4863,7 @@ index 182b889..a9f39e0 100755
          self._build_volumes(repair=repair)
  
      @property
-@@ -175,6 +435,15 @@ class LinstorVolumeManager(object):
+@@ -175,6 +437,15 @@ class LinstorVolumeManager(object):
          """
          return self._base_group_name
  
@@ -4316,7 +4879,7 @@ index 182b889..a9f39e0 100755
      @property
      def volumes(self):
          """
-@@ -184,66 +453,6 @@ class LinstorVolumeManager(object):
+@@ -184,66 +455,6 @@ class LinstorVolumeManager(object):
          """
          return self._volumes
  
@@ -4383,7 +4946,7 @@ index 182b889..a9f39e0 100755
      @property
      def max_volume_size_allowed(self):
          """
-@@ -284,26 +493,67 @@ class LinstorVolumeManager(object):
+@@ -284,26 +495,67 @@ class LinstorVolumeManager(object):
          return self._compute_size('free_capacity')
  
      @property
@@ -4465,7 +5028,7 @@ index 182b889..a9f39e0 100755
  
      @property
      def metadata(self):
-@@ -346,12 +596,8 @@ class LinstorVolumeManager(object):
+@@ -346,12 +598,8 @@ class LinstorVolumeManager(object):
          :rtype: set(str)
          """
  
@@ -4479,14 +5042,13 @@ index 182b889..a9f39e0 100755
              for report in pool.reports:
                  if report.ret_code & linstor.consts.WARN_NOT_CONNECTED == \
                          linstor.consts.WARN_NOT_CONNECTED:
-@@ -367,23 +613,33 @@ class LinstorVolumeManager(object):
+@@ -367,23 +615,29 @@ class LinstorVolumeManager(object):
          """
          return volume_uuid in self._volumes
  
 -    def create_volume(self, volume_uuid, size, persistent=True):
 +    def create_volume(
-+        self, volume_uuid, size, persistent=True, volume_name=None,
-+        no_diskless=False
++        self, volume_uuid, size, persistent=True, volume_name=None
 +    ):
          """
          Create a new volume on the SR.
@@ -4496,8 +5058,6 @@ index 182b889..a9f39e0 100755
          on the next constructor call LinstorSR(...).
 +        :param str volume_name: If set, this name is used in the LINSTOR
 +        database instead of a generated name.
-+        :param bool no_diskless: If set, the default group redundancy is not
-+        used, instead the volume is created on all nodes.
          :return: The current device path of the volume.
          :rtype: str
          """
@@ -4507,16 +5067,14 @@ index 182b889..a9f39e0 100755
 +        if not volume_name:
 +            volume_name = self.build_volume_name(util.gen_uuid())
          volume_properties = self._create_volume_with_properties(
--            volume_uuid, volume_name, size, place_resources=True
-+            volume_uuid, volume_name, size, place_resources=True,
-+            no_diskless=no_diskless
+             volume_uuid, volume_name, size, place_resources=True
          )
  
 +        # Volume created! Now try to find the device path.
          try:
              self._logger(
                  'Find device path of LINSTOR volume {}...'.format(volume_uuid)
-@@ -396,8 +652,10 @@ class LinstorVolumeManager(object):
+@@ -396,8 +650,10 @@ class LinstorVolumeManager(object):
                  'LINSTOR volume {} created!'.format(volume_uuid)
              )
              return device_path
@@ -4529,7 +5087,7 @@ index 182b889..a9f39e0 100755
              raise
  
      def mark_volume_as_persistent(self, volume_uuid):
-@@ -426,7 +684,7 @@ class LinstorVolumeManager(object):
+@@ -426,7 +682,7 @@ class LinstorVolumeManager(object):
          volume_properties[self.PROP_NOT_EXISTS] = self.STATE_NOT_EXISTS
  
          self._volumes.remove(volume_uuid)
@@ -4538,7 +5096,7 @@ index 182b889..a9f39e0 100755
  
      def lock_volume(self, volume_uuid, locked=True):
          """
-@@ -476,12 +734,15 @@ class LinstorVolumeManager(object):
+@@ -476,12 +732,15 @@ class LinstorVolumeManager(object):
  
          waiting = False
  
@@ -4555,7 +5113,7 @@ index 182b889..a9f39e0 100755
                  timestamp = volume_properties.get(
                      self.PROP_IS_READONLY_TIMESTAMP
                  )
-@@ -519,6 +780,7 @@ class LinstorVolumeManager(object):
+@@ -519,10 +778,33 @@ class LinstorVolumeManager(object):
              # We must wait to use the volume. After that we can modify it
              # ONLY if the SR is locked to avoid bad reads on the slaves.
              time.sleep(1)
@@ -4563,7 +5121,33 @@ index 182b889..a9f39e0 100755
  
          if waiting:
              self._logger('No volume locked now!')
-@@ -542,6 +804,9 @@ class LinstorVolumeManager(object):
+ 
++    def remove_volume_if_diskless(self, volume_uuid):
++        """
++        Remove disless path from local node.
++        :param str volume_uuid: The volume uuid to remove.
++        """
++
++        self._ensure_volume_exists(volume_uuid)
++
++        volume_properties = self._get_volume_properties(volume_uuid)
++        volume_name = volume_properties.get(self.PROP_VOLUME_NAME)
++
++        node_name = socket.gethostname()
++        result = self._linstor.resource_delete_if_diskless(
++            node_name=node_name, rsc_name=volume_name
++        )
++        if not linstor.Linstor.all_api_responses_no_error(result):
++            raise LinstorVolumeManagerError(
++                'Unable to delete diskless path of `{}` on node `{}`: {}'
++                .format(volume_name, node_name, ', '.join(
++                    [str(x) for x in result]))
++                )
++
+     def introduce_volume(self, volume_uuid):
+         pass  # TODO: Implement me.
+ 
+@@ -542,6 +824,9 @@ class LinstorVolumeManager(object):
              volume_nr=0,
              size=new_size // 1024
          )
@@ -4573,11 +5157,10 @@ index 182b889..a9f39e0 100755
          error_str = self._get_error_str(result)
          if error_str:
              raise LinstorVolumeManagerError(
-@@ -587,6 +852,25 @@ class LinstorVolumeManager(object):
+@@ -587,6 +872,24 @@ class LinstorVolumeManager(object):
              )
          return size * 1024
  
-+
 +    def set_auto_promote_timeout(self, volume_uuid, timeout):
 +        """
 +        Define the blocking time of open calls when a DRBD
@@ -4599,7 +5182,7 @@ index 182b889..a9f39e0 100755
      def get_volume_info(self, volume_uuid):
          """
          Get the volume info of a particular volume.
-@@ -596,7 +880,7 @@ class LinstorVolumeManager(object):
+@@ -596,11 +899,11 @@ class LinstorVolumeManager(object):
          """
  
          volume_name = self.get_volume_name(volume_uuid)
@@ -4608,7 +5191,12 @@ index 182b889..a9f39e0 100755
  
      def get_device_path(self, volume_uuid):
          """
-@@ -620,7 +904,7 @@ class LinstorVolumeManager(object):
+-        Get the dev path of a volume.
++        Get the dev path of a volume, create a diskless if necessary.
+         :param str volume_uuid: The volume uuid to get the dev path.
+         :return: The current device path of the volume.
+         :rtype: str
+@@ -620,7 +923,7 @@ class LinstorVolumeManager(object):
          expected_volume_name = \
              self.get_volume_name_from_device_path(device_path)
  
@@ -4617,7 +5205,7 @@ index 182b889..a9f39e0 100755
          for volume_uuid, volume_name in volume_names.items():
              if volume_name == expected_volume_name:
                  return volume_uuid
-@@ -631,26 +915,24 @@ class LinstorVolumeManager(object):
+@@ -631,26 +934,24 @@ class LinstorVolumeManager(object):
  
      def get_volume_name_from_device_path(self, device_path):
          """
@@ -4657,7 +5245,7 @@ index 182b889..a9f39e0 100755
  
      def update_volume_uuid(self, volume_uuid, new_volume_uuid, force=False):
          """
-@@ -664,6 +946,8 @@ class LinstorVolumeManager(object):
+@@ -664,6 +965,8 @@ class LinstorVolumeManager(object):
          deleted VDI.
          """
  
@@ -4666,7 +5254,7 @@ index 182b889..a9f39e0 100755
          self._logger(
              'Trying to update volume UUID {} to {}...'
              .format(volume_uuid, new_volume_uuid)
-@@ -685,36 +969,45 @@ class LinstorVolumeManager(object):
+@@ -685,36 +988,45 @@ class LinstorVolumeManager(object):
                  .format(volume_uuid)
              )
  
@@ -4728,7 +5316,7 @@ index 182b889..a9f39e0 100755
              except Exception as e:
                  self._logger(
                      'Failed to clear new volume properties: {} (ignoring...)'
-@@ -725,11 +1018,21 @@ class LinstorVolumeManager(object):
+@@ -725,11 +1037,21 @@ class LinstorVolumeManager(object):
              )
  
          try:
@@ -4752,7 +5340,7 @@ index 182b889..a9f39e0 100755
          except Exception as e:
              raise LinstorVolumeManagerError(
                  'Failed to clear volume properties '
-@@ -743,7 +1046,7 @@ class LinstorVolumeManager(object):
+@@ -743,7 +1065,7 @@ class LinstorVolumeManager(object):
              'UUID update succeeded of {} to {}! (properties={})'
              .format(
                  volume_uuid, new_volume_uuid,
@@ -4761,7 +5349,7 @@ index 182b889..a9f39e0 100755
              )
          )
  
-@@ -788,6 +1091,73 @@ class LinstorVolumeManager(object):
+@@ -788,6 +1110,72 @@ class LinstorVolumeManager(object):
  
          return states
  
@@ -4773,7 +5361,6 @@ index 182b889..a9f39e0 100755
 +        :rtype: dict(str, obj)
 +        """
 +        return get_all_volume_openers(self.get_volume_name(volume_uuid), '0')
-+
 +
 +    def get_volumes_with_name(self):
 +        """
@@ -4835,7 +5422,7 @@ index 182b889..a9f39e0 100755
      def get_volume_metadata(self, volume_uuid):
          """
          Get the metadata of a volume.
-@@ -910,17 +1280,11 @@ class LinstorVolumeManager(object):
+@@ -910,17 +1298,11 @@ class LinstorVolumeManager(object):
                  rsc_name=clone_volume_name,
                  storage_pool=self._group_name
              ))
@@ -4855,7 +5442,7 @@ index 182b889..a9f39e0 100755
              except Exception as e:
                  self._logger(
                      'Unable to destroy volume {} after shallow clone fail: {}'
-@@ -928,12 +1292,16 @@ class LinstorVolumeManager(object):
+@@ -928,12 +1310,15 @@ class LinstorVolumeManager(object):
                  )
  
          def create():
@@ -4867,8 +5454,7 @@ index 182b889..a9f39e0 100755
 +            # Note: placed outside try/except block because we create only definition first.
 +            # There is no reason to call `clean` before the real resource creation.
 +            volume_properties = self._create_volume_with_properties(
-+                clone_uuid, clone_volume_name, size,
-+                place_resources=False
++                clone_uuid, clone_volume_name, size, place_resources=False
 +            )
  
 +            # After this point, `clean` can be called for any fail because the clone UUID
@@ -4877,7 +5463,7 @@ index 182b889..a9f39e0 100755
                  result = self._linstor.resource_create(resources)
                  error_str = self._get_error_str(result)
                  if error_str:
-@@ -946,7 +1314,7 @@ class LinstorVolumeManager(object):
+@@ -946,7 +1331,7 @@ class LinstorVolumeManager(object):
                      )
                  return volume_properties
              except Exception:
@@ -4886,7 +5472,7 @@ index 182b889..a9f39e0 100755
                  raise
  
          # Retry because we can get errors like this:
-@@ -962,7 +1330,7 @@ class LinstorVolumeManager(object):
+@@ -962,7 +1347,7 @@ class LinstorVolumeManager(object):
              self._volumes.add(clone_uuid)
              return device_path
          except Exception as e:
@@ -4895,7 +5481,7 @@ index 182b889..a9f39e0 100755
              raise
  
      def remove_resourceless_volumes(self):
-@@ -974,83 +1342,337 @@ class LinstorVolumeManager(object):
+@@ -974,83 +1359,461 @@ class LinstorVolumeManager(object):
          """
  
          resource_names = self._fetch_resource_names()
@@ -4915,38 +5501,67 @@ index 182b889..a9f39e0 100755
 -        if (force):
 -            for volume_uuid in self._volumes:
 -                self.destroy_volume(volume_uuid)
+-
+-        # TODO: Throw exceptions in the helpers below if necessary.
+-        # TODO: What's the required action if it exists remaining volumes?
++        # 1. Ensure volume list is empty. No cost.
 +        if self._volumes:
 +            raise LinstorVolumeManagerError(
 +                'Cannot destroy LINSTOR volume manager: '
 +                'It exists remaining volumes'
 +            )
 +
++        # 2. Fetch ALL resource names.
++        # This list may therefore contain volumes created outside
++        # the scope of the driver.
++        resource_names = self._fetch_resource_names(ignore_deleted=False)
++        try:
++            resource_names.remove(DATABASE_VOLUME_NAME)
++        except KeyError:
++            # Really strange to reach that point.
++            # Normally we always have the database volume in the list.
++            pass
++
++        # 3. Ensure the resource name list is entirely empty...
++        if resource_names:
++            raise LinstorVolumeManagerError(
++                'Cannot destroy LINSTOR volume manager: '
++                'It exists remaining volumes (created externally or being deleted)'
++            )
++
++        # 4. Destroying...
 +        controller_is_running = self._controller_is_running()
 +        uri = 'linstor://localhost'
 +        try:
 +            if controller_is_running:
 +                self._start_controller(start=False)
 +
-+            # 1. Umount LINSTOR database.
++            # 4.1. Umount LINSTOR database.
 +            self._mount_database_volume(
 +                self.build_device_path(DATABASE_VOLUME_NAME),
 +                mount=False,
 +                force=True
 +            )
 +
-+            # 2. Refresh instance.
++            # 4.2. Refresh instance.
 +            self._start_controller(start=True)
 +            self._linstor = self._create_linstor_instance(
 +                uri, keep_uri_unmodified=True
 +            )
  
--        # TODO: Throw exceptions in the helpers below if necessary.
--        # TODO: What's the required action if it exists remaining volumes?
-+            # 3. Destroy database volume.
-+            self._destroy_resource(DATABASE_VOLUME_NAME)
- 
 -        self._destroy_resource_group(self._linstor, self._group_name)
-+            # 4. Destroy group and storage pools.
++            # 4.3. Destroy database volume.
++            self._destroy_resource(DATABASE_VOLUME_NAME)
++
++            # 4.4. Refresh linstor connection.
++            # Without we get this error:
++            #   "Cannot delete resource group 'xcp-sr-linstor_group_thin_device' because it has existing resource definitions.."
++            # Because the deletion of the databse was not seen by Linstor for some reason.
++            # It seems a simple refresh of the Linstor connection make it aware of the deletion.
++            self._linstor.disconnect()
++            self._linstor.connect()
++
++            # 4.5. Destroy group and storage pools.
 +            self._destroy_resource_group(self._linstor, self._group_name)
 +            for pool in self._get_storage_pools(force=True):
 +                self._destroy_storage_pool(
@@ -5015,8 +5630,7 @@ index 182b889..a9f39e0 100755
 +        cache.
 +        """
 +        self._mark_resource_cache_as_dirty()
- 
--        return (node_names, in_use)
++
 +    def has_node(self, node_name):
 +        """
 +        Check if a node exists in the LINSTOR database.
@@ -5060,6 +5674,94 @@ index 182b889..a9f39e0 100755
 +            error_str = self._get_error_str(errors)
 +            raise LinstorVolumeManagerError(
 +                'Failed to destroy node `{}`: {}'.format(node_name, error_str)
++            )
++
++    def create_node_interface(self, node_name, name, ip):
++        """
++        Create a new node interface in the LINSTOR database.
++        :param str node_name: Node name of the interface to use.
++        :param str name: Interface to create.
++        :param str ip: IP of the interface.
++        """
++        result = self._linstor.netinterface_create(node_name, name, ip)
++        errors = self._filter_errors(result)
++        if errors:
++            error_str = self._get_error_str(errors)
++            raise LinstorVolumeManagerError(
++                'Failed to create node interface on `{}`: {}'.format(node_name, error_str)
++            )
++
++    def destroy_node_interface(self, node_name, name):
++        """
++        Destroy a node interface in the LINSTOR database.
++        :param str node_name: Node name of the interface to remove.
++        :param str name: Interface to remove.
++        """
++        result = self._linstor.netinterface_delete(node_name, name)
++        errors = self._filter_errors(result)
++        if errors:
++            error_str = self._get_error_str(errors)
++            raise LinstorVolumeManagerError(
++                'Failed to destroy node interface on `{}`: {}'.format(node_name, error_str)
++            )
++
++    def modify_node_interface(self, node_name, name, ip):
++        """
++        Modify a node interface in the LINSTOR database. Create it if necessary.
++        :param str node_name: Node name of the interface to use.
++        :param str name: Interface to modify or create.
++        :param str ip: IP of the interface.
++        """
++        result = self._linstor.netinterface_create(node_name, name, ip)
++        errors = self._filter_errors(result)
++        if not errors:
++            return
++
++        if self._check_errors(errors, [linstor.consts.FAIL_EXISTS_NET_IF]):
++            result = self._linstor.netinterface_modify(node_name, name, ip)
++            errors = self._filter_errors(result)
++            if not errors:
++                return
++
++        error_str = self._get_error_str(errors)
++        raise LinstorVolumeManagerError(
++            'Unable to modify interface on `{}`: {}'.format(node_name, error_str)
++        )
++
++    def list_node_interfaces(self, node_name):
++        """
++        List all node interfaces.
++        :param str node_name: Node name to use to list interfaces.
++        :rtype: list
++        :
++        """
++        result = self._linstor.net_interface_list(node_name)
++        if not result:
++            raise LinstorVolumeManagerError(
++                'Unable to list interfaces on `{}`: no list received'.format(node_name)
++            )
++
++        interfaces = {}
++        for interface in result:
++            interface = interface._rest_data
++            interfaces[interface['name']] = {
++                'address': interface['address'],
++                'active': interface['is_active']
++            }
++        return interfaces
++
++    def set_node_preferred_interface(self, node_name, name):
++        """
++        Set the preferred interface to use on a node.
++        :param str node_name: Node name of the interface.
++        :param str name: Preferred interface to use.
++        """
++        result = self._linstor.node_modify(node_name, property_dict={'PrefNic': name})
++        errors = self._filter_errors(result)
++        if errors:
++            error_str = self._get_error_str(errors)
++            raise LinstorVolumeManagerError(
++                'Failed to set preferred node interface on `{}`: {}'.format(node_name, error_str)
 +            )
 +
 +    def get_nodes_info(self):
@@ -5154,7 +5856,8 @@ index 182b889..a9f39e0 100755
 +                'usable-size': usable_size,
 +                'allocated-size': allocated_size
 +            })
-+
+ 
+-        return (node_names, in_use)
 +        for resource_state in resource_list.resource_states:
 +            resource = resources[resource_state.rsc_name][resource_state.node_name]
 +            resource['in-use'] = resource_state.in_use
@@ -5166,6 +5869,14 @@ index 182b889..a9f39e0 100755
 +                    volume['disk-state'] = volume_state.disk_state
 +
 +        return resources
++
++    def get_database_path(self):
++        """
++        Get the database path.
++        :return: The current database path.
++        :rtype: str
++        """
++        return self._request_database_path(self._linstor)
  
      @classmethod
      def create_sr(
@@ -5264,7 +5975,30 @@ index 182b889..a9f39e0 100755
          pools = pools.storage_pools
          if pools:
              existing_node_names = [pool.node_name for pool in pools]
-@@ -1076,9 +1698,14 @@ class LinstorVolumeManager(object):
+@@ -1062,10 +1825,18 @@ class LinstorVolumeManager(object):
+         if lin.resource_group_list_raise(
+             [group_name]
+         ).resource_groups:
+-            raise LinstorVolumeManagerError(
+-                'Unable to create SR `{}`: The group name already exists'
+-                .format(group_name)
+-            )
++            if not lin.resource_dfn_list_raise().resource_definitions:
++                backup_path = cls._create_database_backup_path()
++                logger(
++                    'Group name already exists `{}` without LVs. '
++                    'Ignoring and moving the config files in {}'.format(group_name, backup_path)
++                )
++                cls._move_files(DATABASE_PATH, backup_path)
++            else:
++                raise LinstorVolumeManagerError(
++                    'Unable to create SR `{}`: The group name already exists'
++                    .format(group_name)
++                )
+ 
+         if thin_provisioning:
+             driver_pool_parts = driver_pool_name.split('/')
+@@ -1076,9 +1847,14 @@ class LinstorVolumeManager(object):
                  )
  
          # 2. Create storage pool on each node + resource group.
@@ -5279,7 +6013,7 @@ index 182b889..a9f39e0 100755
              while i < len(node_names):
                  node_name = node_names[i]
  
-@@ -1089,17 +1716,35 @@ class LinstorVolumeManager(object):
+@@ -1089,32 +1865,63 @@ class LinstorVolumeManager(object):
                      driver_pool_name=driver_pool_name
                  )
  
@@ -5313,17 +6047,56 @@ index 182b889..a9f39e0 100755
 +                    storage_pool_count += 1
                  i += 1
  
+-            # 2.b. Create resource group.
+-            result = lin.resource_group_create(
+-                name=group_name,
+-                place_count=redundancy,
+-                storage_pool=group_name,
+-                diskless_on_remaining=True
+-            )
+-            error_str = cls._get_error_str(result)
+-            if error_str:
 +            if not storage_pool_count:
-+                raise LinstorVolumeManagerError(
+                 raise LinstorVolumeManagerError(
+-                    'Could not create RG `{}`: {}'.format(
+-                        group_name, error_str
 +                    'Unable to create SR `{}`: No VG group found'.format(
 +                        group_name,
-+                    )
+                     )
+                 )
+ 
++            # 2.b. Create resource group.
++            rg_creation_attempt = 0
++            while True:
++                result = lin.resource_group_create(
++                    name=group_name,
++                    place_count=redundancy,
++                    storage_pool=group_name,
++                    diskless_on_remaining=False
++                )
++                error_str = cls._get_error_str(result)
++                if not error_str:
++                    break
++
++                errors = cls._filter_errors(result)
++                if cls._check_errors(errors, [linstor.consts.FAIL_EXISTS_RSC_GRP]):
++                    rg_creation_attempt += 1
++                    if rg_creation_attempt < 2:
++                        try:
++                            cls._destroy_resource_group(lin, group_name)
++                        except Exception as e:
++                            error_str = 'Failed to destroy old and empty RG: {}'.format(e)
++                        else:
++                            continue
++
++                raise LinstorVolumeManagerError(
++                    'Could not create RG `{}`: {}'.format(group_name, error_str)
 +                )
 +
-             # 2.b. Create resource group.
-             result = lin.resource_group_create(
-                 name=group_name,
-@@ -1125,30 +1770,78 @@ class LinstorVolumeManager(object):
+             # 2.c. Create volume group.
+             result = lin.volume_group_create(group_name)
+             error_str = cls._get_error_str(result)
+@@ -1125,30 +1932,78 @@ class LinstorVolumeManager(object):
                      )
                  )
  
@@ -5407,7 +6180,7 @@ index 182b889..a9f39e0 100755
          return instance
  
      @classmethod
-@@ -1196,6 +1889,32 @@ class LinstorVolumeManager(object):
+@@ -1196,6 +2051,32 @@ class LinstorVolumeManager(object):
      # Private helpers.
      # --------------------------------------------------------------------------
  
@@ -5440,7 +6213,21 @@ index 182b889..a9f39e0 100755
      def _ensure_volume_exists(self, volume_uuid):
          if volume_uuid not in self._volumes:
              raise LinstorVolumeManagerError(
-@@ -1224,12 +1943,13 @@ class LinstorVolumeManager(object):
+@@ -1215,21 +2096,24 @@ class LinstorVolumeManager(object):
+             )
+         return result[0].candidates
+ 
+-    def _fetch_resource_names(self):
++    def _fetch_resource_names(self, ignore_deleted=True):
+         resource_names = set()
+         dfns = self._linstor.resource_dfn_list_raise().resource_definitions
+         for dfn in dfns:
+-            if dfn.resource_group_name == self._group_name and \
+-                    linstor.consts.FLAG_DELETE not in dfn.flags:
++            if dfn.resource_group_name == self._group_name and (
++                ignore_deleted or
++                linstor.consts.FLAG_DELETE not in dfn.flags
++            ):
                  resource_names.add(dfn.name)
          return resource_names
  
@@ -5459,7 +6246,7 @@ index 182b889..a9f39e0 100755
              if resource.name not in all_volume_info:
                  current = all_volume_info[resource.name] = self.VolumeInfo(
                      resource.name
-@@ -1237,6 +1957,9 @@ class LinstorVolumeManager(object):
+@@ -1237,6 +2121,9 @@ class LinstorVolumeManager(object):
              else:
                  current = all_volume_info[resource.name]
  
@@ -5469,7 +6256,7 @@ index 182b889..a9f39e0 100755
              for volume in resource.volumes:
                  # We ignore diskless pools of the form "DfltDisklessStorPool".
                  if volume.storage_pool_name == self._group_name:
-@@ -1245,22 +1968,32 @@ class LinstorVolumeManager(object):
+@@ -1245,22 +2132,32 @@ class LinstorVolumeManager(object):
                             'Failed to get allocated size of `{}` on `{}`'
                             .format(resource.name, volume.storage_pool_name)
                          )
@@ -5512,7 +6299,7 @@ index 182b889..a9f39e0 100755
          return all_volume_info
  
      def _get_volume_node_names_and_size(self, volume_name):
-@@ -1289,12 +2022,8 @@ class LinstorVolumeManager(object):
+@@ -1289,12 +2186,8 @@ class LinstorVolumeManager(object):
          return (node_names, size * 1024)
  
      def _compute_size(self, attr):
@@ -5526,7 +6313,7 @@ index 182b889..a9f39e0 100755
              space = pool.free_space
              if space:
                  size = getattr(space, attr)
-@@ -1308,45 +2037,104 @@ class LinstorVolumeManager(object):
+@@ -1308,42 +2201,73 @@ class LinstorVolumeManager(object):
  
      def _get_node_names(self):
          node_names = set()
@@ -5547,12 +6334,10 @@ index 182b889..a9f39e0 100755
 -                'Failed to create volume `{}` from SR `{}`, it already exists'
 -                .format(volume_uuid, self._group_name),
 -                LinstorVolumeManagerError.ERR_VOLUME_EXISTS
--            )
 +    def _get_storage_pools(self, force=False):
 +        cur_time = time.time()
 +        elsaped_time = cur_time - self._storage_pools_time
- 
--        if errors:
++
 +        if force or elsaped_time >= self.STORAGE_POOLS_FETCH_INTERVAL:
 +            self._storage_pools = self._linstor.storage_pool_list_raise(
 +                filter_by_stor_pools=[self._group_name]
@@ -5562,39 +6347,10 @@ index 182b889..a9f39e0 100755
 +        return self._storage_pools
 +
 +    def _create_volume(
-+        self, volume_uuid, volume_name, size, place_resources,
-+        no_diskless=False
++        self, volume_uuid, volume_name, size, place_resources
 +    ):
-+        if no_diskless and not place_resources:
-             raise LinstorVolumeManagerError(
--                'Failed to create volume `{}` from SR `{}`: {}'.format(
--                    volume_uuid,
--                    self._group_name,
--                    self._get_error_str(errors)
--                )
-+                'Could not create volume `{}` from SR `{}`: it\'s impossible '
-+                .format(volume_uuid, self._group_name) +
-+                'to force no diskless without placing resources'
-             )
- 
--    def _create_volume(self, volume_uuid, volume_name, size, place_resources):
-         size = self.round_up_volume_size(size)
++        size = self.round_up_volume_size(size)
 +        self._mark_resource_cache_as_dirty()
- 
--        self._check_volume_creation_errors(self._linstor.resource_group_spawn(
--            rsc_grp_name=self._group_name,
--            rsc_dfn_name=volume_name,
--            vlm_sizes=['{}B'.format(size)],
--            definitions_only=not place_resources
--        ), volume_uuid)
-+        resources = []
-+        if no_diskless:
-+            for node_name in self._get_node_names():
-+                resources.append(linstor.ResourceData(
-+                    node_name=node_name,
-+                    rsc_name=volume_name,
-+                    storage_pool=self._group_name
-+                ))
 +
 +        def create_definition():
 +            self._check_volume_creation_errors(
@@ -5606,9 +6362,15 @@ index 182b889..a9f39e0 100755
 +                ),
 +                volume_uuid,
 +                self._group_name
-+            )
+             )
 +            self._configure_volume_peer_slots(self._linstor, volume_name)
-+
+ 
+-        if errors:
+-            raise LinstorVolumeManagerError(
+-                'Failed to create volume `{}` from SR `{}`: {}'.format(
+-                    volume_uuid,
+-                    self._group_name,
+-                    self._get_error_str(errors)
 +        def clean():
 +            try:
 +                self._destroy_volume(volume_uuid, force=True)
@@ -5616,28 +6378,21 @@ index 182b889..a9f39e0 100755
 +                self._logger(
 +                    'Unable to destroy volume {} after creation fail: {}'
 +                    .format(volume_uuid, e)
-+                )
-+
+                 )
+-            )
+ 
+-    def _create_volume(self, volume_uuid, volume_name, size, place_resources):
+-        size = self.round_up_volume_size(size)
 +        def create():
 +            try:
 +                create_definition()
-+                if no_diskless:
-+                    # Create a physical resource on each node.
-+                    result = self._linstor.resource_create(resources)
-+                    error_str = self._get_error_str(result)
-+                    if error_str:
-+                        raise LinstorVolumeManagerError(
-+                            'Could not create volume `{}` from SR `{}`: {}'.format(
-+                                volume_uuid, self._group_name, error_str
-+                            )
-+                        )
-+                elif place_resources:
++                if place_resources:
 +                    # Basic case when we use the default redundancy of the group.
 +                    self._check_volume_creation_errors(
 +                        self._linstor.resource_auto_place(
 +                            rsc_name=volume_name,
 +                            place_count=self._redundancy,
-+                            diskless_on_remaining=not no_diskless
++                            diskless_on_remaining=False
 +                        ),
 +                        volume_uuid,
 +                        self._group_name
@@ -5649,22 +6404,19 @@ index 182b889..a9f39e0 100755
 +            except Exception:
 +                clean()
 +                raise
-+
+ 
+-        self._check_volume_creation_errors(self._linstor.resource_group_spawn(
+-            rsc_grp_name=self._group_name,
+-            rsc_dfn_name=volume_name,
+-            vlm_sizes=['{}B'.format(size)],
+-            definitions_only=not place_resources
+-        ), volume_uuid)
 +        util.retry(create, maxretry=5)
  
      def _create_volume_with_properties(
--        self, volume_uuid, volume_name, size, place_resources
-+        self, volume_uuid, volume_name, size, place_resources,
-+        no_diskless=False
-     ):
-         if self.check_volume_exists(volume_uuid):
-             raise LinstorVolumeManagerError(
-@@ -1375,9 +2163,11 @@ class LinstorVolumeManager(object):
-             volume_properties[self.PROP_VOLUME_NAME] = volume_name
- 
-             self._create_volume(
--                volume_uuid, volume_name, size, place_resources
-+                volume_uuid, volume_name, size, place_resources, no_diskless
+         self, volume_uuid, volume_name, size, place_resources
+@@ -1378,6 +2302,8 @@ class LinstorVolumeManager(object):
+                 volume_uuid, volume_name, size, place_resources
              )
  
 +            assert volume_properties.namespace == \
@@ -5672,7 +6424,7 @@ index 182b889..a9f39e0 100755
              return volume_properties
          except LinstorVolumeManagerError as e:
              # Do not destroy existing resource!
-@@ -1385,12 +2175,8 @@ class LinstorVolumeManager(object):
+@@ -1385,12 +2311,8 @@ class LinstorVolumeManager(object):
              # before the `self._create_volume` case.
              # It can only happen if the same volume uuid is used in the same
              # call in another host.
@@ -5687,7 +6439,7 @@ index 182b889..a9f39e0 100755
              raise
  
      def _find_device_path(self, volume_uuid, volume_name):
-@@ -1417,68 +2203,73 @@ class LinstorVolumeManager(object):
+@@ -1417,68 +2339,73 @@ class LinstorVolumeManager(object):
  
      def _request_device_path(self, volume_uuid, volume_name, activate=False):
          node_name = socket.gethostname()
@@ -5702,36 +6454,64 @@ index 182b889..a9f39e0 100755
          )
  
 -        if not resources or not resources[0]:
--            raise LinstorVolumeManagerError(
--                'No response list for dev path of `{}`'.format(volume_uuid)
--            )
--        if isinstance(resources[0], linstor.responses.ResourceResponse):
--            if not resources[0].resources:
--                if activate:
--                    self._activate_device_path(node_name, volume_name)
--                    return self._request_device_path(volume_uuid, volume_name)
--                raise LinstorVolumeManagerError(
--                    'Empty dev path for `{}`, but definition "seems" to exist'
--                    .format(volume_uuid)
 +        if not resources:
 +            if activate:
 +                self._mark_resource_cache_as_dirty()
 +                self._activate_device_path(
 +                    self._linstor, node_name, volume_name
-                 )
--            # Contains a path of the /dev/drbd<id> form.
--            return resources[0].resources[0].volumes[0].device_path
--
--        raise LinstorVolumeManagerError(
--            'Unable to get volume dev path `{}`: {}'.format(
--                volume_uuid, str(resources[0])
++                )
 +                return self._request_device_path(volume_uuid, volume_name)
 +            raise LinstorVolumeManagerError(
 +                'Empty dev path for `{}`, but definition "seems" to exist'
 +                .format(volume_uuid)
++            )
++        # Contains a path of the /dev/drbd<id> form.
++        return resources[0].volumes[0].device_path
++
++    def _destroy_resource(self, resource_name, force=False):
++        result = self._linstor.resource_dfn_delete(resource_name)
++        error_str = self._get_error_str(result)
++        if not error_str:
++            self._mark_resource_cache_as_dirty()
++            return
++
++        if not force:
++            self._mark_resource_cache_as_dirty()
+             raise LinstorVolumeManagerError(
+-                'No response list for dev path of `{}`'.format(volume_uuid)
++               'Could not destroy resource `{}` from SR `{}`: {}'
++                .format(resource_name, self._group_name, error_str)
              )
--        )
--
+-        if isinstance(resources[0], linstor.responses.ResourceResponse):
+-            if not resources[0].resources:
+-                if activate:
+-                    self._activate_device_path(node_name, volume_name)
+-                    return self._request_device_path(volume_uuid, volume_name)
++
++        # If force is used, ensure there is no opener.
++        all_openers = get_all_volume_openers(resource_name, '0')
++        for openers in all_openers.itervalues():
++            if openers:
++                self._mark_resource_cache_as_dirty()
+                 raise LinstorVolumeManagerError(
+-                    'Empty dev path for `{}`, but definition "seems" to exist'
+-                    .format(volume_uuid)
++                    'Could not force destroy resource `{}` from SR `{}`: {} (openers=`{}`)'
++                    .format(resource_name, self._group_name, error_str, all_openers)
+                 )
+-            # Contains a path of the /dev/drbd<id> form.
+-            return resources[0].resources[0].volumes[0].device_path
+ 
+-        raise LinstorVolumeManagerError(
+-            'Unable to get volume dev path `{}`: {}'.format(
+-                volume_uuid, str(resources[0])
+-            )
++        # Maybe the resource is blocked in primary mode. DRBD/LINSTOR issue?
++        resource_states = filter(
++            lambda resource_state: resource_state.name == resource_name,
++            self._get_resource_cache().resource_states
+         )
+ 
 -    def _activate_device_path(self, node_name, volume_name):
 -        result = self._linstor.resource_create([
 -            linstor.ResourceData(node_name, volume_name, diskless=True)
@@ -5749,48 +6529,21 @@ index 182b889..a9f39e0 100755
 -            .format(volume_name, node_name, ', '.join(
 -                [str(x) for x in result]))
 -        )
-+        # Contains a path of the /dev/drbd<id> form.
-+        return resources[0].volumes[0].device_path
- 
+-
 -    def _destroy_resource(self, resource_name):
-+    def _destroy_resource(self, resource_name, force=False):
-         result = self._linstor.resource_dfn_delete(resource_name)
-         error_str = self._get_error_str(result)
+-        result = self._linstor.resource_dfn_delete(resource_name)
+-        error_str = self._get_error_str(result)
 -        if error_str:
-+        if not error_str:
-+            self._mark_resource_cache_as_dirty()
-+            return
-+
-+        if not force:
-+            self._mark_resource_cache_as_dirty()
-             raise LinstorVolumeManagerError(
+-            raise LinstorVolumeManagerError(
 -                'Could not destroy resource `{}` from SR `{}`: {}'
-+               'Could not destroy resource `{}` from SR `{}`: {}'
-                 .format(resource_name, self._group_name, error_str)
-             )
+-                .format(resource_name, self._group_name, error_str)
+-            )
++        # Mark only after computation of states.
++        self._mark_resource_cache_as_dirty()
  
 -    def _destroy_volume(self, volume_uuid, volume_properties):
 -        assert volume_properties.namespace == \
 -            self._build_volume_namespace(volume_uuid)
-+        # If force is used, ensure there is no opener.
-+        all_openers = get_all_volume_openers(resource_name, '0')
-+        for openers in all_openers.itervalues():
-+            if openers:
-+                self._mark_resource_cache_as_dirty()
-+                raise LinstorVolumeManagerError(
-+                    'Could not force destroy resource `{}` from SR `{}`: {} (openers=`{}`)'
-+                    .format(resource_name, self._group_name, error_str, all_openers)
-+                )
-+
-+        # Maybe the resource is blocked in primary mode. DRBD/LINSTOR issue?
-+        resource_states = filter(
-+            lambda resource_state: resource_state.name == resource_name,
-+            self._get_resource_cache().resource_states
-+        )
-+
-+        # Mark only after computation of states.
-+        self._mark_resource_cache_as_dirty()
-+
 +        for resource_state in resource_states:
 +            volume_state = resource_state.volume_states[0]
 +            if resource_state.in_use:
@@ -5808,7 +6561,7 @@ index 182b889..a9f39e0 100755
  
              # Assume this call is atomic.
              volume_properties.clear()
-@@ -1487,19 +2278,8 @@ class LinstorVolumeManager(object):
+@@ -1487,19 +2414,8 @@ class LinstorVolumeManager(object):
                  'Cannot destroy volume `{}`: {}'.format(volume_uuid, e)
              )
  
@@ -5829,7 +6582,7 @@ index 182b889..a9f39e0 100755
          resource_names = self._fetch_resource_names()
  
          self._volumes = set()
-@@ -1517,9 +2297,7 @@ class LinstorVolumeManager(object):
+@@ -1517,9 +2433,7 @@ class LinstorVolumeManager(object):
              self.REG_NOT_EXISTS, ignore_inexisting_volumes=False
          )
          for volume_uuid, not_exists in existing_volumes.items():
@@ -5840,7 +6593,7 @@ index 182b889..a9f39e0 100755
  
              src_uuid = properties.get(self.PROP_UPDATING_UUID_SRC)
              if src_uuid:
-@@ -1569,7 +2347,7 @@ class LinstorVolumeManager(object):
+@@ -1569,7 +2483,7 @@ class LinstorVolumeManager(object):
                  # Little optimization, don't call `self._destroy_volume`,
                  # we already have resource name list.
                  if volume_name in resource_names:
@@ -5849,7 +6602,7 @@ index 182b889..a9f39e0 100755
  
                  # Assume this call is atomic.
                  properties.clear()
-@@ -1579,37 +2357,42 @@ class LinstorVolumeManager(object):
+@@ -1579,37 +2493,42 @@ class LinstorVolumeManager(object):
                      'Cannot clean volume {}: {}'.format(volume_uuid, e)
                  )
  
@@ -5909,7 +6662,7 @@ index 182b889..a9f39e0 100755
  
          volume_properties = {}
          for volume_uuid in self._volumes:
-@@ -1625,15 +2408,17 @@ class LinstorVolumeManager(object):
+@@ -1625,15 +2544,17 @@ class LinstorVolumeManager(object):
  
          return volume_properties
  
@@ -5933,7 +6686,7 @@ index 182b889..a9f39e0 100755
  
      @classmethod
      def _build_sr_namespace(cls):
-@@ -1653,46 +2438,429 @@ class LinstorVolumeManager(object):
+@@ -1653,46 +2574,433 @@ class LinstorVolumeManager(object):
          ])
  
      @classmethod
@@ -5994,9 +6747,7 @@ index 182b889..a9f39e0 100755
 +
 +    @classmethod
 +    def _activate_device_path(cls, lin, node_name, volume_name):
-+        result = lin.resource_create([
-+            linstor.ResourceData(node_name, volume_name, diskless=True)
-+        ])
++        result = lin.resource_make_available(node_name, volume_name, diskful=False)
 +        if linstor.Linstor.all_api_responses_no_error(result):
 +            return
 +        errors = linstor.Linstor.filter_api_call_response_errors(result)
@@ -6031,10 +6782,10 @@ index 182b889..a9f39e0 100755
 +            if activate:
 +                cls._activate_device_path(
 +                    lin, node_name, DATABASE_VOLUME_NAME
-+                )
+                 )
 +                return cls._request_database_path(
 +                    DATABASE_VOLUME_NAME, DATABASE_VOLUME_NAME
-                 )
++                )
 +            raise LinstorVolumeManagerError(
 +                'Empty dev path for `{}`, but definition "seems" to exist'
 +                .format(DATABASE_PATH)
@@ -6129,8 +6880,8 @@ index 182b889..a9f39e0 100755
 +                'Could not create database volume from SR `{}`: {}'.format(
 +                    group_name, error_str
 +                )
-+            )
-+
+             )
+ 
 +        # We must modify the quorum. Otherwise we can't use correctly the
 +        # drbd-reactor daemon.
 +        if auto_quorum:
@@ -6171,7 +6922,10 @@ index 182b889..a9f39e0 100755
 +            )
 +
 +        try:
-+            util.pread2([DATABASE_MKFS, expected_device_path])
++            util.retry(
++                lambda: util.pread2([DATABASE_MKFS, expected_device_path]),
++                maxretry=5
++            )
 +        except Exception as e:
 +            raise LinstorVolumeManagerError(
 +               'Failed to execute {} on database volume: {}'
@@ -6189,23 +6943,14 @@ index 182b889..a9f39e0 100755
 +            raise LinstorVolumeManagerError(
 +                'Could not destroy resource `{}` from SR `{}`: {}'
 +                .format(DATABASE_VOLUME_NAME, group_name, error_str)
-             )
- 
++            )
++
 +    @classmethod
 +    def _mount_database_volume(cls, volume_path, mount=True, force=False):
-+        backup_path = DATABASE_PATH + '-' + str(uuid.uuid4())
-+
 +        try:
 +            # 1. Create a backup config folder.
 +            database_not_empty = bool(os.listdir(DATABASE_PATH))
-+            if database_not_empty:
-+                try:
-+                    os.mkdir(backup_path)
-+                except Exception as e:
-+                    raise LinstorVolumeManagerError(
-+                        'Failed to create backup path {} of LINSTOR config: {}'
-+                        .format(backup_path, e)
-+                    )
++            backup_path = cls._create_database_backup_path()
 +
 +            # 2. Move the config in the mounted volume.
 +            if database_not_empty:
@@ -6219,9 +6964,9 @@ index 182b889..a9f39e0 100755
 +                # 3. Remove useless backup directory.
 +                try:
 +                    os.rmdir(backup_path)
-+                except Exception:
++                except Exception as e:
 +                    raise LinstorVolumeManagerError(
-+                        'Failed to remove backup path {} of LINSTOR config {}'
++                        'Failed to remove backup path {} of LINSTOR config: {}'
 +                        .format(backup_path, e)
 +                    )
 +        except Exception as e:
@@ -6374,10 +7119,22 @@ index 182b889..a9f39e0 100755
 +                )
 +            )
 +
++    @staticmethod
++    def _create_database_backup_path():
++        path = DATABASE_PATH + '-' + str(uuid.uuid4())
++        try:
++            os.mkdir(path)
++            return path
++        except Exception as e:
++            raise LinstorVolumeManagerError(
++                'Failed to create backup path {} of LINSTOR config: {}'
++                .format(path, e)
++            )
++
      @staticmethod
      def _get_filtered_properties(properties):
          return dict(properties.items())
-@@ -1711,3 +2879,110 @@ class LinstorVolumeManager(object):
+@@ -1711,3 +3019,110 @@ class LinstorVolumeManager(object):
                  if err.is_error(code):
                      return True
          return False
@@ -6736,6 +7493,19 @@ index 3a3027e..279786e 100755
      cmd = [VHD_UTIL, "query", OPT_LOG_ERR, opts, "-n", path]
      ret = ioretry(cmd)
      fields = ret.strip().split('\n')
+diff --git a/etc/systemd/system/drbd-reactor.service.d/override.conf b/etc/systemd/system/drbd-reactor.service.d/override.conf
+new file mode 100644
+index 0000000..c079ab6
+--- /dev/null
++++ b/etc/systemd/system/drbd-reactor.service.d/override.conf
+@@ -0,0 +1,7 @@
++[Unit]
++StartLimitInterval=60
++StartLimitBurst=10
++
++[Service]
++Restart=always
++RestartSec=2
 diff --git a/etc/systemd/system/linstor-satellite.service.d/override.conf b/etc/systemd/system/linstor-satellite.service.d/override.conf
 new file mode 100644
 index 0000000..b1686b4
@@ -7137,10 +7907,10 @@ index 0000000..665a60b
 +        syslog.syslog(sys.argv[1] + ' is now terminated!')
 diff --git a/scripts/linstor-kv-tool b/scripts/linstor-kv-tool
 new file mode 100755
-index 0000000..c907027
+index 0000000..b845ec2
 --- /dev/null
 +++ b/scripts/linstor-kv-tool
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,84 @@
 +#!/usr/bin/env python
 +#
 +# Copyright (C) 2022  Vates SAS
@@ -7156,6 +7926,10 @@ index 0000000..c907027
 +#
 +# You should have received a copy of the GNU General Public License
 +# along with this program.  If not, see <https://www.gnu.org/licenses/>.
++import sys
++sys.path[0] = '/opt/xensource/sm/'
++
++from linstorvolumemanager import get_controller_uri
 +
 +import argparse
 +import json
@@ -7199,7 +7973,7 @@ index 0000000..c907027
 +
 +def main():
 +    parser = argparse.ArgumentParser()
-+    parser.add_argument('-u', '--uri', required=True)
++    parser.add_argument('-u', '--uri', required=False)
 +    parser.add_argument('-g', '--group-name', required=True)
 +    parser.add_argument('-n', '--namespace', default='/')
 +
@@ -7209,12 +7983,14 @@ index 0000000..c907027
 +    action.add_argument('--remove-all-volumes', action='store_true')
 +
 +    args = parser.parse_args()
++    controller_uri = get_controller_uri() if args.uri is None else args.uri
++
 +    if args.dump_volumes:
-+        dump_kv(args.uri, args.group_name, args.namespace)
++        dump_kv(controller_uri, args.group_name, args.namespace)
 +    elif args.remove_volume:
-+        remove_volume(args.uri, args.group_name, args.remove_volume)
++        remove_volume(controller_uri, args.group_name, args.remove_volume)
 +    elif args.remove_all_volumes:
-+        remove_all_volumes(args.uri, args.group_name)
++        remove_all_volumes(controller_uri, args.group_name)
 +
 +
 +if __name__ == '__main__':
@@ -7286,5 +8062,5 @@ index 1aad363..d6f5713 100644
      def fake_import(self, name, *args):
          print('Asked to import {}'.format(name))
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
+++ b/SOURCES/0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
@@ -1,26 +1,26 @@
-From 650edc6d5f8a131acdc4986cea91cbdb7c0ef1a9 Mon Sep 17 00:00:00 2001
+From 71aa8bf0a3f3ff0087df9aa4dfca5f4508aa7a75 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 30 Jun 2023 12:41:43 +0200
-Subject: [PATCH 20/22] feat(LinstorSR): is now compatible with python 3
+Subject: [PATCH 20/25] feat(LinstorSR): is now compatible with python 3
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
  drivers/LinstorSR.py            | 19 +++++++++----------
  drivers/cleanup.py              |  2 +-
- drivers/linstor-manager         |  2 +-
+ drivers/linstor-manager         |  4 ++--
  drivers/linstorvhdutil.py       | 13 +++++--------
  drivers/linstorvolumemanager.py | 30 +++++++++++++++---------------
  drivers/util.py                 |  2 +-
  scripts/fork-log-daemon         |  2 +-
  scripts/linstor-kv-tool         |  2 +-
  scripts/safe-umount             |  2 +-
- 9 files changed, 35 insertions(+), 39 deletions(-)
+ 9 files changed, 36 insertions(+), 40 deletions(-)
 
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index 9cb4ed4..b9616fb 100755
+index 5f143e7..b5bcc39 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
-@@ -832,7 +832,7 @@ class LinstorSR(SR.SR):
+@@ -756,7 +756,7 @@ class LinstorSR(SR.SR):
          self._load_vdis()
          self._update_physical_size()
  
@@ -29,7 +29,7 @@ index 9cb4ed4..b9616fb 100755
              if self.vdis[vdi_uuid].deleted:
                  del self.vdis[vdi_uuid]
  
-@@ -950,7 +950,7 @@ class LinstorSR(SR.SR):
+@@ -889,7 +889,7 @@ class LinstorSR(SR.SR):
          secondary_hosts = []
  
          hosts = self.session.xenapi.host.get_all_records()
@@ -38,7 +38,7 @@ index 9cb4ed4..b9616fb 100755
              hostname = host_rec['hostname']
              if controller_node_name == hostname:
                  controller_host = host_ref
-@@ -1061,7 +1061,7 @@ class LinstorSR(SR.SR):
+@@ -1000,7 +1000,7 @@ class LinstorSR(SR.SR):
          # We use the size of the smallest disk, this is an approximation that
          # ensures the displayed physical size is reachable by the user.
          (min_physical_size, pool_count) = self._linstor.get_min_physical_size()
@@ -47,7 +47,7 @@ index 9cb4ed4..b9616fb 100755
              self._linstor.redundancy
  
          self.physical_utilisation = self._linstor.allocated_volume_size
-@@ -1301,7 +1301,7 @@ class LinstorSR(SR.SR):
+@@ -1240,7 +1240,7 @@ class LinstorSR(SR.SR):
  
          # 9. Remove all hidden leaf nodes to avoid introducing records that
          # will be GC'ed.
@@ -56,7 +56,7 @@ index 9cb4ed4..b9616fb 100755
              if vdi_uuid not in geneology and self.vdis[vdi_uuid].hidden:
                  util.SMlog(
                      'Scan found hidden leaf ({}), ignoring'.format(vdi_uuid)
-@@ -1513,17 +1513,16 @@ class LinstorSR(SR.SR):
+@@ -1446,17 +1446,16 @@ class LinstorSR(SR.SR):
      # --------------------------------------------------------------------------
  
      def _create_linstor_cache(self):
@@ -78,7 +78,7 @@ index 9cb4ed4..b9616fb 100755
                  raise e
  
          self._all_volume_metadata_cache = \
-@@ -2665,7 +2664,7 @@ class LinstorVDI(VDI.VDI):
+@@ -2643,7 +2642,7 @@ class LinstorVDI(VDI.VDI):
                  '--nbd-name',
                  volume_name,
                  '--urls',
@@ -88,10 +88,10 @@ index 9cb4ed4..b9616fb 100755
                  str(device_size)
              ]
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index 51f2912..e90cf79 100755
+index 989068a..0a890d2 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
-@@ -3192,7 +3192,7 @@ class LinstorSR(SR):
+@@ -3335,7 +3335,7 @@ class LinstorSR(SR):
      def _checkSlaves(self, vdi):
          try:
              all_openers = self._linstor.get_volume_openers(vdi.uuid)
@@ -101,7 +101,7 @@ index 51f2912..e90cf79 100755
                      if opener['process-name'] != 'tapdisk':
                          raise util.SMException(
 diff --git a/drivers/linstor-manager b/drivers/linstor-manager
-index 45201ee..9ff7fff 100755
+index 6b45875..71e2e90 100755
 --- a/drivers/linstor-manager
 +++ b/drivers/linstor-manager
 @@ -1,4 +1,4 @@
@@ -110,11 +110,20 @@ index 45201ee..9ff7fff 100755
  #
  # Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
  #
+@@ -493,7 +493,7 @@ def get_key_hash(session, args):
+ def get_block_bitmap(session, args):
+     try:
+         device_path = args['devicePath']
+-        return base64.b64encode(vhdutil.getBlockBitmap(device_path)) or ''
++        return base64.b64encode(vhdutil.getBlockBitmap(device_path)).decode('ascii')
+     except Exception as e:
+         util.SMlog('linstor-manager:get_block_bitmap error: {}'.format(e))
+         raise
 diff --git a/drivers/linstorvhdutil.py b/drivers/linstorvhdutil.py
-index 83d7f8b..4cf4f86 100644
+index 494b4b0..eb8d285 100644
 --- a/drivers/linstorvhdutil.py
 +++ b/drivers/linstorvhdutil.py
-@@ -25,9 +25,6 @@ import xs_errors
+@@ -27,9 +27,6 @@ import xs_errors
  
  MANAGER_PLUGIN = 'linstor-manager'
  
@@ -122,9 +131,9 @@ index 83d7f8b..4cf4f86 100644
 -EMEDIUMTYPE = 124
 -
  
- def call_vhd_util_on_host(session, host_ref, method, device_path, args):
+ def call_remote_method(session, host_ref, method, device_path, args):
      try:
-@@ -105,7 +102,7 @@ def linstorhostcall(local_method, remote_method):
+@@ -107,7 +104,7 @@ def linstorhostcall(local_method, remote_method):
                  'groupName': self._linstor.group_name
              }
              remote_args.update(**kwargs)
@@ -133,7 +142,7 @@ index 83d7f8b..4cf4f86 100644
  
              try:
                  def remote_call():
-@@ -331,7 +328,7 @@ class LinstorVhdUtil:
+@@ -426,7 +423,7 @@ class LinstorVhdUtil:
                  try:
                      return local_method(device_path, *args, **kwargs)
                  except util.CommandException as e:
@@ -142,7 +151,7 @@ index 83d7f8b..4cf4f86 100644
                          raise ErofsLinstorCallException(e)  # Break retry calls.
                      if e.code == errno.ENOENT:
                          raise NoPathLinstorCallException(e)
-@@ -380,7 +377,7 @@ class LinstorVhdUtil:
+@@ -478,7 +475,7 @@ class LinstorVhdUtil:
              'groupName': self._linstor.group_name
          }
          remote_args.update(**kwargs)
@@ -151,7 +160,7 @@ index 83d7f8b..4cf4f86 100644
  
          volume_uuid = self._linstor.get_volume_uuid_from_device_path(
              device_path
-@@ -403,12 +400,12 @@ class LinstorVhdUtil:
+@@ -501,12 +498,12 @@ class LinstorVhdUtil:
                  )
  
              no_host_found = True
@@ -167,10 +176,10 @@ index 83d7f8b..4cf4f86 100644
                      continue
  
 diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
-index a9f39e0..91de3a9 100755
+index 92fd028..629bc52 100755
 --- a/drivers/linstorvolumemanager.py
 +++ b/drivers/linstorvolumemanager.py
-@@ -526,8 +526,8 @@ class LinstorVolumeManager(object):
+@@ -528,8 +528,8 @@ class LinstorVolumeManager(object):
                  current[volume.number] = max(current_size, current.get(volume.number) or 0)
  
          total_size = 0
@@ -181,7 +190,7 @@ index a9f39e0..91de3a9 100755
                  total_size += size
  
          return total_size * 1024
-@@ -1638,8 +1638,8 @@ class LinstorVolumeManager(object):
+@@ -1779,8 +1779,8 @@ class LinstorVolumeManager(object):
  
          lin = cls._create_linstor_instance(uri, keep_uri_unmodified=True)
  
@@ -192,7 +201,7 @@ index a9f39e0..91de3a9 100755
              while True:
                  # Try to create node.
                  result = lin.node_create(
-@@ -2204,13 +2204,13 @@ class LinstorVolumeManager(object):
+@@ -2340,13 +2340,13 @@ class LinstorVolumeManager(object):
      def _request_device_path(self, volume_uuid, volume_name, activate=False):
          node_name = socket.gethostname()
  
@@ -209,7 +218,7 @@ index a9f39e0..91de3a9 100755
              if activate:
                  self._mark_resource_cache_as_dirty()
                  self._activate_device_path(
-@@ -2222,7 +2222,7 @@ class LinstorVolumeManager(object):
+@@ -2358,7 +2358,7 @@ class LinstorVolumeManager(object):
                  .format(volume_uuid)
              )
          # Contains a path of the /dev/drbd<id> form.
@@ -218,7 +227,7 @@ index a9f39e0..91de3a9 100755
  
      def _destroy_resource(self, resource_name, force=False):
          result = self._linstor.resource_dfn_delete(resource_name)
-@@ -2240,7 +2240,7 @@ class LinstorVolumeManager(object):
+@@ -2376,7 +2376,7 @@ class LinstorVolumeManager(object):
  
          # If force is used, ensure there is no opener.
          all_openers = get_all_volume_openers(resource_name, '0')
@@ -227,7 +236,7 @@ index a9f39e0..91de3a9 100755
              if openers:
                  self._mark_resource_cache_as_dirty()
                  raise LinstorVolumeManagerError(
-@@ -2506,18 +2506,18 @@ class LinstorVolumeManager(object):
+@@ -2640,18 +2640,18 @@ class LinstorVolumeManager(object):
          node_name = socket.gethostname()
  
          try:
@@ -249,7 +258,7 @@ index a9f39e0..91de3a9 100755
              if activate:
                  cls._activate_device_path(
                      lin, node_name, DATABASE_VOLUME_NAME
-@@ -2530,7 +2530,7 @@ class LinstorVolumeManager(object):
+@@ -2664,7 +2664,7 @@ class LinstorVolumeManager(object):
                  .format(DATABASE_PATH)
              )
          # Contains a path of the /dev/drbd<id> form.
@@ -258,7 +267,7 @@ index a9f39e0..91de3a9 100755
  
      @classmethod
      def _create_database_volume(
-@@ -2565,7 +2565,7 @@ class LinstorVolumeManager(object):
+@@ -2699,7 +2699,7 @@ class LinstorVolumeManager(object):
              )
  
          # Ensure we have a correct list of storage pools.
@@ -267,7 +276,7 @@ index a9f39e0..91de3a9 100755
          assert nodes_with_pool  # We must have at least one storage pool!
          for node_name in nodes_with_pool:
              assert node_name in node_names
-@@ -2815,7 +2815,7 @@ class LinstorVolumeManager(object):
+@@ -2943,7 +2943,7 @@ class LinstorVolumeManager(object):
      def _move_files(cls, src_dir, dest_dir, force=False):
          def listdir(dir):
              ignored = ['lost+found']
@@ -300,7 +309,7 @@ index 665a60b..986de63 100755
  import select
  import signal
 diff --git a/scripts/linstor-kv-tool b/scripts/linstor-kv-tool
-index c907027..9d74656 100755
+index b845ec2..de14e73 100755
 --- a/scripts/linstor-kv-tool
 +++ b/scripts/linstor-kv-tool
 @@ -1,4 +1,4 @@
@@ -320,5 +329,5 @@ index 9c1dcc4..3c64a3f 100755
  import argparse
  import subprocess
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
+++ b/SOURCES/0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
@@ -1,7 +1,7 @@
-From 9b51ea2d170524c77dd100fdb5ec5f8a6648b309 Mon Sep 17 00:00:00 2001
+From 746a4c47bbd7ca191f295a7f449960a5b6c65e59 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Fri, 4 Aug 2023 12:10:37 +0200
-Subject: [PATCH 21/22] Remove `SR_PROBE` from ZFS capabilities (#36)
+Subject: [PATCH 21/25] Remove `SR_PROBE` from ZFS capabilities (#36)
 
 The probe method is not implemented so we
 shouldn't advertise it.
@@ -24,5 +24,5 @@ index 354ca90..5301d5e 100644
      'VDI_CREATE',
      'VDI_DELETE',
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0022-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0022-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,7 +1,7 @@
-From e05967859f781b7eb85e5a66f7ba40340526e0f3 Mon Sep 17 00:00:00 2001
+From 3655e383baad67cbb170fc3715120063313dcce1 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Wed, 16 Aug 2023 13:42:21 +0200
-Subject: [PATCH 22/22] Fix vdi-ref when static vdis are used
+Subject: [PATCH 22/25] Fix vdi-ref when static vdis are used
 
 When static vdis are used there is no snapshots and we don't want to
 call method from XAPI.
@@ -33,5 +33,5 @@ index 666af83..ec10fe7 100755
          if needDeflate:
              try:
 -- 
-2.41.0
+2.43.0
 

--- a/SOURCES/0023-Repair-coverage-to-be-compatible-with-8.3-test-env.patch
+++ b/SOURCES/0023-Repair-coverage-to-be-compatible-with-8.3-test-env.patch
@@ -1,0 +1,78 @@
+From 22464ff6666c7ca6cb89e3d34b3071e7843ffb9f Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Fri, 22 Sep 2023 11:11:27 +0200
+Subject: [PATCH 23/25] Repair coverage to be compatible with 8.3 test env
+
+Impacted drivers: LINSTOR, MooseFS and ZFS.
+- Ignore all linstor.* members during coverage,
+  the module is not installed in github runner.
+- Use mock from unittest, the old one is not found now.
+- Remove useless return from LinstorSR scan method.
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/LinstorSR.py    | 3 +--
+ tests/pylintrc          | 2 +-
+ tests/test_MooseFSSR.py | 4 +++-
+ tests/test_ZFSSR.py     | 5 +++--
+ 4 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
+index b5bcc39..859d42d 100755
+--- a/drivers/LinstorSR.py
++++ b/drivers/LinstorSR.py
+@@ -777,9 +777,8 @@ class LinstorSR(SR.SR):
+ 
+         # Update the database before the restart of the GC to avoid
+         # bad sync in the process if new VDIs have been introduced.
+-        ret = super(LinstorSR, self).scan(self.uuid)
++        super(LinstorSR, self).scan(self.uuid)
+         self._kick_gc()
+-        return ret
+ 
+     @_locked_load
+     def vdi(self, uuid):
+diff --git a/tests/pylintrc b/tests/pylintrc
+index a982913..4588675 100644
+--- a/tests/pylintrc
++++ b/tests/pylintrc
+@@ -84,7 +84,7 @@ ignored-classes=SQLObject
+ 
+ # List of members which are set dynamically and missed by pylint inference
+ # system, and so shouldn't trigger E0201 when accessed.
+-generated-members=REQUEST,acl_users,aq_parent
++generated-members=REQUEST,acl_users,aq_parent,linstor.*
+ 
+ # List of module names for which member attributes should not be checked
+ # # (useful for modules/projects where namespaces are manipulated during runtime
+diff --git a/tests/test_MooseFSSR.py b/tests/test_MooseFSSR.py
+index feaac62..f4e0a85 100644
+--- a/tests/test_MooseFSSR.py
++++ b/tests/test_MooseFSSR.py
+@@ -1,4 +1,6 @@
+-import mock
++from unittest import mock
++import unittest
++
+ import MooseFSSR
+ import unittest
+ 
+diff --git a/tests/test_ZFSSR.py b/tests/test_ZFSSR.py
+index e95ab7e..ac2c6eb 100644
+--- a/tests/test_ZFSSR.py
++++ b/tests/test_ZFSSR.py
+@@ -1,8 +1,9 @@
++from unittest import mock
++import unittest
++
+ import FileSR
+-import mock
+ import os
+ import SR
+-import unittest
+ import ZFSSR
+ 
+ 
+-- 
+2.43.0
+

--- a/SOURCES/0024-Support-IPv6-for-NFS-ISO-SR.patch
+++ b/SOURCES/0024-Support-IPv6-for-NFS-ISO-SR.patch
@@ -1,0 +1,44 @@
+From 137e3fd7a3f3978a2bc761bdf3c4597a2b9a2db5 Mon Sep 17 00:00:00 2001
+From: BenjiReis <benjamin.reis@vates.fr>
+Date: Mon, 25 Sep 2023 16:00:33 +0200
+Subject: [PATCH 24/25] Support IPv6 for NFS ISO SR
+
+Location are of form: `[<ipv6>]:/path`
+
+Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ drivers/ISOSR.py | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/ISOSR.py b/drivers/ISOSR.py
+index d7f836e..fdb7252 100755
+--- a/drivers/ISOSR.py
++++ b/drivers/ISOSR.py
+@@ -326,13 +326,22 @@ class ISOSR(SR.SR):
+                 # For NFS, do a soft mount with tcp as protocol. Since ISO SR is
+                 # going to be r-only, a failure in nfs link can be reported back
+                 # to the process waiting.
+-                serv_path = location.split(':')
++                serv_path = []
++                transport = 'tcp'
++                if location.startswith('['):
++                    # IPv6 target: remove brackets around the IPv6
++                    transport = 'tcp6'
++                    ip6 = location[1:location.index(']')]
++                    path = location[location.index(']') + 2:]
++                    serv_path = [ip6, path]
++                else:
++                    serv_path = location.split(':')
+                 util._testHost(serv_path[0], NFSPORT, 'NFSTarget')
+                 # Extract timeout and retrans values, if any
+                 io_timeout = nfs.get_nfs_timeout(self.other_config)
+                 io_retrans = nfs.get_nfs_retrans(self.other_config)
+                 nfs.soft_mount(self.mountpoint, serv_path[0], serv_path[1],
+-                               'tcp', useroptions=options, nfsversion=self.nfsversion,
++                               transport, useroptions=options, nfsversion=self.nfsversion,
+                                timeout=io_timeout, retrans=io_retrans)
+             else:
+                 if self.smbversion in SMB_VERSION_3:
+-- 
+2.43.0
+

--- a/SOURCES/0025-Support-IPv6-in-Ceph-Driver.patch
+++ b/SOURCES/0025-Support-IPv6-in-Ceph-Driver.patch
@@ -1,0 +1,44 @@
+From 205a7be0cb7ae1127ad9d74ad3de8998106d08c3 Mon Sep 17 00:00:00 2001
+From: BenjiReis <benjamin.reis@vates.fr>
+Date: Mon, 25 Sep 2023 16:13:13 +0200
+Subject: [PATCH 25/25] Support IPv6 in Ceph Driver
+
+Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ drivers/CephFSSR.py | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/CephFSSR.py b/drivers/CephFSSR.py
+index d85faf9..2f8c50d 100644
+--- a/drivers/CephFSSR.py
++++ b/drivers/CephFSSR.py
+@@ -20,6 +20,7 @@
+ 
+ import errno
+ import os
++import socket
+ import syslog as _syslog
+ import xmlrpc.client
+ from syslog import syslog
+@@ -141,7 +142,17 @@ class CephFSSR(FileSR.FileSR):
+                 options.append(self.dconf['options'])
+             if options:
+                 options = ['-o', ','.join(options)]
+-            command = ["mount", '-t', 'ceph', self.remoteserver+":"+self.remoteport+":"+self.remotepath, mountpoint] + options
++            acc = []
++            for server in self.remoteserver.split(','):
++                try:
++                    addr_info = socket.getaddrinfo(server, 0)[0]
++                except Exception:
++                    continue
++
++                acc.append('[' + server + ']' if addr_info[0] == socket.AF_INET6 else server)
++
++            remoteserver = ','.join(acc)
++            command = ["mount", '-t', 'ceph', remoteserver + ":" + self.remoteport + ":" + self.remotepath, mountpoint] + options
+             util.ioretry(lambda: util.pread(command), errlist=[errno.EPIPE, errno.EIO], maxretry=2, nofail=True)
+         except util.CommandException as inst:
+             syslog(_syslog.LOG_ERR, 'CephFS mount failed ' + inst.__str__())
+-- 
+2.43.0
+

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -6,7 +6,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.0.10
-Release: 1.2%{?xsrel}%{?dist}
+Release: 1.3%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -67,6 +67,9 @@ Patch1019: 0019-feat-LinstorSR-import-all-8.2-changes.patch
 Patch1020: 0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
 Patch1021: 0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
 Patch1022: 0022-Fix-vdi-ref-when-static-vdis-are-used.patch
+Patch1023: 0023-Repair-coverage-to-be-compatible-with-8.3-test-env.patch
+Patch1024: 0024-Support-IPv6-for-NFS-ISO-SR.patch
+Patch1025: 0025-Support-IPv6-in-Ceph-Driver.patch
 
 %description
 This package contains storage backends used in XCP
@@ -292,6 +295,7 @@ cp -r htmlcov %{buildroot}/htmlcov
 %config /etc/udev/rules.d/57-usb.rules
 %doc CONTRIB LICENSE MAINTAINERS README.md
 # XCP-ng
+/etc/systemd/system/drbd-reactor.service.d/override.conf
 /etc/systemd/system/linstor-satellite.service.d/override.conf
 /etc/systemd/system/var-lib-linstor.service
 /etc/xapi.d/plugins/linstor-manager
@@ -339,6 +343,26 @@ The package contains a fake key lookup plugin for system tests
 /opt/xensource/sm/plugins/keymanagerutil.py*
 
 %changelog
+* Fri Jan 12 2024 Ronan Abhamon <ronan.abhamon@vates.fr> - 3.0.10-1.3
+- Add 0023-Repair-coverage-to-be-compatible-with-8.3-test-env.patch
+- Add 0024-Support-IPv6-for-NFS-ISO-SR.patch
+- Add 0025-Support-IPv6-in-Ceph-Driver.patch
+- Import sm 8.2 LINSTOR fixes on 8.3:
+- Assume VDI is always a VHD when the info is missing during cleanup
+- Remove SR lock during thin attach/detach
+- Ensure database is mounted during scan
+- Restart drbd-reactor in case of failure
+- Retry in case of failure during mkfs call on database
+- Avoid diskless creation when a new resource is added
+- Remove diskless after VDI.detach calls
+- Ignore volumes marked with a DELETED flag in GC
+- Ensure detach never fails on plugin failure
+- Don't try to repair persistent volumes in GC
+- Wait for a "ready" state during attach to open the DRBD path
+- GC support resized volumes
+- Ensure we can deflate on any host after a journal rollback
+- Robustify SR destroy
+
 * Tue Sep 19 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 3.0.10-1.2
 - Import sm 8.2 LINSTOR fixes on 8.3:
 - Ensure we always have a device path during leaf-coalesce calls


### PR DESCRIPTION
    * Import sm 8.2 LINSTOR fixes on 8.3:
    - Assume VDI is always a VHD when the info is missing during cleanup
    - Remove SR lock during thin attach/detach
    - Ensure database is mounted during scan
    - Restart drbd-reactor in case of failure
    - Retry in case of failure during mkfs call on database
    - Avoid diskless creation when a new resource is added
    - Remove diskless after VDI.detach calls
    - Ignore volumes marked with a DELETED flag in GC
    - Ensure detach never fails on plugin failure
    - Don't try to repair persistent volumes in GC
    - Wait for a "ready" state during attach to open the DRBD path
    - GC support resized volumes
    - Ensure we can deflate on any host after a journal rollback
    - Robustify SR destroy
    
    * IPv6 support:
    - Add 0024-Support-IPv6-for-NFS-ISO-SR.patch
    - Add 0025-Support-IPv6-in-Ceph-Driver.patch
    
