### PR TITLE
Update our patches (3.0.12-6.2)

### DIFF
--- a/SOURCES/0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From 2770378e017970f501cbb4ce81af5526e3e28c7a Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 01/25] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 01/26] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0002-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
+++ b/SOURCES/0002-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
@@ -1,7 +1,7 @@
 From 15a733cdd0cdce2d3932c54d93c7f7369f78285a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 02/25] feat(drivers): add CephFS and GlusterFS drivers
+Subject: [PATCH 02/26] feat(drivers): add CephFS and GlusterFS drivers
 
 ---
  Makefile               |   2 +

--- a/SOURCES/0003-feat-drivers-add-XFS-driver.patch
+++ b/SOURCES/0003-feat-drivers-add-XFS-driver.patch
@@ -1,7 +1,7 @@
 From 4bd1b328c5e8f30d879acdb4e7ded8d6be31332b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 03/25] feat(drivers): add XFS driver
+Subject: [PATCH 03/26] feat(drivers): add XFS driver
 
 Originally-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 

--- a/SOURCES/0004-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0004-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From db32b49b94fd70a2faa65b2895537eb0435c9aa3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 04/25] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 04/26] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---

--- a/SOURCES/0005-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0005-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From 56716b3adaee8c1aab9790beec224ce597347cf6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 05/25] feat(drivers): add LinstorSR driver
+Subject: [PATCH 05/26] feat(drivers): add LinstorSR driver
 
 Some important points:
 

--- a/SOURCES/0006-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0006-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From f3756614f6ddba21abf1bb521cc17830b229e0ca Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 06/25] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 06/26] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages

--- a/SOURCES/0007-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0007-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From 2492cd66bad5e99551a1c02d880bb94dfecbc303 Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 07/25] Added SM Driver for MooseFS
+Subject: [PATCH 07/26] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>

--- a/SOURCES/0008-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0008-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From 213f754c4d8050fe2ea9de5fdb4fd945e256b9ed Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 08/25] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 08/26] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir

--- a/SOURCES/0009-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0009-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From a0b9f932891cd8f601b8b086cd9ebb1f3d3a2a59 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 09/25] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 09/26] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior

--- a/SOURCES/0010-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0010-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From 7241c0e43d90bbbbfee692de1e0d70964dec6320 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 10/25] Fix is_open call for many drivers (#25)
+Subject: [PATCH 10/26] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.

--- a/SOURCES/0011-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0011-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From f3a45acf21cfd2e83367c47ee1309e9b5c176065 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 11/25] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 11/26] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.

--- a/SOURCES/0012-Fix-code-coverage-regarding-MooseFSSR-and-ZFSSR-29.patch
+++ b/SOURCES/0012-Fix-code-coverage-regarding-MooseFSSR-and-ZFSSR-29.patch
@@ -1,7 +1,7 @@
 From 38d71654f4860a579e709b02e37ba55aff20b376 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 19 Sep 2022 10:31:00 +0200
-Subject: [PATCH 12/25] Fix code coverage regarding MooseFSSR and ZFSSR (#29)
+Subject: [PATCH 12/26] Fix code coverage regarding MooseFSSR and ZFSSR (#29)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0013-py3-simple-changes-from-futurize-on-XCP-ng-drivers.patch
+++ b/SOURCES/0013-py3-simple-changes-from-futurize-on-XCP-ng-drivers.patch
@@ -1,7 +1,7 @@
 From 884fb8f43566e4ba4a8379d5e42215c748fa7f8f Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:13:18 +0100
-Subject: [PATCH 13/25] py3: simple changes from futurize on XCP-ng drivers
+Subject: [PATCH 13/26] py3: simple changes from futurize on XCP-ng drivers
 
 * `except` syntax fixes
 * drop `has_key()` usage

--- a/SOURCES/0014-py3-futurize-fix-of-xmlrpc-calls-for-CephFS-GlusterF.patch
+++ b/SOURCES/0014-py3-futurize-fix-of-xmlrpc-calls-for-CephFS-GlusterF.patch
@@ -1,7 +1,7 @@
 From 732a4b6e07758c4692f8c6580f06ccd29b5c88f5 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:28:10 +0100
-Subject: [PATCH 14/25] py3: futurize fix of xmlrpc calls for CephFS,
+Subject: [PATCH 14/26] py3: futurize fix of xmlrpc calls for CephFS,
  GlusterFS, MooseFS, Linstore
 
 Signed-off-by: Yann Dirson <yann.dirson@vates.fr>

--- a/SOURCES/0015-py3-use-of-integer-division-operator.patch
+++ b/SOURCES/0015-py3-use-of-integer-division-operator.patch
@@ -1,7 +1,7 @@
 From 6a1e48693309aa2810257a936b30645d680ea33e Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 10:32:37 +0100
-Subject: [PATCH 15/25] py3: use of integer division operator
+Subject: [PATCH 15/26] py3: use of integer division operator
 
 Guided by futurize's "old_div" use
 

--- a/SOURCES/0016-test_on_slave-allow-to-work-with-SR-using-absolute-P.patch
+++ b/SOURCES/0016-test_on_slave-allow-to-work-with-SR-using-absolute-P.patch
@@ -1,7 +1,7 @@
 From 625f31df8829632549002c4a7ad9d012e9389523 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 8 Mar 2023 13:53:21 +0100
-Subject: [PATCH 16/25] test_on_slave: allow to work with SR using absolute
+Subject: [PATCH 16/26] test_on_slave: allow to work with SR using absolute
  PROBE_MOUNTPOINT
 
 PROBE_MOUNTPOINT in a some drivers is a relative path, which is resolved

--- a/SOURCES/0017-py3-switch-interpreter-to-python3.patch
+++ b/SOURCES/0017-py3-switch-interpreter-to-python3.patch
@@ -1,7 +1,7 @@
 From 2a1076fecd826da3a62e051e3b20bd792cc7cb9a Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Mon, 27 Mar 2023 15:30:46 +0200
-Subject: [PATCH 17/25] py3: switch interpreter to python3
+Subject: [PATCH 17/26] py3: switch interpreter to python3
 
 ---
  drivers/CephFSSR.py             | 2 +-

--- a/SOURCES/0018-Support-recent-version-of-coverage-tool.patch
+++ b/SOURCES/0018-Support-recent-version-of-coverage-tool.patch
@@ -1,7 +1,7 @@
 From ad4ae9e8c2f9e03d3bd97348f0254e4ede25aca2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 4 May 2023 10:24:22 +0200
-Subject: [PATCH 18/25] Support recent version of coverage tool (coverage
+Subject: [PATCH 18/26] Support recent version of coverage tool (coverage
  7.2.5)
 
 Without these changes many warns/errors are emitted:

--- a/SOURCES/0019-feat-LinstorSR-import-all-8.2-changes.patch
+++ b/SOURCES/0019-feat-LinstorSR-import-all-8.2-changes.patch
@@ -1,18 +1,18 @@
-From 600ee689dec6285e70d6288b00ffbc030782485b Mon Sep 17 00:00:00 2001
+From 7eca02d94205d85bc4ff4b8a9a5b56ec51ef5539 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 20 Nov 2020 16:42:52 +0100
-Subject: [PATCH 19/25] feat(LinstorSR): import all 8.2 changes
+Subject: [PATCH 19/26] feat(LinstorSR): import all 8.2 changes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
  Makefile                                      |   13 +
- drivers/LinstorSR.py                          | 1453 ++++++++---
- drivers/blktap2.py                            |   23 +-
+ drivers/LinstorSR.py                          | 1463 ++++++++---
+ drivers/blktap2.py                            |   45 +-
  drivers/cleanup.py                            |  351 ++-
  drivers/linstor-manager                       |  941 ++++++-
  drivers/linstorjournaler.py                   |   48 +-
  drivers/linstorvhdutil.py                     |  480 +++-
- drivers/linstorvolumemanager.py               | 2244 +++++++++++++----
+ drivers/linstorvolumemanager.py               | 2336 +++++++++++++----
  drivers/on_slave.py                           |   23 +-
  drivers/tapdisk-pause                         |    8 +-
  drivers/util.py                               |  125 +-
@@ -26,7 +26,7 @@ Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
  scripts/linstor-kv-tool                       |   84 +
  scripts/safe-umount                           |   39 +
  tests/test_on_slave.py                        |   10 +-
- 21 files changed, 5054 insertions(+), 1061 deletions(-)
+ 21 files changed, 5127 insertions(+), 1112 deletions(-)
  create mode 100644 etc/systemd/system/drbd-reactor.service.d/override.conf
  create mode 100644 etc/systemd/system/linstor-satellite.service.d/override.conf
  create mode 100644 etc/systemd/system/var-lib-linstor.service
@@ -80,7 +80,7 @@ index 6f35949..701dd1f 100755
  	install -m 755 scripts/check-device-sharing $(SM_STAGING)$(LIBEXEC)
  	install -m 755 scripts/usb_change $(SM_STAGING)$(LIBEXEC)
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index a72d43e..c770dc7 100755
+index a72d43e..94591f0 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
 @@ -19,25 +19,39 @@ from constants import CBTLOG_TAG
@@ -488,7 +488,7 @@ index a72d43e..c770dc7 100755
 -                    )
 +        def load(self, *args, **kwargs):
 +            # Activate all LVMs to make drbd-reactor happy.
-+            if self.srcmd.cmd == 'sr_attach':
++            if self.srcmd.cmd in ('sr_attach', 'vdi_attach_from_config'):
 +                activate_lvm_group(self._group_name)
  
 -                    try:
@@ -506,15 +506,15 @@ index a72d43e..c770dc7 100755
 +                            uri,
                              self._group_name,
 -                            logger=util.SMlog
-+                            logger=util.SMlog,
-+                            attempt_count=attempt_count
-                         )
+-                        )
 -                        return
 -                    except Exception as e:
 -                        util.SMlog(
 -                            'Ignore exception. Failed to build LINSTOR '
 -                            'instance without session: {}'.format(e)
--                        )
++                            logger=util.SMlog,
++                            attempt_count=attempt_count
+                         )
 -                return
 +                        # Only required if we are attaching from config using a non-special VDI.
 +                        # I.e. not an HA volume.
@@ -567,14 +567,14 @@ index a72d43e..c770dc7 100755
 -            self._journaler = LinstorJournaler(
 -                self._master_uri, self._group_name, logger=util.SMlog
 -            )
--
++                    self._vdi_shared_time = time.time()
+ 
 -            # Ensure ports are opened and LINSTOR controller/satellite
 -            # are activated.
 -            if self.srcmd.cmd == 'sr_create':
 -                # TODO: Disable if necessary
 -                self._enable_linstor_on_all_hosts(status=True)
-+                    self._vdi_shared_time = time.time()
- 
+-
 -            try:
 -                # Try to open SR if exists.
 -                self._linstor = LinstorVolumeManager(
@@ -801,9 +801,7 @@ index a72d43e..c770dc7 100755
 +                if r_name == node_name:
 +                    host = slave
 +                    break
- 
--            self._linstor.destroy()
--            Lock.cleanupAll(self.uuid)
++
 +        if not host:
 +            raise xs_errors.XenError(
 +                'LinstorSRDelete',
@@ -811,7 +809,9 @@ index a72d43e..c770dc7 100755
 +                    node_name
 +                )
 +            )
-+
+ 
+-            self._linstor.destroy()
+-            Lock.cleanupAll(self.uuid)
 +        try:
 +            self._update_drbd_reactor_on_all_hosts(
 +                controller_node_name=node_name, enabled=False
@@ -1078,18 +1078,18 @@ index a72d43e..c770dc7 100755
 -        # Physical size contains the total physical size.
 -        # i.e. the sum of the sizes of all devices on all hosts, not the AVG.
 -        self.physical_size = self._linstor.physical_size
+-
+-        # `self._linstor.physical_free_size` contains the total physical free
+-        # memory. If Thin provisioning is used we can't use it, we must use
+-        # LINSTOR volume size to gives a good idea of the required
+-        # usable memory to the users.
+-        self.physical_utilisation = self._linstor.total_allocated_volume_size
 +        # We use the size of the smallest disk, this is an approximation that
 +        # ensures the displayed physical size is reachable by the user.
 +        (min_physical_size, pool_count) = self._linstor.get_min_physical_size()
 +        self.physical_size = min_physical_size * pool_count / \
 +            self._linstor.redundancy
  
--        # `self._linstor.physical_free_size` contains the total physical free
--        # memory. If Thin provisioning is used we can't use it, we must use
--        # LINSTOR volume size to gives a good idea of the required
--        # usable memory to the users.
--        self.physical_utilisation = self._linstor.total_allocated_volume_size
--
 -        # If Thick provisioning is used, we can use this line instead:
 -        # self.physical_utilisation = \
 -        #     self.physical_size - self._linstor.physical_free_size
@@ -1457,16 +1457,13 @@ index a72d43e..c770dc7 100755
              self.sr.srcmd.params['vdi_uuid'] != self.uuid
          ) and self.sr._journaler.has_entries(self.uuid):
              raise xs_errors.XenError(
-@@ -1423,56 +1790,87 @@ class LinstorVDI(VDI.VDI):
+@@ -1423,56 +1790,62 @@ class LinstorVDI(VDI.VDI):
                  'scan SR first to trigger auto-repair'
              )
  
 -        writable = 'args' not in self.sr.srcmd.params or \
 -            self.sr.srcmd.params['args'][0] == 'true'
-+        if not attach_from_config or self.sr._is_master:
-+            writable = 'args' not in self.sr.srcmd.params or \
-+                self.sr.srcmd.params['args'][0] == 'true'
- 
+-
 -        # We need to inflate the volume if we don't have enough place
 -        # to mount the VHD image. I.e. the volume capacity must be greater
 -        # than the VHD size + bitmap size.
@@ -1474,7 +1471,10 @@ index a72d43e..c770dc7 100755
 -        if self.vdi_type == vhdutil.VDI_TYPE_RAW or not writable or \
 -                self.capacity >= compute_volume_size(self.size, self.vdi_type):
 -            need_inflate = False
--
++        if not attach_from_config or self.sr._is_master:
++            writable = 'args' not in self.sr.srcmd.params or \
++                self.sr.srcmd.params['args'][0] == 'true'
+ 
 -        if need_inflate:
 -            try:
 -                self._prepare_thin(True)
@@ -1523,35 +1523,10 @@ index a72d43e..c770dc7 100755
 +            self.path.startswith('/dev/http-nbd/')
 +        ):
 +            return self._attach_using_http_nbd()
-+
-+        # Ensure we have a path...
-+        while vdi_uuid:
-+            path = self._linstor.get_device_path(vdi_uuid)
-+            if not util.pathexists(path):
-+                raise xs_errors.XenError(
-+                    'VDIUnavailable', opterr='Could not find: {}'.format(path)
-+                )
  
 -        self.xenstore_data['storage-type'] = LinstorSR.DRIVER_TYPE
-+            # Diskless path can be created on the fly, ensure we can open it.
-+            def check_volume_usable():
-+                while True:
-+                    try:
-+                        with open(path, 'r+'):
-+                            pass
-+                    except IOError as e:
-+                        if e.errno == errno.ENODATA:
-+                            time.sleep(2)
-+                            continue
-+                        if e.errno == errno.EROFS:
-+                            util.SMlog('Volume not attachable because RO. Openers: {}'.format(
-+                                self.sr._linstor.get_volume_openers(vdi_uuid)
-+                            ))
-+                        raise
-+                    break
-+            util.retry(check_volume_usable, 15, 2)
-+
-+            vdi_uuid = self.sr._vhdutil.get_vhd_info(vdi_uuid).parentUuid
++        # Ensure we have a path...
++        self._create_chain_paths(self.uuid)
  
          self.attached = True
 -
@@ -1575,7 +1550,7 @@ index a72d43e..c770dc7 100755
          already_deflated = self.capacity <= volume_size
  
          if already_deflated:
-@@ -1501,11 +1899,45 @@ class LinstorVDI(VDI.VDI):
+@@ -1501,11 +1874,45 @@ class LinstorVDI(VDI.VDI):
                      .format(e)
                  )
  
@@ -1621,7 +1596,7 @@ index a72d43e..c770dc7 100755
          if size < self.size:
              util.SMlog(
                  'vdi_resize: shrinking not supported: '
-@@ -1513,36 +1945,34 @@ class LinstorVDI(VDI.VDI):
+@@ -1513,36 +1920,34 @@ class LinstorVDI(VDI.VDI):
              )
              raise xs_errors.XenError('VDISize', opterr='shrinking not allowed')
  
@@ -1656,8 +1631,9 @@ index a72d43e..c770dc7 100755
          else:
              if new_volume_size != old_volume_size:
 -                inflate(
+-                    self.sr._journaler, self._linstor, self.uuid, self.path,
 +                self.sr._vhdutil.inflate(
-                     self.sr._journaler, self._linstor, self.uuid, self.path,
++                    self.sr._journaler, self.uuid, self.path,
                      new_volume_size, old_volume_size
                  )
 -            vhdutil.setSizeVirtFast(self.path, size)
@@ -1665,7 +1641,7 @@ index a72d43e..c770dc7 100755
  
          # Reload size attributes.
          self._load_this()
-@@ -1552,7 +1982,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1552,7 +1957,7 @@ class LinstorVDI(VDI.VDI):
          self.session.xenapi.VDI.set_physical_utilisation(
              vdi_ref, str(self.utilisation)
          )
@@ -1674,7 +1650,7 @@ index a72d43e..c770dc7 100755
          return VDI.VDI.get_params(self)
  
      def clone(self, sr_uuid, vdi_uuid):
-@@ -1574,8 +2004,8 @@ class LinstorVDI(VDI.VDI):
+@@ -1574,8 +1979,8 @@ class LinstorVDI(VDI.VDI):
          if not blktap2.VDI.tap_pause(self.session, self.sr.uuid, self.uuid):
              raise util.SMException('Failed to pause VDI {}'.format(self.uuid))
          try:
@@ -1685,7 +1661,7 @@ index a72d43e..c770dc7 100755
              self.sr.session.xenapi.VDI.set_managed(
                  self.sr.srcmd.params['args'][0], False
              )
-@@ -1598,25 +2028,40 @@ class LinstorVDI(VDI.VDI):
+@@ -1598,25 +2003,40 @@ class LinstorVDI(VDI.VDI):
  
          util.SMlog('LinstorVDI.generate_config for {}'.format(self.uuid))
  
@@ -1738,7 +1714,7 @@ index a72d43e..c770dc7 100755
          config = xmlrpc.client.dumps(tuple([resp]), 'vdi_attach_from_config')
          return xmlrpc.client.dumps((config,), "", True)
  
-@@ -1652,19 +2097,28 @@ class LinstorVDI(VDI.VDI):
+@@ -1652,19 +2072,28 @@ class LinstorVDI(VDI.VDI):
                  .format(self.uuid)
              )
  
@@ -1772,7 +1748,7 @@ index a72d43e..c770dc7 100755
          self.capacity = volume_info.virtual_size
  
          if self.vdi_type == vhdutil.VDI_TYPE_RAW:
-@@ -1691,7 +2145,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1691,7 +2120,7 @@ class LinstorVDI(VDI.VDI):
              return
  
          if self.vdi_type == vhdutil.VDI_TYPE_VHD:
@@ -1781,7 +1757,7 @@ index a72d43e..c770dc7 100755
          else:
              self._linstor.update_volume_metadata(self.uuid, {
                  HIDDEN_TAG: hidden
-@@ -1739,25 +2193,19 @@ class LinstorVDI(VDI.VDI):
+@@ -1739,25 +2168,19 @@ class LinstorVDI(VDI.VDI):
          else:
              fn = 'attach' if attach else 'detach'
  
@@ -1815,7 +1791,7 @@ index a72d43e..c770dc7 100755
  
          # Reload size attrs after inflate or deflate!
          self._load_this()
-@@ -1807,9 +2255,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1807,9 +2230,7 @@ class LinstorVDI(VDI.VDI):
                  'VDIUnavailable',
                  opterr='failed to get vdi_type in metadata'
              )
@@ -1826,7 +1802,7 @@ index a72d43e..c770dc7 100755
  
      def _update_device_name(self, device_name):
          self._device_name = device_name
-@@ -1832,7 +2278,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1832,7 +2253,7 @@ class LinstorVDI(VDI.VDI):
  
          # 2. Write the snapshot content.
          is_raw = (self.vdi_type == vhdutil.VDI_TYPE_RAW)
@@ -1835,7 +1811,7 @@ index a72d43e..c770dc7 100755
              snap_path, self.path, is_raw, self.MAX_METADATA_VIRT_SIZE
          )
  
-@@ -1862,7 +2308,7 @@ class LinstorVDI(VDI.VDI):
+@@ -1862,7 +2283,7 @@ class LinstorVDI(VDI.VDI):
          volume_info = self._linstor.get_volume_info(snap_uuid)
  
          snap_vdi.size = self.sr._vhdutil.get_size_virt(snap_uuid)
@@ -1844,17 +1820,17 @@ index a72d43e..c770dc7 100755
  
          # 6. Update sm config.
          snap_vdi.sm_config = {}
-@@ -1932,6 +2378,9 @@ class LinstorVDI(VDI.VDI):
+@@ -1932,6 +2353,9 @@ class LinstorVDI(VDI.VDI):
          elif depth >= vhdutil.MAX_CHAIN_SIZE:
              raise xs_errors.XenError('SnapshotChainTooLong')
  
 +        # Ensure we have a valid path if we don't have a local diskful.
-+        self.sr._linstor.get_device_path(self.uuid)
++        self._create_chain_paths(self.uuid)
 +
          volume_path = self.path
          if not util.pathexists(volume_path):
              raise xs_errors.XenError(
-@@ -2057,7 +2506,7 @@ class LinstorVDI(VDI.VDI):
+@@ -2057,7 +2481,7 @@ class LinstorVDI(VDI.VDI):
                      raise
  
              if snap_type != VDI.SNAPSHOT_INTERNAL:
@@ -1863,7 +1839,16 @@ index a72d43e..c770dc7 100755
  
              # 10. Return info on the new user-visible leaf VDI.
              ret_vdi = snap_vdi
-@@ -2088,10 +2537,318 @@ class LinstorVDI(VDI.VDI):
+@@ -2070,7 +2494,7 @@ class LinstorVDI(VDI.VDI):
+             self.session.xenapi.VDI.set_sm_config(
+                 vdi_ref, active_vdi.sm_config
+             )
+-        except Exception as e:
++        except Exception:
+             util.logException('Failed to snapshot!')
+             try:
+                 self.sr._handle_interrupted_clone(
+@@ -2088,10 +2512,349 @@ class LinstorVDI(VDI.VDI):
  
          return ret_vdi.get_params()
  
@@ -2169,6 +2154,37 @@ index a72d43e..c770dc7 100755
 +        self._kill_persistent_nbd_server(volume_name)
 +        self._kill_persistent_http_server(volume_name)
 +
++    def _create_chain_paths(self, vdi_uuid):
++        # OPTIMIZE: Add a limit_to_first_allocated_block param to limit vhdutil calls.
++        # Useful for the snapshot code algorithm.
++
++        while vdi_uuid:
++            path = self._linstor.get_device_path(vdi_uuid)
++            if not util.pathexists(path):
++                raise xs_errors.XenError(
++                    'VDIUnavailable', opterr='Could not find: {}'.format(path)
++                )
++
++            # Diskless path can be created on the fly, ensure we can open it.
++            def check_volume_usable():
++                while True:
++                    try:
++                        with open(path, 'r+'):
++                            pass
++                    except IOError as e:
++                        if e.errno == errno.ENODATA:
++                            time.sleep(2)
++                            continue
++                        if e.errno == errno.EROFS:
++                            util.SMlog('Volume not attachable because RO. Openers: {}'.format(
++                                self.sr._linstor.get_volume_openers(vdi_uuid)
++                            ))
++                        raise
++                    break
++            util.retry(check_volume_usable, 15, 2)
++
++            vdi_uuid = self.sr._vhdutil.get_vhd_info(vdi_uuid).parentUuid
++
  # ------------------------------------------------------------------------------
  
  
@@ -2184,7 +2200,7 @@ index a72d43e..c770dc7 100755
  else:
      SR.registerSR(LinstorSR)
 diff --git a/drivers/blktap2.py b/drivers/blktap2.py
-index 6fda56a..e853c38 100755
+index 6fda56a..4896a1f 100755
 --- a/drivers/blktap2.py
 +++ b/drivers/blktap2.py
 @@ -50,6 +50,12 @@ import VDI as sm
@@ -2224,6 +2240,40 @@ index 6fda56a..e853c38 100755
                      try:
                          tapdisk = cls.__from_blktap(blktap)
                          node = '/sys/dev/block/%d:%d' % (tapdisk.major(), tapdisk.minor)
+@@ -1602,20 +1623,24 @@ class VDI(object):
+         """Wraps target.activate and adds a tapdisk"""
+ 
+         #util.SMlog("VDI.activate %s" % vdi_uuid)
++        refresh = False
+         if self.tap_wanted():
+             if not self._add_tag(vdi_uuid, not options["rdonly"]):
+                 return False
+-            # it is possible that while the VDI was paused some of its
+-            # attributes have changed (e.g. its size if it was inflated; or its
+-            # path if it was leaf-coalesced onto a raw LV), so refresh the
+-            # object completely
+-            params = self.target.vdi.sr.srcmd.params
+-            target = sm.VDI.from_uuid(self.target.vdi.session, vdi_uuid)
+-            target.sr.srcmd.params = params
+-            driver_info = target.sr.srcmd.driver_info
+-            self.target = self.TargetDriver(target, driver_info)
++            refresh = True
+ 
+         try:
++            if refresh:
++                # it is possible that while the VDI was paused some of its
++                # attributes have changed (e.g. its size if it was inflated; or its
++                # path if it was leaf-coalesced onto a raw LV), so refresh the
++                # object completely
++                params = self.target.vdi.sr.srcmd.params
++                target = sm.VDI.from_uuid(self.target.vdi.session, vdi_uuid)
++                target.sr.srcmd.params = params
++                driver_info = target.sr.srcmd.driver_info
++                self.target = self.TargetDriver(target, driver_info)
++
+             util.fistpoint.activate_custom_fn(
+                     "blktap_activate_inject_failure",
+                     lambda: util.inject_failure())
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
 index 1d8da7b..1768e27 100755
 --- a/drivers/cleanup.py
@@ -4540,7 +4590,7 @@ index 7a13566..836f4ce 100644
 +                opterr='Failed to zero out VHD footer {}'.format(path)
 +            )
 diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
-index 182b889..dc810e5 100755
+index 182b889..5e5bcd5 100755
 --- a/drivers/linstorvolumemanager.py
 +++ b/drivers/linstorvolumemanager.py
 @@ -16,14 +16,104 @@
@@ -5219,17 +5269,46 @@ index 182b889..dc810e5 100755
      def introduce_volume(self, volume_uuid):
          pass  # TODO: Implement me.
  
-@@ -542,6 +831,9 @@ class LinstorVolumeManager(object):
-             volume_nr=0,
-             size=new_size // 1024
-         )
+@@ -535,15 +824,30 @@ class LinstorVolumeManager(object):
+ 
+         volume_name = self.get_volume_name(volume_uuid)
+         self.ensure_volume_is_not_locked(volume_uuid)
+-        new_size = self.round_up_volume_size(new_size)
++        new_size = self.round_up_volume_size(new_size) // 1024
 +
-+        self._mark_resource_cache_as_dirty()
++        retry_count = 30
++        while True:
++            result = self._linstor.volume_dfn_modify(
++                rsc_name=volume_name,
++                volume_nr=0,
++                size=new_size
++            )
 +
-         error_str = self._get_error_str(result)
-         if error_str:
++            self._mark_resource_cache_as_dirty()
++
++            error_str = self._get_error_str(result)
++            if not error_str:
++                break
++
++            # After volume creation, DRBD volume can be unusable during many seconds.
++            # So we must retry the definition change if the device is not up to date.
++            # Often the case for thick provisioning.
++            if retry_count and error_str.find('non-UpToDate DRBD device') >= 0:
++                time.sleep(2)
++                retry_count -= 1
++                continue
+ 
+-        result = self._linstor.volume_dfn_modify(
+-            rsc_name=volume_name,
+-            volume_nr=0,
+-            size=new_size // 1024
+-        )
+-        error_str = self._get_error_str(result)
+-        if error_str:
              raise LinstorVolumeManagerError(
-@@ -587,6 +879,24 @@ class LinstorVolumeManager(object):
+                 'Could not resize volume `{}` from SR `{}`: {}'
+                 .format(volume_uuid, self._group_name, error_str)
+@@ -587,6 +891,24 @@ class LinstorVolumeManager(object):
              )
          return size * 1024
  
@@ -5254,7 +5333,7 @@ index 182b889..dc810e5 100755
      def get_volume_info(self, volume_uuid):
          """
          Get the volume info of a particular volume.
-@@ -596,11 +906,11 @@ class LinstorVolumeManager(object):
+@@ -596,11 +918,11 @@ class LinstorVolumeManager(object):
          """
  
          volume_name = self.get_volume_name(volume_uuid)
@@ -5268,7 +5347,7 @@ index 182b889..dc810e5 100755
          :param str volume_uuid: The volume uuid to get the dev path.
          :return: The current device path of the volume.
          :rtype: str
-@@ -620,7 +930,7 @@ class LinstorVolumeManager(object):
+@@ -620,7 +942,7 @@ class LinstorVolumeManager(object):
          expected_volume_name = \
              self.get_volume_name_from_device_path(device_path)
  
@@ -5277,7 +5356,7 @@ index 182b889..dc810e5 100755
          for volume_uuid, volume_name in volume_names.items():
              if volume_name == expected_volume_name:
                  return volume_uuid
-@@ -631,26 +941,24 @@ class LinstorVolumeManager(object):
+@@ -631,26 +953,24 @@ class LinstorVolumeManager(object):
  
      def get_volume_name_from_device_path(self, device_path):
          """
@@ -5317,16 +5396,16 @@ index 182b889..dc810e5 100755
  
      def update_volume_uuid(self, volume_uuid, new_volume_uuid, force=False):
          """
-@@ -664,6 +972,8 @@ class LinstorVolumeManager(object):
-         deleted VDI.
-         """
- 
-+        assert volume_uuid != new_volume_uuid
-+
-         self._logger(
+@@ -668,6 +988,8 @@ class LinstorVolumeManager(object):
              'Trying to update volume UUID {} to {}...'
              .format(volume_uuid, new_volume_uuid)
-@@ -685,36 +995,45 @@ class LinstorVolumeManager(object):
+         )
++        assert volume_uuid != new_volume_uuid, 'can\'t update volume UUID, same value'
++
+         if not force:
+             self._ensure_volume_exists(volume_uuid)
+         self.ensure_volume_is_not_locked(volume_uuid)
+@@ -685,36 +1007,45 @@ class LinstorVolumeManager(object):
                  .format(volume_uuid)
              )
  
@@ -5388,7 +5467,7 @@ index 182b889..dc810e5 100755
              except Exception as e:
                  self._logger(
                      'Failed to clear new volume properties: {} (ignoring...)'
-@@ -725,11 +1044,21 @@ class LinstorVolumeManager(object):
+@@ -725,11 +1056,21 @@ class LinstorVolumeManager(object):
              )
  
          try:
@@ -5412,7 +5491,7 @@ index 182b889..dc810e5 100755
          except Exception as e:
              raise LinstorVolumeManagerError(
                  'Failed to clear volume properties '
-@@ -743,7 +1072,7 @@ class LinstorVolumeManager(object):
+@@ -743,7 +1084,7 @@ class LinstorVolumeManager(object):
              'UUID update succeeded of {} to {}! (properties={})'
              .format(
                  volume_uuid, new_volume_uuid,
@@ -5421,36 +5500,71 @@ index 182b889..dc810e5 100755
              )
          )
  
-@@ -788,6 +1117,72 @@ class LinstorVolumeManager(object):
+@@ -788,55 +1129,121 @@ class LinstorVolumeManager(object):
  
          return states
  
+-    def get_volume_metadata(self, volume_uuid):
 +    def get_volume_openers(self, volume_uuid):
-+        """
+         """
+-        Get the metadata of a volume.
+-        :return: Dictionary that contains metadata.
+-        :rtype: dict
 +        Get openers of a volume.
 +        :param str volume_uuid: The volume uuid to monitor.
 +        :return: A dictionnary that contains openers.
 +        :rtype: dict(str, obj)
-+        """
+         """
 +        return get_all_volume_openers(self.get_volume_name(volume_uuid), '0')
-+
+ 
+-        self._ensure_volume_exists(volume_uuid)
+-        volume_properties = self._get_volume_properties(volume_uuid)
+-        metadata = volume_properties.get(self.PROP_METADATA)
+-        if metadata:
+-            metadata = json.loads(metadata)
+-            if isinstance(metadata, dict):
+-                return metadata
+-            raise LinstorVolumeManagerError(
+-                'Expected dictionary in volume metadata: {}'
+-                .format(volume_uuid)
+-            )
+-        return {}
+-
+-    def set_volume_metadata(self, volume_uuid, metadata):
 +    def get_volumes_with_name(self):
-+        """
+         """
+-        Set the metadata of a volume.
+-        :param dict metadata: Dictionary that contains metadata.
 +        Give a volume dictionnary that contains names actually owned.
 +        :return: A volume/name dict.
 +        :rtype: dict(str, str)
-+        """
+         """
 +        return self._get_volumes_by_property(self.REG_VOLUME_NAME)
-+
+ 
+-        self._ensure_volume_exists(volume_uuid)
+-        self.ensure_volume_is_not_locked(volume_uuid)
+-
+-        assert isinstance(metadata, dict)
+-        volume_properties = self._get_volume_properties(volume_uuid)
+-        volume_properties[self.PROP_METADATA] = json.dumps(metadata)
+-
+-    def update_volume_metadata(self, volume_uuid, metadata):
 +    def get_volumes_with_info(self):
-+        """
+         """
+-        Update the metadata of a volume. It modify only the given keys.
+-        It doesn't remove unreferenced key instead of set_volume_metadata.
+-        :param dict metadata: Dictionary that contains metadata.
 +        Give a volume dictionnary that contains VolumeInfos.
 +        :return: A volume/VolumeInfo dict.
 +        :rtype: dict(str, VolumeInfo)
-+        """
-+
+         """
+ 
+-        self._ensure_volume_exists(volume_uuid)
+-        self.ensure_volume_is_not_locked(volume_uuid)
 +        volumes = {}
-+
+ 
+-        assert isinstance(metadata, dict)
+-        volume_properties = self._get_volume_properties(volume_uuid)
 +        all_volume_info = self._get_volumes_info()
 +        volume_names = self.get_volumes_with_name()
 +        for volume_uuid, volume_name in volume_names.items():
@@ -5459,7 +5573,10 @@ index 182b889..dc810e5 100755
 +                if volume_info:
 +                    volumes[volume_uuid] = volume_info
 +                    continue
-+
+ 
+-        current_metadata = json.loads(
+-            volume_properties.get(self.PROP_METADATA, '{}')
+-        )
 +            # Well I suppose if this volume is not available,
 +            # LINSTOR has been used directly without using this API.
 +            volumes[volume_uuid] = self.VolumeInfo('')
@@ -5491,10 +5608,59 @@ index 182b889..dc810e5 100755
 +
 +        return volumes
 +
-     def get_volume_metadata(self, volume_uuid):
-         """
-         Get the metadata of a volume.
-@@ -850,8 +1245,7 @@ class LinstorVolumeManager(object):
++    def get_volume_metadata(self, volume_uuid):
++        """
++        Get the metadata of a volume.
++        :return: Dictionary that contains metadata.
++        :rtype: dict
++        """
++
++        self._ensure_volume_exists(volume_uuid)
++        volume_properties = self._get_volume_properties(volume_uuid)
++        metadata = volume_properties.get(self.PROP_METADATA)
++        if metadata:
++            metadata = json.loads(metadata)
++            if isinstance(metadata, dict):
++                return metadata
++            raise LinstorVolumeManagerError(
++                'Expected dictionary in volume metadata: {}'
++                .format(volume_uuid)
++            )
++        return {}
++
++    def set_volume_metadata(self, volume_uuid, metadata):
++        """
++        Set the metadata of a volume.
++        :param dict metadata: Dictionary that contains metadata.
++        """
++
++        self._ensure_volume_exists(volume_uuid)
++        self.ensure_volume_is_not_locked(volume_uuid)
++
++        assert isinstance(metadata, dict)
++        volume_properties = self._get_volume_properties(volume_uuid)
++        volume_properties[self.PROP_METADATA] = json.dumps(metadata)
++
++    def update_volume_metadata(self, volume_uuid, metadata):
++        """
++        Update the metadata of a volume. It modify only the given keys.
++        It doesn't remove unreferenced key instead of set_volume_metadata.
++        :param dict metadata: Dictionary that contains metadata.
++        """
++
++        self._ensure_volume_exists(volume_uuid)
++        self.ensure_volume_is_not_locked(volume_uuid)
++
++        assert isinstance(metadata, dict)
++        volume_properties = self._get_volume_properties(volume_uuid)
++
++        current_metadata = json.loads(
++            volume_properties.get(self.PROP_METADATA, '{}')
++        )
+         if not isinstance(metadata, dict):
+             raise LinstorVolumeManagerError(
+                 'Expected dictionary in volume metadata: {}'
+@@ -850,8 +1257,7 @@ class LinstorVolumeManager(object):
      def shallow_clone_volume(self, volume_uuid, clone_uuid, persistent=True):
          """
          Clone a volume. Do not copy the data, this method creates a new volume
@@ -5504,7 +5670,7 @@ index 182b889..dc810e5 100755
          :param str volume_uuid: The volume to clone.
          :param str clone_uuid: The cloned volume.
          :param bool persistent: If false the volume will be unavailable
-@@ -872,98 +1266,8 @@ class LinstorVolumeManager(object):
+@@ -872,98 +1278,8 @@ class LinstorVolumeManager(object):
                  'Invalid size of {} for volume `{}`'.format(size, volume_name)
              )
  
@@ -5605,7 +5771,7 @@ index 182b889..dc810e5 100755
  
      def remove_resourceless_volumes(self):
          """
-@@ -974,83 +1278,461 @@ class LinstorVolumeManager(object):
+@@ -974,83 +1290,461 @@ class LinstorVolumeManager(object):
          """
  
          resource_names = self._fetch_resource_names()
@@ -5631,9 +5797,7 @@ index 182b889..dc810e5 100755
 +                'Cannot destroy LINSTOR volume manager: '
 +                'It exists remaining volumes'
 +            )
- 
--        # TODO: Throw exceptions in the helpers below if necessary.
--        # TODO: What's the required action if it exists remaining volumes?
++
 +        # 2. Fetch ALL resource names.
 +        # This list may therefore contain volumes created outside
 +        # the scope of the driver.
@@ -5665,7 +5829,9 @@ index 182b889..dc810e5 100755
 +                mount=False,
 +                force=True
 +            )
-+
+ 
+-        # TODO: Throw exceptions in the helpers below if necessary.
+-        # TODO: What's the required action if it exists remaining volumes?
 +            # 4.2. Refresh instance.
 +            self._start_controller(start=True)
 +            self._linstor = self._create_linstor_instance(
@@ -5798,7 +5964,8 @@ index 182b889..dc810e5 100755
 +            raise LinstorVolumeManagerError(
 +                'Failed to destroy node `{}`: {}'.format(node_name, error_str)
 +            )
-+
+ 
+-        return (node_names, in_use)
 +    def create_node_interface(self, node_name, name, ip):
 +        """
 +        Create a new node interface in the LINSTOR database.
@@ -5901,8 +6068,7 @@ index 182b889..dc810e5 100755
 +            raise LinstorVolumeManagerError(
 +                'Failed to get all nodes: `{}`'.format(e)
 +            )
- 
--        return (node_names, in_use)
++
 +    def get_storage_pools_info(self):
 +        """
 +        Give all storage pools of current group name.
@@ -6098,7 +6264,7 @@ index 182b889..dc810e5 100755
          pools = pools.storage_pools
          if pools:
              existing_node_names = [pool.node_name for pool in pools]
-@@ -1062,10 +1744,18 @@ class LinstorVolumeManager(object):
+@@ -1062,10 +1756,18 @@ class LinstorVolumeManager(object):
          if lin.resource_group_list_raise(
              [group_name]
          ).resource_groups:
@@ -6121,7 +6287,7 @@ index 182b889..dc810e5 100755
  
          if thin_provisioning:
              driver_pool_parts = driver_pool_name.split('/')
-@@ -1076,9 +1766,14 @@ class LinstorVolumeManager(object):
+@@ -1076,9 +1778,14 @@ class LinstorVolumeManager(object):
                  )
  
          # 2. Create storage pool on each node + resource group.
@@ -6136,7 +6302,7 @@ index 182b889..dc810e5 100755
              while i < len(node_names):
                  node_name = node_names[i]
  
-@@ -1089,32 +1784,63 @@ class LinstorVolumeManager(object):
+@@ -1089,32 +1796,63 @@ class LinstorVolumeManager(object):
                      driver_pool_name=driver_pool_name
                  )
  
@@ -6219,7 +6385,7 @@ index 182b889..dc810e5 100755
              # 2.c. Create volume group.
              result = lin.volume_group_create(group_name)
              error_str = cls._get_error_str(result)
-@@ -1125,30 +1851,78 @@ class LinstorVolumeManager(object):
+@@ -1125,30 +1863,78 @@ class LinstorVolumeManager(object):
                      )
                  )
  
@@ -6303,7 +6469,7 @@ index 182b889..dc810e5 100755
          return instance
  
      @classmethod
-@@ -1196,6 +1970,32 @@ class LinstorVolumeManager(object):
+@@ -1196,6 +1982,32 @@ class LinstorVolumeManager(object):
      # Private helpers.
      # --------------------------------------------------------------------------
  
@@ -6336,7 +6502,7 @@ index 182b889..dc810e5 100755
      def _ensure_volume_exists(self, volume_uuid):
          if volume_uuid not in self._volumes:
              raise LinstorVolumeManagerError(
-@@ -1215,21 +2015,24 @@ class LinstorVolumeManager(object):
+@@ -1215,21 +2027,24 @@ class LinstorVolumeManager(object):
              )
          return result[0].candidates
  
@@ -6369,7 +6535,7 @@ index 182b889..dc810e5 100755
              if resource.name not in all_volume_info:
                  current = all_volume_info[resource.name] = self.VolumeInfo(
                      resource.name
-@@ -1237,6 +2040,9 @@ class LinstorVolumeManager(object):
+@@ -1237,6 +2052,9 @@ class LinstorVolumeManager(object):
              else:
                  current = all_volume_info[resource.name]
  
@@ -6379,7 +6545,7 @@ index 182b889..dc810e5 100755
              for volume in resource.volumes:
                  # We ignore diskless pools of the form "DfltDisklessStorPool".
                  if volume.storage_pool_name == self._group_name:
-@@ -1245,22 +2051,32 @@ class LinstorVolumeManager(object):
+@@ -1245,22 +2063,32 @@ class LinstorVolumeManager(object):
                             'Failed to get allocated size of `{}` on `{}`'
                             .format(resource.name, volume.storage_pool_name)
                          )
@@ -6395,16 +6561,16 @@ index 182b889..dc810e5 100755
 +                    current.allocated_size = current.allocated_size and \
 +                        max(current.allocated_size, allocated_size) or \
 +                        allocated_size
-+
+ 
+-                    current.virtual_size = current.virtual_size and \
+-                        min(current.virtual_size, virtual_size) or virtual_size
 +                    usable_size = volume.usable_size
 +                    if usable_size > 0 and (
 +                        usable_size < current.virtual_size or
 +                        not current.virtual_size
 +                    ):
 +                        current.virtual_size = usable_size
- 
--                    current.virtual_size = current.virtual_size and \
--                        min(current.virtual_size, virtual_size) or virtual_size
++
 +        if current.virtual_size <= 0:
 +            raise LinstorVolumeManagerError(
 +               'Failed to get usable size of `{}` on `{}`'
@@ -6422,7 +6588,7 @@ index 182b889..dc810e5 100755
          return all_volume_info
  
      def _get_volume_node_names_and_size(self, volume_name):
-@@ -1289,12 +2105,8 @@ class LinstorVolumeManager(object):
+@@ -1289,12 +2117,8 @@ class LinstorVolumeManager(object):
          return (node_names, size * 1024)
  
      def _compute_size(self, attr):
@@ -6436,7 +6602,7 @@ index 182b889..dc810e5 100755
              space = pool.free_space
              if space:
                  size = getattr(space, attr)
-@@ -1308,48 +2120,79 @@ class LinstorVolumeManager(object):
+@@ -1308,42 +2132,73 @@ class LinstorVolumeManager(object):
  
      def _get_node_names(self):
          node_names = set()
@@ -6457,42 +6623,21 @@ index 182b889..dc810e5 100755
 -                'Failed to create volume `{}` from SR `{}`, it already exists'
 -                .format(volume_uuid, self._group_name),
 -                LinstorVolumeManagerError.ERR_VOLUME_EXISTS
--            )
--
--        if errors:
--            raise LinstorVolumeManagerError(
--                'Failed to create volume `{}` from SR `{}`: {}'.format(
--                    volume_uuid,
--                    self._group_name,
--                    self._get_error_str(errors)
--                )
--            )
 +    def _get_storage_pools(self, force=False):
 +        cur_time = time.time()
 +        elsaped_time = cur_time - self._storage_pools_time
- 
--    def _create_volume(self, volume_uuid, volume_name, size, place_resources):
--        size = self.round_up_volume_size(size)
++
 +        if force or elsaped_time >= self.STORAGE_POOLS_FETCH_INTERVAL:
 +            self._storage_pools = self._linstor.storage_pool_list_raise(
 +                filter_by_stor_pools=[self._group_name]
 +            ).storage_pools
 +            self._storage_pools_time = time.time()
- 
--        self._check_volume_creation_errors(self._linstor.resource_group_spawn(
--            rsc_grp_name=self._group_name,
--            rsc_dfn_name=volume_name,
--            vlm_sizes=['{}B'.format(size)],
--            definitions_only=not place_resources
--        ), volume_uuid)
++
 +        return self._storage_pools
- 
--    def _create_volume_with_properties(
++
 +    def _create_volume(
-         self, volume_uuid, volume_name, size, place_resources
-     ):
--        if self.check_volume_exists(volume_uuid):
--            raise LinstorVolumeManagerError(
++        self, volume_uuid, volume_name, size, place_resources
++    ):
 +        size = self.round_up_volume_size(size)
 +        self._mark_resource_cache_as_dirty()
 +
@@ -6506,9 +6651,15 @@ index 182b889..dc810e5 100755
 +                ),
 +                volume_uuid,
 +                self._group_name
-+            )
+             )
 +            self._configure_volume_peer_slots(self._linstor, volume_name)
-+
+ 
+-        if errors:
+-            raise LinstorVolumeManagerError(
+-                'Failed to create volume `{}` from SR `{}`: {}'.format(
+-                    volume_uuid,
+-                    self._group_name,
+-                    self._get_error_str(errors)
 +        def clean():
 +            try:
 +                self._destroy_volume(volume_uuid, force=True)
@@ -6516,8 +6667,11 @@ index 182b889..dc810e5 100755
 +                self._logger(
 +                    'Unable to destroy volume {} after creation fail: {}'
 +                    .format(volume_uuid, e)
-+                )
-+
+                 )
+-            )
+ 
+-    def _create_volume(self, volume_uuid, volume_name, size, place_resources):
+-        size = self.round_up_volume_size(size)
 +        def create():
 +            try:
 +                create_definition()
@@ -6539,18 +6693,18 @@ index 182b889..dc810e5 100755
 +            except Exception:
 +                clean()
 +                raise
-+
+ 
+-        self._check_volume_creation_errors(self._linstor.resource_group_spawn(
+-            rsc_grp_name=self._group_name,
+-            rsc_dfn_name=volume_name,
+-            vlm_sizes=['{}B'.format(size)],
+-            definitions_only=not place_resources
+-        ), volume_uuid)
 +        util.retry(create, maxretry=5)
-+
-+    def _create_volume_with_properties(
-+        self, volume_uuid, volume_name, size, place_resources
-+    ):
-+        if self.check_volume_exists(volume_uuid):
-+            raise LinstorVolumeManagerError(
-                 'Could not create volume `{}` from SR `{}`, it already exists'
-                 .format(volume_uuid, self._group_name) + ' in properties',
-                 LinstorVolumeManagerError.ERR_VOLUME_EXISTS
-@@ -1378,6 +2221,8 @@ class LinstorVolumeManager(object):
+ 
+     def _create_volume_with_properties(
+         self, volume_uuid, volume_name, size, place_resources
+@@ -1378,6 +2233,8 @@ class LinstorVolumeManager(object):
                  volume_uuid, volume_name, size, place_resources
              )
  
@@ -6559,7 +6713,7 @@ index 182b889..dc810e5 100755
              return volume_properties
          except LinstorVolumeManagerError as e:
              # Do not destroy existing resource!
-@@ -1385,12 +2230,8 @@ class LinstorVolumeManager(object):
+@@ -1385,12 +2242,8 @@ class LinstorVolumeManager(object):
              # before the `self._create_volume` case.
              # It can only happen if the same volume uuid is used in the same
              # call in another host.
@@ -6574,7 +6728,7 @@ index 182b889..dc810e5 100755
              raise
  
      def _find_device_path(self, volume_uuid, volume_name):
-@@ -1417,68 +2258,73 @@ class LinstorVolumeManager(object):
+@@ -1417,68 +2270,73 @@ class LinstorVolumeManager(object):
  
      def _request_device_path(self, volume_uuid, volume_name, activate=False):
          node_name = socket.gethostname()
@@ -6668,7 +6822,7 @@ index 182b889..dc810e5 100755
 +                    'Could not force destroy resource `{}` from SR `{}`: {} (openers=`{}`)'
 +                    .format(resource_name, self._group_name, error_str, all_openers)
 +                )
- 
++
 +        # Maybe the resource is blocked in primary mode. DRBD/LINSTOR issue?
 +        resource_states = filter(
 +            lambda resource_state: resource_state.name == resource_name,
@@ -6684,7 +6838,7 @@ index 182b889..dc810e5 100755
 +                demote_drbd_resource(resource_state.node_name, resource_name)
 +                break
 +        self._destroy_resource(resource_name)
-+
+ 
 +    def _destroy_volume(self, volume_uuid, force=False):
 +        volume_properties = self._get_volume_properties(volume_uuid)
          try:
@@ -6695,7 +6849,7 @@ index 182b889..dc810e5 100755
  
              # Assume this call is atomic.
              volume_properties.clear()
-@@ -1487,19 +2333,8 @@ class LinstorVolumeManager(object):
+@@ -1487,19 +2345,8 @@ class LinstorVolumeManager(object):
                  'Cannot destroy volume `{}`: {}'.format(volume_uuid, e)
              )
  
@@ -6716,7 +6870,7 @@ index 182b889..dc810e5 100755
          resource_names = self._fetch_resource_names()
  
          self._volumes = set()
-@@ -1517,9 +2352,7 @@ class LinstorVolumeManager(object):
+@@ -1517,9 +2364,7 @@ class LinstorVolumeManager(object):
              self.REG_NOT_EXISTS, ignore_inexisting_volumes=False
          )
          for volume_uuid, not_exists in existing_volumes.items():
@@ -6727,7 +6881,7 @@ index 182b889..dc810e5 100755
  
              src_uuid = properties.get(self.PROP_UPDATING_UUID_SRC)
              if src_uuid:
-@@ -1569,7 +2402,7 @@ class LinstorVolumeManager(object):
+@@ -1569,7 +2414,7 @@ class LinstorVolumeManager(object):
                  # Little optimization, don't call `self._destroy_volume`,
                  # we already have resource name list.
                  if volume_name in resource_names:
@@ -6736,7 +6890,7 @@ index 182b889..dc810e5 100755
  
                  # Assume this call is atomic.
                  properties.clear()
-@@ -1579,37 +2412,42 @@ class LinstorVolumeManager(object):
+@@ -1579,37 +2424,42 @@ class LinstorVolumeManager(object):
                      'Cannot clean volume {}: {}'.format(volume_uuid, e)
                  )
  
@@ -6796,7 +6950,7 @@ index 182b889..dc810e5 100755
  
          volume_properties = {}
          for volume_uuid in self._volumes:
-@@ -1625,15 +2463,17 @@ class LinstorVolumeManager(object):
+@@ -1625,15 +2475,17 @@ class LinstorVolumeManager(object):
  
          return volume_properties
  
@@ -6820,7 +6974,7 @@ index 182b889..dc810e5 100755
  
      @classmethod
      def _build_sr_namespace(cls):
-@@ -1653,46 +2493,433 @@ class LinstorVolumeManager(object):
+@@ -1653,46 +2505,433 @@ class LinstorVolumeManager(object):
          ])
  
      @classmethod
@@ -7268,7 +7422,7 @@ index 182b889..dc810e5 100755
      @staticmethod
      def _get_filtered_properties(properties):
          return dict(properties.items())
-@@ -1711,3 +2938,110 @@ class LinstorVolumeManager(object):
+@@ -1711,3 +2950,110 @@ class LinstorVolumeManager(object):
                  if err.is_error(code):
                      return True
          return False

--- a/SOURCES/0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
+++ b/SOURCES/0020-feat-LinstorSR-is-now-compatible-with-python-3.patch
@@ -1,7 +1,7 @@
-From d2dbdb19c1f89b59187cfe89501f8e3232f1042d Mon Sep 17 00:00:00 2001
+From 04184ed2c8daa62e188ec97311eb6e999da8f4ea Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 30 Jun 2023 12:41:43 +0200
-Subject: [PATCH 20/25] feat(LinstorSR): is now compatible with python 3
+Subject: [PATCH 20/26] feat(LinstorSR): is now compatible with python 3
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
@@ -17,7 +17,7 @@ Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
  9 files changed, 36 insertions(+), 40 deletions(-)
 
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index c770dc7..a396aee 100755
+index 94591f0..7a34521 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
 @@ -758,7 +758,7 @@ class LinstorSR(SR.SR):
@@ -78,7 +78,7 @@ index c770dc7..a396aee 100755
                  raise e
  
          self._all_volume_metadata_cache = \
-@@ -2652,7 +2651,7 @@ class LinstorVDI(VDI.VDI):
+@@ -2627,7 +2626,7 @@ class LinstorVDI(VDI.VDI):
                  '--nbd-name',
                  volume_name,
                  '--urls',
@@ -176,7 +176,7 @@ index 836f4ce..13e1bb0 100644
                      continue
  
 diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
-index dc810e5..4da34b5 100755
+index 5e5bcd5..dbca3b4 100755
 --- a/drivers/linstorvolumemanager.py
 +++ b/drivers/linstorvolumemanager.py
 @@ -529,8 +529,8 @@ class LinstorVolumeManager(object):
@@ -190,7 +190,7 @@ index dc810e5..4da34b5 100755
                  total_size += size
  
          return total_size * 1024
-@@ -1698,8 +1698,8 @@ class LinstorVolumeManager(object):
+@@ -1710,8 +1710,8 @@ class LinstorVolumeManager(object):
  
          lin = cls._create_linstor_instance(uri, keep_uri_unmodified=True)
  
@@ -201,7 +201,7 @@ index dc810e5..4da34b5 100755
              while True:
                  # Try to create node.
                  result = lin.node_create(
-@@ -2259,13 +2259,13 @@ class LinstorVolumeManager(object):
+@@ -2271,13 +2271,13 @@ class LinstorVolumeManager(object):
      def _request_device_path(self, volume_uuid, volume_name, activate=False):
          node_name = socket.gethostname()
  
@@ -218,7 +218,7 @@ index dc810e5..4da34b5 100755
              if activate:
                  self._mark_resource_cache_as_dirty()
                  self._activate_device_path(
-@@ -2277,7 +2277,7 @@ class LinstorVolumeManager(object):
+@@ -2289,7 +2289,7 @@ class LinstorVolumeManager(object):
                  .format(volume_uuid)
              )
          # Contains a path of the /dev/drbd<id> form.
@@ -227,7 +227,7 @@ index dc810e5..4da34b5 100755
  
      def _destroy_resource(self, resource_name, force=False):
          result = self._linstor.resource_dfn_delete(resource_name)
-@@ -2295,7 +2295,7 @@ class LinstorVolumeManager(object):
+@@ -2307,7 +2307,7 @@ class LinstorVolumeManager(object):
  
          # If force is used, ensure there is no opener.
          all_openers = get_all_volume_openers(resource_name, '0')
@@ -236,7 +236,7 @@ index dc810e5..4da34b5 100755
              if openers:
                  self._mark_resource_cache_as_dirty()
                  raise LinstorVolumeManagerError(
-@@ -2559,18 +2559,18 @@ class LinstorVolumeManager(object):
+@@ -2571,18 +2571,18 @@ class LinstorVolumeManager(object):
          node_name = socket.gethostname()
  
          try:
@@ -258,7 +258,7 @@ index dc810e5..4da34b5 100755
              if activate:
                  cls._activate_device_path(
                      lin, node_name, DATABASE_VOLUME_NAME
-@@ -2583,7 +2583,7 @@ class LinstorVolumeManager(object):
+@@ -2595,7 +2595,7 @@ class LinstorVolumeManager(object):
                  .format(DATABASE_PATH)
              )
          # Contains a path of the /dev/drbd<id> form.
@@ -267,7 +267,7 @@ index dc810e5..4da34b5 100755
  
      @classmethod
      def _create_database_volume(
-@@ -2618,7 +2618,7 @@ class LinstorVolumeManager(object):
+@@ -2630,7 +2630,7 @@ class LinstorVolumeManager(object):
              )
  
          # Ensure we have a correct list of storage pools.
@@ -276,7 +276,7 @@ index dc810e5..4da34b5 100755
          assert nodes_with_pool  # We must have at least one storage pool!
          for node_name in nodes_with_pool:
              assert node_name in node_names
-@@ -2862,7 +2862,7 @@ class LinstorVolumeManager(object):
+@@ -2874,7 +2874,7 @@ class LinstorVolumeManager(object):
      def _move_files(cls, src_dir, dest_dir, force=False):
          def listdir(dir):
              ignored = ['lost+found']

--- a/SOURCES/0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
+++ b/SOURCES/0021-Remove-SR_PROBE-from-ZFS-capabilities-36.patch
@@ -1,7 +1,7 @@
-From ad27aaf2c1c7c2611304f18185af47a15100c868 Mon Sep 17 00:00:00 2001
+From 53085ab0a5aae6a102b865d97d7b45e83980bf00 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Fri, 4 Aug 2023 12:10:37 +0200
-Subject: [PATCH 21/25] Remove `SR_PROBE` from ZFS capabilities (#36)
+Subject: [PATCH 21/26] Remove `SR_PROBE` from ZFS capabilities (#36)
 
 The probe method is not implemented so we
 shouldn't advertise it.

--- a/SOURCES/0022-Repair-coverage-to-be-compatible-with-8.3-test-env.patch
+++ b/SOURCES/0022-Repair-coverage-to-be-compatible-with-8.3-test-env.patch
@@ -1,7 +1,7 @@
-From efa113931be9a101a6a9789610d7de0b860b55c8 Mon Sep 17 00:00:00 2001
+From 92d9300bc73693aa13366485ecd3af196b7c4f1d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 22 Sep 2023 11:11:27 +0200
-Subject: [PATCH 22/25] Repair coverage to be compatible with 8.3 test env
+Subject: [PATCH 22/26] Repair coverage to be compatible with 8.3 test env
 
 Impacted drivers: LINSTOR, MooseFS and ZFS.
 - Ignore all linstor.* members during coverage,
@@ -18,7 +18,7 @@ Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
  4 files changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
-index a396aee..b9ab37d 100755
+index 7a34521..c8aa56b 100755
 --- a/drivers/LinstorSR.py
 +++ b/drivers/LinstorSR.py
 @@ -779,9 +779,8 @@ class LinstorSR(SR.SR):

--- a/SOURCES/0023-Support-IPv6-in-Ceph-Driver.patch
+++ b/SOURCES/0023-Support-IPv6-in-Ceph-Driver.patch
@@ -1,7 +1,7 @@
-From 6969aa636737ae49dc60fd8e506c139b17ebc2e8 Mon Sep 17 00:00:00 2001
+From ded093de9e1762bf6bfe77bb253e2dc3e135b485 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Mon, 25 Sep 2023 16:13:13 +0200
-Subject: [PATCH 23/25] Support IPv6 in Ceph Driver
+Subject: [PATCH 23/26] Support IPv6 in Ceph Driver
 
 Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
 ---

--- a/SOURCES/0024-lvutil-use-wipefs-not-dd-to-clear-existing-signature.patch
+++ b/SOURCES/0024-lvutil-use-wipefs-not-dd-to-clear-existing-signature.patch
@@ -1,7 +1,7 @@
-From 70e81bf8fdd19e880c028a8bf83634bb90880456 Mon Sep 17 00:00:00 2001
+From 03b2c031754578d9ab6875d9154aec21203c66f3 Mon Sep 17 00:00:00 2001
 From: Yann Dirson <yann.dirson@vates.fr>
 Date: Wed, 5 Jul 2023 16:57:26 +0200
-Subject: [PATCH 24/25] lvutil: use wipefs not dd to clear existing signatures
+Subject: [PATCH 24/26] lvutil: use wipefs not dd to clear existing signatures
  (xapi-project#624)
 
 Signed-off-by: Yann Dirson <yann.dirson@vates.fr>

--- a/SOURCES/0025-Implement-correctly-fake_import-in-test_on_slave.py.patch
+++ b/SOURCES/0025-Implement-correctly-fake_import-in-test_on_slave.py.patch
@@ -1,7 +1,7 @@
-From 1dde93cb983dfbefc1496827e8e43318ce54d978 Mon Sep 17 00:00:00 2001
+From 079107836f10f21ea47be4eabc62245129391292 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 23 Jan 2024 17:15:51 +0100
-Subject: [PATCH 25/25] Implement correctly fake_import in test_on_slave.py
+Subject: [PATCH 25/26] Implement correctly fake_import in test_on_slave.py
 
 *args and **kwargs must be forwarded to __import__ otherwise
 the import context (global & local) can be incomplete to find

--- a/SOURCES/0026-fix-NFSSR-ensure-we-can-attach-SR-during-attach_from.patch
+++ b/SOURCES/0026-fix-NFSSR-ensure-we-can-attach-SR-during-attach_from.patch
@@ -1,0 +1,241 @@
+From c7340e7db9fafbcd106d437212857ff79fdcc9ac Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Wed, 11 Oct 2023 15:14:08 +0200
+Subject: [PATCH 26/26] fix(NFSSR): ensure we can attach SR during
+ attach_from_config call
+
+We can get a trace like that if the SR is not attached:
+```
+2170:Oct 10 16:02:59 xcp4 SM: [2564] ***** NFSFileVDI.attach_from_config: EXCEPTION <type 'exceptions.AttributeError'>, 'NoneType' object has no attribute 'xenapi'
+2329-Oct 10 16:02:59 xcp4 SM: [2564]   File "/opt/xensource/sm/NFSSR", line 296, in attach_from_config
+2427-Oct 10 16:02:59 xcp4 SM: [2564]     self.sr.attach(sr_uuid)
+2487-Oct 10 16:02:59 xcp4 SM: [2564]   File "/opt/xensource/sm/NFSSR", line 148, in attach
+2573-Oct 10 16:02:59 xcp4 SM: [2564]     self._check_hardlinks()
+2633-Oct 10 16:02:59 xcp4 SM: [2564]   File "/opt/xensource/sm/FileSR.py", line 1122, in _check_hardlinks
+2734-Oct 10 16:02:59 xcp4 SM: [2564]     self.session.xenapi.SR.remove_from_sm_config(
+2816-Oct 10 16:02:59 xcp4 SM: [2564]
+```
+
+Because the session is not set during this call.
+So instead of using the XenAPI to store hardlink support, use a file on the storage itself.
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/FileSR.py    | 67 +++++++++++++++++++++++++++++++++-----------
+ tests/test_FileSR.py | 35 +++--------------------
+ 2 files changed, 55 insertions(+), 47 deletions(-)
+
+diff --git a/drivers/FileSR.py b/drivers/FileSR.py
+index 346e263..ec2a59a 100755
+--- a/drivers/FileSR.py
++++ b/drivers/FileSR.py
+@@ -419,6 +419,9 @@ class FileSR(SR.SR):
+                                 (util.ismount(mount_path) or \
+                                  util.pathexists(self.remotepath) and self._isbind()))
+ 
++    # Override in SharedFileSR.
++    def _check_hardlinks(self):
++        return True
+ 
+ class FileVDI(VDI.VDI):
+     PARAM_VHD = "vhd"
+@@ -762,11 +765,10 @@ class FileVDI(VDI.VDI):
+         os.unlink(path)
+ 
+     def _create_new_parent(self, src, newsrc):
+-        sr_sm_config = self.session.xenapi.SR.get_sm_config(self.sr.sr_ref)
+-        if SharedFileSR.NO_HARDLINK_SUPPORT in sr_sm_config:
+-            self._rename(src, newsrc)
+-        else:
++        if self.sr._check_hardlinks():
+             self._link(src, newsrc)
++        else:
++            self._rename(src, newsrc)
+ 
+     def __fist_enospace(self):
+         raise util.CommandException(28, "vhd-util snapshot", reason="No space")
+@@ -1072,12 +1074,15 @@ class SharedFileSR(FileSR):
+     """
+     FileSR subclass for SRs that use shared network storage
+     """
+-    NO_HARDLINK_SUPPORT = "no_hardlinks"
+ 
+     def _raise_hardlink_error(self):
+         raise OSError(524, "Unknown error 524")
+ 
+     def _check_hardlinks(self):
++        hardlink_conf = self._read_hardlink_conf()
++        if hardlink_conf is not None:
++            return hardlink_conf
++
+         test_name = os.path.join(self.path, str(uuid4()))
+         open(test_name, 'ab').close()
+ 
+@@ -1089,25 +1094,55 @@ class SharedFileSR(FileSR):
+                 self._raise_hardlink_error)
+ 
+             os.link(test_name, link_name)
+-            self.session.xenapi.SR.remove_from_sm_config(
+-                self.sr_ref, SharedFileSR.NO_HARDLINK_SUPPORT)
++            self._write_hardlink_conf(supported=True)
++            return True
+         except OSError:
++            self._write_hardlink_conf(supported=False)
++
+             msg = "File system for SR %s does not support hardlinks, crash " \
+                 "consistency of snapshots cannot be assured" % self.uuid
+             util.SMlog(msg, priority=util.LOG_WARNING)
+-            try:
+-                self.session.xenapi.SR.add_to_sm_config(
+-                    self.sr_ref, SharedFileSR.NO_HARDLINK_SUPPORT, 'True')
+-                self.session.xenapi.message.create(
+-                    "sr_does_not_support_hardlinks", 2, "SR", self.uuid,
+-                    msg)
+-            except XenAPI.Failure:
+-                # Might already be set and checking has TOCTOU issues
+-                pass
++            # Note: session can be not set during attach/detach_from_config calls.
++            if self.session:
++                try:
++                    self.session.xenapi.message.create(
++                        "sr_does_not_support_hardlinks", 2, "SR", self.uuid,
++                        msg)
++                except XenAPI.Failure:
++                    # Might already be set and checking has TOCTOU issues
++                    pass
+         finally:
+             util.force_unlink(link_name)
+             util.force_unlink(test_name)
+ 
++        return False
++
++    def _get_hardlink_conf_path(self):
++        return os.path.join(self.path, 'sm-hardlink.conf')
++
++    def _read_hardlink_conf(self):
++        try:
++            with open(self._get_hardlink_conf_path(), 'r') as f:
++                try:
++                    return bool(int(f.read()))
++                except Exception as e:
++                    # If we can't read, assume the file is empty and test for hardlink support.
++                    return None
++        except IOError as e:
++            if e.errno == errno.ENOENT:
++                # If the config file doesn't exist, assume we want to support hardlinks.
++                return None
++            util.SMlog('Failed to read hardlink conf: {}'.format(e))
++            # Can be caused by a concurrent access, not a major issue.
++            return None
++
++    def _write_hardlink_conf(self, supported):
++        try:
++            with open(self._get_hardlink_conf_path(), 'w') as f:
++                f.write('1' if supported else '0')
++        except Exception as e:
++            # Can be caused by a concurrent access, not a major issue.
++            util.SMlog('Failed to write hardlink conf: {}'.format(e))
+ 
+ if __name__ == '__main__':
+     SRCommand.run(FileSR, DRIVER_INFO)
+diff --git a/tests/test_FileSR.py b/tests/test_FileSR.py
+index ff46301..a929d53 100644
+--- a/tests/test_FileSR.py
++++ b/tests/test_FileSR.py
+@@ -15,7 +15,6 @@ import SRCommand
+ import testlib
+ import util
+ import vhdutil
+-from XenAPI import Failure
+ 
+ 
+ class FakeFileVDI(FileSR.FileVDI):
+@@ -193,6 +192,7 @@ class TestFileVDI(unittest.TestCase):
+         vdi_uuid = str(uuid.uuid4())
+         sr = mock.MagicMock()
+         sr.path = "sr_path"
++        sr._check_hardlinks.return_value = False
+         vdi = FakeFileVDI(sr, vdi_uuid)
+         vdi.sr = sr
+ 
+@@ -205,9 +205,6 @@ class TestFileVDI(unittest.TestCase):
+ 
+         mock_query_p_uuid.side_effect = [new_vdi_uuid, new_vdi_uuid, grandp_uuid]
+ 
+-        sr.session.xenapi.SR.get_sm_config.return_value = {
+-            "no_hardlinks": "True"}
+-
+         # Act
+         clone_xml = vdi.clone(sr_uuid, vdi_uuid)
+ 
+@@ -431,6 +428,8 @@ class FakeSharedFileSR(FileSR.SharedFileSR):
+     def attach(self, sr_uuid):
+         self._check_hardlinks()
+ 
++    def _read_hardlink_conf(self):
++        return None
+ 
+ class TestShareFileSR(unittest.TestCase):
+     """
+@@ -438,7 +437,6 @@ class TestShareFileSR(unittest.TestCase):
+     """
+     TEST_SR_REF = "test_sr_ref"
+     ERROR_524 = "Unknown error 524"
+-    NO_HARDLINKS = "no_hardlinks"
+ 
+     def setUp(self):
+         util_patcher = mock.patch('FileSR.util', autospec=True)
+@@ -487,8 +485,7 @@ class TestShareFileSR(unittest.TestCase):
+             test_sr.attach(self.sr_uuid)
+ 
+         # Assert
+-        self.mock_session.xenapi.SR.remove_from_sm_config.assert_called_with(
+-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS)
++        self.assertEqual(0, self.mock_session.xenapi.message.create.call_count)
+ 
+     def test_attach_link_fail(self):
+         """
+@@ -503,31 +500,9 @@ class TestShareFileSR(unittest.TestCase):
+             test_sr.attach(self.sr_uuid)
+ 
+         # Assert
+-        self.mock_session.xenapi.SR.add_to_sm_config.assert_called_with(
+-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS, 'True')
+         self.mock_session.xenapi.message.create.assert_called_with(
+             'sr_does_not_support_hardlinks', 2, "SR", self.sr_uuid, mock.ANY)
+ 
+-    def test_attach_link_fail_already_set(self):
+-        """
+-        Attach SR on FS with no hardlinks with config set
+-        """
+-        test_sr = self.create_test_sr()
+-
+-        self.mock_link.side_effect = OSError(524, TestShareFileSR.ERROR_524)
+-        self.mock_session.xenapi.SR.add_to_sm_config.side_effect = Failure(
+-            ['MAP_DUPLICATE_KEY', 'SR', 'sm_config',
+-            'OpaqueRef:be8cc595-4924-4946-9082-59aef531daae',
+-             TestShareFileSR.NO_HARDLINKS])
+-
+-        # Act
+-        with mock.patch('FileSR.open'):
+-            test_sr.attach(self.sr_uuid)
+-
+-        # Assert
+-        self.mock_session.xenapi.SR.add_to_sm_config.assert_called_with(
+-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS, 'True')
+-
+     def test_attach_fist_active(self):
+         """
+         Attach SR with FIST point active to set no hardlinks
+@@ -541,8 +516,6 @@ class TestShareFileSR(unittest.TestCase):
+             test_sr.attach(self.sr_uuid)
+ 
+         # Assert
+-        self.mock_session.xenapi.SR.add_to_sm_config.assert_called_with(
+-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS, 'True')
+         self.mock_session.xenapi.message.create.assert_called_with(
+             'sr_does_not_support_hardlinks', 2, "SR", self.sr_uuid, mock.ANY)
+ 
+-- 
+2.43.0
+

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -1,7 +1,7 @@
 %global package_speccommit d6933df59571ee3471f10f184c8b73427daa56ed
 %global usver 3.0.12
 %global xsver 6
-%global xsrel %{xsver}.1%{?xscount}%{?xshash}
+%global xsrel %{xsver}.2%{?xscount}%{?xshash}
 %global package_srccommit v3.0.12
 
 # -*- rpm-spec -*-
@@ -360,6 +360,12 @@ The package contains a fake key lookup plugin for system tests
 /opt/xensource/sm/plugins/keymanagerutil.py*
 
 %changelog
+* Thu Feb 22 2024 Ronan Abhamon <ronan.abhamon@vates.fr> - 3.0.12-6.2
+- Ensure we can always attach NFS SR during attach_from_config call
+- Always activate LVs for LINSTOR if attach from config is asked
+- Create VHD diskless chain for LINSTOR during snapshots
+- Robustify LINSTOR resize when a volume has just been created
+
 * Wed Jan 24 2024 Ronan Abhamon <ronan.abhamon@vates.fr> - 3.0.12-6.1
 - Rebase on 3.0.12-6
 - Drop 0022-Fix-vdi-ref-when-static-vdis-are-used.patch


### PR DESCRIPTION
- Ensure we can always attach NFS SR during attach_from_config call
- Always activate LVs for LINSTOR if attach from config is asked
- Create VHD diskless chain for LINSTOR during snapshots
- Robustify LINSTOR resize when a volume has just been created

Koji build (v8.3-incoming, scratch): http://koji.xcp-ng.org/taskinfo?taskID=47650