### PR TITLE
Stable LINSTOR release

### DIFF
--- a/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
+++ b/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
@@ -1,7 +1,7 @@
 From 0db4b82a2799eae8840d41c8c9a348e6b90145c1 Mon Sep 17 00:00:00 2001
 From: Mark Syms <mark.syms@citrix.com>
 Date: Thu, 20 May 2021 17:40:06 +0100
-Subject: [PATCH 001/162] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
+Subject: [PATCH 001/170] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
  CA-354692: check for device parameter in create/probe calls
 
 Signed-off-by: Mark Syms <mark.syms@citrix.com>
@@ -87,5 +87,5 @@ index aa5a6b1..c752863 100755
  def registerSR(SRClass):
      """Register SR with handler. All SR subclasses should call this in 
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From 9eab9d86013024f93a6e7d8836460b5ff1a789d6 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 002/162] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 002/170] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.
@@ -21,5 +21,5 @@ index 99cb313..609c6ef 100644
  Conflicts=shutdown.target
  RefuseManualStop=yes
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0003-Add-TrueNAS-multipath-config.patch
+++ b/SOURCES/0003-Add-TrueNAS-multipath-config.patch
@@ -1,7 +1,7 @@
 From 17d4c900fd4f0ab1c86feca0a31c45b10bd4665d Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:26:43 +0200
-Subject: [PATCH 003/162] Add TrueNAS multipath config
+Subject: [PATCH 003/170] Add TrueNAS multipath config
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.
@@ -26,5 +26,5 @@ index 8a46a19..5ce7e99 100644
 +	}
  }
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
+++ b/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
@@ -1,7 +1,7 @@
 From 31707d93dd21a35e4f83e91e526d1ff73e88ee08 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 004/162] feat(drivers): add CephFS, GlusterFS and XFS drivers
+Subject: [PATCH 004/170] feat(drivers): add CephFS, GlusterFS and XFS drivers
 
 ---
  Makefile               |   3 +
@@ -888,5 +888,5 @@ index 97c332c..ad1ee86 100755
      if not type in SR.TYPES:
          raise util.SMException("Unsupported SR type: %s" % type)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From f2d0f0428ff4f3bf90da88ca8a6c8d3ad4419689 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 005/162] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 005/170] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---
@@ -201,5 +201,5 @@ index ad1ee86..327103f 100755
          type = SR.TYPE_FILE
      if not type in SR.TYPES:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
+++ b/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
@@ -1,7 +1,7 @@
 From 1c46a4afa57cf16b74553e5359b4acff0ec7b489 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 17:10:12 +0200
-Subject: [PATCH 006/162] Re-add the ext4 driver for users who need to
+Subject: [PATCH 006/170] Re-add the ext4 driver for users who need to
  transition
 
 The driver is needed to transition to the ext driver.
@@ -288,5 +288,5 @@ index 327103f..867c789 100755
          type = SR.TYPE_FILE
      if not type in SR.TYPES:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From 70ec54d7979c4072d7a645f92ccb5d4b28167b34 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 007/162] feat(drivers): add LinstorSR driver
+Subject: [PATCH 007/170] feat(drivers): add LinstorSR driver
 
 Some important points:
 
@@ -5680,5 +5680,5 @@ diff --git a/tests/mocks/linstor/__init__.py b/tests/mocks/linstor/__init__.py
 new file mode 100644
 index 0000000..e69de29
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From 8e5d0c2536c72cf8c8f0d5a8d41dc515be4a1558 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 008/162] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 008/170] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages
@@ -205,5 +205,5 @@ index 0000000..6f8040d
 +            failed = True
 +        self.assertTrue(failed)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
+++ b/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
@@ -1,7 +1,7 @@
 From d48c254de2538496020a4dc15d7110343fe9a030 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Thu, 25 Feb 2021 09:54:52 +0100
-Subject: [PATCH 009/162] If no NFS ACLs provided, assume everyone:
+Subject: [PATCH 009/170] If no NFS ACLs provided, assume everyone:
 
 Some QNAP devices do not provide ACL when fetching NFS mounts.
 In this case the assumed ACL should be: "*".
@@ -71,5 +71,5 @@ index 71800ab..cef414f 100644
 +        self.assertEqual(len(pread2.mock_calls), 1)
 +        pread2.assert_called_with(['/usr/sbin/showmount', '--no-headers', '-e', 'aServer'])
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From cd6c7922d0e66d60ad82027e848a7e45bcaa8dfa Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 010/162] Added SM Driver for MooseFS
+Subject: [PATCH 010/170] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
@@ -386,5 +386,5 @@ index 0000000..5a61cf5
 +        mfssr.detach('asr_uuid')
 +        self.assertTrue(mfssr.attached)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From a2ca100774401570255bc4743cf3d2e38d0fd9e3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 011/162] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 011/170] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir
@@ -103,5 +103,5 @@ index 7655f14..03c8851 100644
  class TestISOSR_overNFS(unittest.TestCase):
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From 0c04fb589d64c6f03202d681508a80fd4ab98c72 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 012/162] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 012/170] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior
@@ -126,5 +126,5 @@ index be5112c..ab72f4e 100755
              self.detach(sr_uuid)
              if inst.code != errno.ENOENT:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From 9602d27ca3600f3a4ecdf9ee7a11bbfe103a1d49 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 013/162] Fix is_open call for many drivers (#25)
+Subject: [PATCH 013/170] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.
@@ -104,5 +104,5 @@ index 0d60d96..534e6c9 100755
  
      driver = SR.driver(srType)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From 864d51d861fd9b5bb9da4126e2c28cdb7e3858f1 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 014/162] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 014/170] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.
@@ -56,5 +56,5 @@ index ab72f4e..212f1ad 100755
                  "VDI_UPDATE", "VDI_CLONE", "VDI_SNAPSHOT", "VDI_RESIZE", "VDI_MIRROR",
                  "VDI_GENERATE_CONFIG",
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
+++ b/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
@@ -1,7 +1,7 @@
 From a4e1fdcf964e43541c78db9d5d885acd8df1b521 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Fri, 4 Aug 2023 12:10:08 +0200
-Subject: [PATCH 015/162] Remove `SR_PROBE` from ZFS capabilities (#37)
+Subject: [PATCH 015/170] Remove `SR_PROBE` from ZFS capabilities (#37)
 
 The probe method is not implemented so we
 shouldn't advertise it.
@@ -24,5 +24,5 @@ index d375210..b803211 100644
      'VDI_CREATE',
      'VDI_DELETE',
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,7 +1,7 @@
 From 4122b2496fa3ee45122b94f443aa9be20363cc4d Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Wed, 16 Aug 2023 13:42:21 +0200
-Subject: [PATCH 016/162] Fix vdi-ref when static vdis are used
+Subject: [PATCH 016/170] Fix vdi-ref when static vdis are used
 
 When static vdis are used there is no snapshots and we don't want to
 call method from XAPI.
@@ -32,5 +32,5 @@ index dd8e20b..6ac3f80 100755
          if needDeflate:
              try:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0017-Tell-users-not-to-edit-multipath.conf-directly.patch
+++ b/SOURCES/0017-Tell-users-not-to-edit-multipath.conf-directly.patch
@@ -1,7 +1,7 @@
 From 3e4a5e0b1c206a307530c989ede8010163579207 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 27 Jan 2023 12:03:15 +0100
-Subject: [PATCH 017/162] Tell users not to edit multipath.conf directly
+Subject: [PATCH 017/170] Tell users not to edit multipath.conf directly
 
 This file is meant to remain unchanged and regularly updated along with
 the SM component. Users can create a custom configuration file in
@@ -30,5 +30,5 @@ index 5ce7e99..f1afa11 100644
  # multipathd.
  # For information on the syntax refer to `man multipath.conf` and the examples
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0018-Add-custom.conf-multipath-configuration-file.patch
+++ b/SOURCES/0018-Add-custom.conf-multipath-configuration-file.patch
@@ -1,7 +1,7 @@
 From b50a5a6079388363a536ee5c425c95a153621f46 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 27 Jan 2023 12:23:13 +0100
-Subject: [PATCH 018/162] Add custom.conf multipath configuration file
+Subject: [PATCH 018/170] Add custom.conf multipath configuration file
 
 Meant to be installed as /etc/multipath/conf.d/custom.conf for users
 to have an easy entry point for editing, as well as information on what
@@ -27,5 +27,5 @@ index 0000000..3c8583f
 +
 +# Refer to "man multipath.conf"
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0019-Install-etc-multipath-conf.d-custom.conf.patch
+++ b/SOURCES/0019-Install-etc-multipath-conf.d-custom.conf.patch
@@ -1,7 +1,7 @@
 From f20c924d7de6277b1359a92180d4e5021afdef4d Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 25 Aug 2023 17:47:34 +0200
-Subject: [PATCH 019/162] Install /etc/multipath/conf.d/custom.conf
+Subject: [PATCH 019/170] Install /etc/multipath/conf.d/custom.conf
 
 Update Makefile so that the file is installed along with sm.
 
@@ -48,5 +48,5 @@ index b0ae353..3357cbf 100755
  	  $(SM_STAGING)/$(INIT_DIR)
  	install -m 755 multipath/multipath-root-setup \
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0020-Backport-NFS4-only-support.patch
+++ b/SOURCES/0020-Backport-NFS4-only-support.patch
@@ -1,7 +1,7 @@
 From 57bb20c2074eedf8512700711406a63d3da4f26a Mon Sep 17 00:00:00 2001
 From: Benjamin Reis <benjamin.reis@vates.tech>
 Date: Mon, 18 Dec 2023 10:22:26 +0100
-Subject: [PATCH 020/162] Backport NFS4 only support
+Subject: [PATCH 020/170] Backport NFS4 only support
 
 See: https://github.com/xapi-project/sm/pull/617
 
@@ -426,5 +426,5 @@ index cef414f..9ea807f 100644
          expected = """<?xml version="1.0" ?>
  <nfs-exports>
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
+++ b/SOURCES/0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
@@ -1,7 +1,7 @@
 From a25b42e0f7d4fad119418bd9532a84d1f69d0f16 Mon Sep 17 00:00:00 2001
 From: Benjamin Reis <benjamin.reis@vates.tech>
 Date: Mon, 18 Dec 2023 10:35:46 +0100
-Subject: [PATCH 021/162] Backport probe for NFS4 when rpcinfo does not include
+Subject: [PATCH 021/170] Backport probe for NFS4 when rpcinfo does not include
  it
 
 See: https://github.com/xapi-project/sm/pull/655
@@ -164,5 +164,5 @@ index 9ea807f..3874d8e 100644
          return ([binary, 'remoteserver:remotepath', 'mountpoint', '-o',
                   'soft,proto=transport,vers=%s,acdirmin=0,acdirmax=0' % vers])
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0022-Fix-timeout_call-alarm-must-be-reset-in-case-of-succ.patch
+++ b/SOURCES/0022-Fix-timeout_call-alarm-must-be-reset-in-case-of-succ.patch
@@ -1,7 +1,7 @@
 From 7b5acda61ff391ef82e8150bfd7e906c03240979 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Feb 2022 18:24:56 +0100
-Subject: [PATCH 022/162] Fix timeout_call: alarm must be reset in case of
+Subject: [PATCH 022/170] Fix timeout_call: alarm must be reset in case of
  success
 
 Otherwise the SIGALRM signal can be emitted after the execution
@@ -28,5 +28,5 @@ index f673937..c479de9 100755
  
  def _incr_iscsiSR_refcount(targetIQN, uuid):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0023-timeout_call-returns-the-result-of-user-function-now.patch
+++ b/SOURCES/0023-timeout_call-returns-the-result-of-user-function-now.patch
@@ -1,7 +1,7 @@
 From 57958fecf5aacdf5865a8c09b3758f37b49e379a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Feb 2022 18:28:06 +0100
-Subject: [PATCH 023/162] timeout_call returns the result of user function now
+Subject: [PATCH 023/170] timeout_call returns the result of user function now
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
@@ -22,5 +22,5 @@ index c479de9..f4f6252 100755
          signal.alarm(0)
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0024-Always-remove-the-pause-tag-from-VDIs-in-case-of-fai.patch
+++ b/SOURCES/0024-Always-remove-the-pause-tag-from-VDIs-in-case-of-fai.patch
@@ -1,7 +1,7 @@
 From f299b42bb872308c9b34a0fe32d713738eb1960b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Feb 2024 23:16:16 +0100
-Subject: [PATCH 024/162] Always remove the pause tag from VDIs in case of
+Subject: [PATCH 024/170] Always remove the pause tag from VDIs in case of
  failure
 
 During VDI activation in the blktap module and in case of failure
@@ -54,5 +54,5 @@ index e1f75e9..e9305ce 100755
                      "blktap_activate_inject_failure",
                      lambda: util.inject_failure())
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0025-fix-LinstorSR-repair-volumes-only-if-an-exclusive-co.patch
+++ b/SOURCES/0025-fix-LinstorSR-repair-volumes-only-if-an-exclusive-co.patch
@@ -1,7 +1,7 @@
 From 7855c8d7601747187cdfc7b6d1a4321751c108e3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 20 Nov 2020 16:42:52 +0100
-Subject: [PATCH 025/162] fix(LinstorSR): repair volumes only if an exclusive
+Subject: [PATCH 025/170] fix(LinstorSR): repair volumes only if an exclusive
  command is executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -32,5 +32,5 @@ index 8be1836..a5bf5ab 100755
                  )
                  self._vhdutil = LinstorVhdUtil(self.session, self._linstor)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0026-feat-LinstorSR-Improve-LINSTOR-performance.patch
+++ b/SOURCES/0026-feat-LinstorSR-Improve-LINSTOR-performance.patch
@@ -1,7 +1,7 @@
 From 51af0e8914046285c81fb806849682f5e71af3ac Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 10 Dec 2020 17:56:15 +0100
-Subject: [PATCH 026/162] feat(LinstorSR): Improve LINSTOR performance
+Subject: [PATCH 026/170] feat(LinstorSR): Improve LINSTOR performance
 
 Details:
 - vdi_attach and vdi_detach are now exclusive
@@ -1417,5 +1417,5 @@ index d400421..d617655 100755
          return 'xcp-sr-{}'.format(self._group_name)
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0027-feat-LinstorSR-robustify-scan-to-avoid-losing-VDIs-i.patch
+++ b/SOURCES/0027-feat-LinstorSR-robustify-scan-to-avoid-losing-VDIs-i.patch
@@ -1,7 +1,7 @@
 From ddbcb1138e10e49b157b0baec6ba4361eee22d30 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 7 Jan 2021 11:17:08 +0100
-Subject: [PATCH 027/162] feat(LinstorSR): robustify scan to avoid losing VDIs
+Subject: [PATCH 027/170] feat(LinstorSR): robustify scan to avoid losing VDIs
  if function is called outside module
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -87,5 +87,5 @@ index 548f4b1..52131a5 100755
                  LinstorJournaler.CLONE
              ).items())
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0028-feat-LinstorSR-display-a-correctly-readable-size-for.patch
+++ b/SOURCES/0028-feat-LinstorSR-display-a-correctly-readable-size-for.patch
@@ -1,7 +1,7 @@
 From 0969b9faa09ea40c547512045014bd7d716df1a6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 8 Jan 2021 16:12:15 +0100
-Subject: [PATCH 028/162] feat(LinstorSR): display a correctly readable size
+Subject: [PATCH 028/170] feat(LinstorSR): display a correctly readable size
  for the user
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -277,5 +277,5 @@ index d617655..a6f67d8 100755
  
          self._volume_info_cache_dirty = False
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0029-feat-linstor-monitord-scan-all-LINSTOR-SRs-every-12-.patch
+++ b/SOURCES/0029-feat-linstor-monitord-scan-all-LINSTOR-SRs-every-12-.patch
@@ -1,7 +1,7 @@
 From 57cd7298e2f6600436a956d102b5810f3cebf17a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 12 Jan 2021 14:06:34 +0100
-Subject: [PATCH 029/162] feat(linstor-monitord): scan all LINSTOR SRs every 12
+Subject: [PATCH 029/170] feat(linstor-monitord): scan all LINSTOR SRs every 12
  minutes to update allocated size stats
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -331,5 +331,5 @@ index 8161813..a1592fd 100644
  
    const int inotifyFd = createInotifyInstance();
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0030-fix-LinstorSR-call-correctly-method-in-_locked_load-.patch
+++ b/SOURCES/0030-fix-LinstorSR-call-correctly-method-in-_locked_load-.patch
@@ -1,7 +1,7 @@
 From c1e4105783d6d87650de2110225c3787f12b0c8d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 15 Jan 2021 17:01:05 +0100
-Subject: [PATCH 030/162] fix(LinstorSR): call correctly method in _locked_load
+Subject: [PATCH 030/170] fix(LinstorSR): call correctly method in _locked_load
  when vdi_attach_from_config is executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -40,5 +40,5 @@ index 16cb0d6..2df2d68 100755
              self._master_uri = 'linstor://{}'.format(
                  util.get_master_rec(self.session)['address']
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0031-feat-LinstorSR-integrate-minidrbdcluster-daemon.patch
+++ b/SOURCES/0031-feat-LinstorSR-integrate-minidrbdcluster-daemon.patch
@@ -1,7 +1,7 @@
 From 2af13c7191749af0003ca883f285687a1ec43a1f Mon Sep 17 00:00:00 2001
 From: Wescoeur <ronan.abhamon@vates.fr>
 Date: Wed, 20 Jan 2021 18:04:26 +0100
-Subject: [PATCH 031/162] feat(LinstorSR): integrate minidrbdcluster daemon
+Subject: [PATCH 031/170] feat(LinstorSR): integrate minidrbdcluster daemon
 
 Now, we can:
 - Start a controller on any node
@@ -2065,5 +2065,5 @@ index 0000000..3de6ac4
 +[Install]
 +WantedBy=multi-user.target
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0032-feat-LinstorSR-ensure-heartbeat-and-redo_log-VDIs-ar.patch
+++ b/SOURCES/0032-feat-LinstorSR-ensure-heartbeat-and-redo_log-VDIs-ar.patch
@@ -1,7 +1,7 @@
 From 49b678242733b47c51c8f360b1f5ac73f23a0209 Mon Sep 17 00:00:00 2001
 From: Wescoeur <ronan.abhamon@vates.fr>
 Date: Wed, 24 Feb 2021 11:17:23 +0100
-Subject: [PATCH 032/162] feat(LinstorSR): ensure heartbeat and redo_log VDIs
+Subject: [PATCH 032/170] feat(LinstorSR): ensure heartbeat and redo_log VDIs
  are not diskless
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -164,5 +164,5 @@ index a383e32..d8d64b4 100755
  
              assert volume_properties.namespace == \
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0033-feat-LinstorSR-protect-sr-commands-to-avoid-forgetti.patch
+++ b/SOURCES/0033-feat-LinstorSR-protect-sr-commands-to-avoid-forgetti.patch
@@ -1,7 +1,7 @@
 From 918ebd8d01ca76bd5f0523a7fe567c105fe33cd1 Mon Sep 17 00:00:00 2001
 From: Wescoeur <ronan.abhamon@vates.fr>
 Date: Thu, 25 Feb 2021 17:52:57 +0100
-Subject: [PATCH 033/162] feat(LinstorSR): protect sr commands to avoid
+Subject: [PATCH 033/170] feat(LinstorSR): protect sr commands to avoid
  forgetting LINSTOR volumes when master satellite is down
 
 Steps to reproduce:
@@ -162,5 +162,5 @@ index d943d49..092f5e8 100755
  
      def _load_vdis_ex(self):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0034-fix-LinstorJournaler-ensure-uri-is-not-None-during-l.patch
+++ b/SOURCES/0034-fix-LinstorJournaler-ensure-uri-is-not-None-during-l.patch
@@ -1,7 +1,7 @@
 From 5cc685d2fd43b7f4089aee6dd1f831a9b7ccaa1e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 8 Mar 2021 13:25:28 +0100
-Subject: [PATCH 034/162] fix(LinstorJournaler): ensure uri is not None during
+Subject: [PATCH 034/170] fix(LinstorJournaler): ensure uri is not None during
  linstor.KV creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -53,5 +53,5 @@ index 285012c..3993f60 100755
  
      @staticmethod
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0035-feat-LinstorSR-add-an-option-to-disable-auto-quorum-.patch
+++ b/SOURCES/0035-feat-LinstorSR-add-an-option-to-disable-auto-quorum-.patch
@@ -1,7 +1,7 @@
 From 3fe4841a4e7df555e34d2b1d130df29ab5431d2e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 22 Mar 2021 17:32:26 +0100
-Subject: [PATCH 035/162] feat(LinstorSR): add an option to disable auto-quorum
+Subject: [PATCH 035/170] feat(LinstorSR): add an option to disable auto-quorum
  on volume DB + fix doc
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -141,5 +141,5 @@ index d8d64b4..27c8df5 100755
          current_device_path = cls._request_database_path(lin, activate=True)
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0036-fix-LinstorVolumeManager-add-a-workaround-to-create-.patch
+++ b/SOURCES/0036-fix-LinstorVolumeManager-add-a-workaround-to-create-.patch
@@ -1,7 +1,7 @@
 From 3b23603e061bc794609dd7b180ca12bac787ef52 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 23 Mar 2021 14:49:39 +0100
-Subject: [PATCH 036/162] fix(LinstorVolumeManager): add a workaround to create
+Subject: [PATCH 036/170] fix(LinstorVolumeManager): add a workaround to create
  properly SR with thin LVM
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -32,5 +32,5 @@ index 27c8df5..3aaffdf 100755
          cls._check_volume_creation_errors(lin.resource_group_spawn(
              rsc_grp_name=group_name,
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0037-feat-LinstorSR-add-optional-ips-parameter.patch
+++ b/SOURCES/0037-feat-LinstorSR-add-optional-ips-parameter.patch
@@ -1,7 +1,7 @@
 From ae050ecd790f256a63d3d69e8be22b4d664c207b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 24 Mar 2021 10:06:58 +0100
-Subject: [PATCH 037/162] feat(LinstorSR): add optional ips parameter
+Subject: [PATCH 037/170] feat(LinstorSR): add optional ips parameter
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
@@ -119,5 +119,5 @@ index 3aaffdf..5c04d02 100755
          group_name = cls._build_group_name(group_name)
          pools = lin.storage_pool_list_raise(filter_by_stor_pools=[group_name])
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0038-feat-LinstorSR-add-a-helper-log_drbd_erofs-to-trace-.patch
+++ b/SOURCES/0038-feat-LinstorSR-add-a-helper-log_drbd_erofs-to-trace-.patch
@@ -1,7 +1,7 @@
 From fd0927b5edd7a489d25a951f108d1ff3be87f386 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 26 Mar 2021 16:13:20 +0100
-Subject: [PATCH 038/162] feat(LinstorSR): add a helper `log_drbd_erofs` to
+Subject: [PATCH 038/170] feat(LinstorSR): add a helper `log_drbd_erofs` to
  trace EROFS errno code with DRBD resources + check EROFS error
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -212,5 +212,5 @@ index 422834e..0a8fe91 100755
  def getVHDInfo(path, extractUuidFunction, includeParent = True):
      """Get the VHD info. The parent info may optionally be omitted: vhd-util
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0039-fix-LinstorSR-try-to-restart-the-services-again-if-t.patch
+++ b/SOURCES/0039-fix-LinstorSR-try-to-restart-the-services-again-if-t.patch
@@ -1,7 +1,7 @@
 From 9cbd9bdae07b620f87b9392e781909b2d5446b39 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 28 Apr 2021 15:15:58 +0200
-Subject: [PATCH 039/162] fix(LinstorSR): try to restart the services again if
+Subject: [PATCH 039/170] fix(LinstorSR): try to restart the services again if
  there is a failure in linstor-manager
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -70,5 +70,5 @@ index a06ed20..dcd4bc6 100755
  
  def stop_service(name):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0040-fix-LinstorSR-robustify-linstor-manager-to-never-inc.patch
+++ b/SOURCES/0040-fix-LinstorSR-robustify-linstor-manager-to-never-inc.patch
@@ -1,7 +1,7 @@
 From 594aaa43b1e7cf6d067635f195ab9a40f304b041 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 26 Aug 2021 15:26:11 +0200
-Subject: [PATCH 040/162] fix(LinstorSR): robustify linstor-manager to never
+Subject: [PATCH 040/170] fix(LinstorSR): robustify linstor-manager to never
  include from plugins path
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -35,5 +35,5 @@ index dcd4bc6..f12747f 100755
  from linstorvolumemanager import get_controller_uri, LinstorVolumeManager
  from lock import Lock
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0041-fix-LinstorSR-prevent-starting-controller-during-fai.patch
+++ b/SOURCES/0041-fix-LinstorSR-prevent-starting-controller-during-fai.patch
@@ -1,7 +1,7 @@
 From faafe4543ec4aa032eea9feeba652dd01beb1711 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 26 Aug 2021 16:52:01 +0200
-Subject: [PATCH 041/162] fix(LinstorSR): prevent starting controller during
+Subject: [PATCH 041/170] fix(LinstorSR): prevent starting controller during
  fail in linstor manager destroy method
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -61,5 +61,5 @@ index 0357b92..e9b7c2f 100755
      def _is_mounted(mountpoint):
          (ret, out, err) = util.doexec(['mountpoint', '-q', mountpoint])
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0042-feat-LinstorVolumeManager-increase-peer-slots-limit-.patch
+++ b/SOURCES/0042-feat-LinstorVolumeManager-increase-peer-slots-limit-.patch
@@ -1,7 +1,7 @@
 From 99ed7e3d9c45f1955851735bc19f1f6cd5c06120 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 19 Oct 2021 14:48:17 +0200
-Subject: [PATCH 042/162] feat(LinstorVolumeManager): increase peer slots limit
+Subject: [PATCH 042/170] feat(LinstorVolumeManager): increase peer slots limit
  (support 31 connections to a DRBD)
 
 - Also, create diskless devices when db is created
@@ -166,5 +166,5 @@ index e9b7c2f..553e2f5 100755
          # /dev/drbd/by-res/<resource_name>.
          expected_device_path = cls.build_device_path(DATABASE_VOLUME_NAME)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0043-feat-LinstorVolumeManager-add-a-fallback-to-find-con.patch
+++ b/SOURCES/0043-feat-LinstorVolumeManager-add-a-fallback-to-find-con.patch
@@ -1,7 +1,7 @@
 From 17c46febe59a332a263f683b78e569215205bdc4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 20 Oct 2021 14:33:04 +0200
-Subject: [PATCH 043/162] feat(LinstorVolumeManager): add a fallback to find
+Subject: [PATCH 043/170] feat(LinstorVolumeManager): add a fallback to find
  controller uri (when len(hosts) >= 4)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -113,5 +113,5 @@ index 553e2f5..821ef42 100755
  
  def get_controller_uri():
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0044-fix-var-lib-linstor.mount-ensure-we-always-mount-dat.patch
+++ b/SOURCES/0044-fix-var-lib-linstor.mount-ensure-we-always-mount-dat.patch
@@ -1,7 +1,7 @@
 From 80467ecc27251dfbee4357e1542a645a22cc8c8a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 21 Oct 2021 11:13:07 +0200
-Subject: [PATCH 044/162] fix(var-lib-linstor.mount): ensure we always mount
+Subject: [PATCH 044/170] fix(var-lib-linstor.mount): ensure we always mount
  database with RW flags
 
 Sometimes systemd fallback to read only FS if the volume can't be mounted, we must
@@ -106,5 +106,5 @@ index 0000000..d230d04
 +ExecStop=/bin/umount /var/lib/linstor
 +RemainAfterExit=true
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0045-feat-LinstorVolumeManager-add-a-fallback-to-find-nod.patch
+++ b/SOURCES/0045-feat-LinstorVolumeManager-add-a-fallback-to-find-nod.patch
@@ -1,7 +1,7 @@
 From 74b226834d375b559d6f9b9b6423217c363883aa Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 21 Oct 2021 11:51:32 +0200
-Subject: [PATCH 045/162] feat(LinstorVolumeManager): add a fallback to find
+Subject: [PATCH 045/170] feat(LinstorVolumeManager): add a fallback to find
  node name (when len(hosts) >= 4)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -48,5 +48,5 @@ index 821ef42..e497afa 100755
  # ==============================================================================
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0046-feat-LinstorSR-explain-on-which-host-plugins-command.patch
+++ b/SOURCES/0046-feat-LinstorSR-explain-on-which-host-plugins-command.patch
@@ -1,7 +1,7 @@
 From 8f14abe6de2f1c7ca17108d46b0218d6bb91cda2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 26 Oct 2021 10:44:00 +0200
-Subject: [PATCH 046/162] feat(LinstorSR): explain on which host, plugins
+Subject: [PATCH 046/170] feat(LinstorSR): explain on which host, plugins
  commands are executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -46,5 +46,5 @@ index 4b761b5..519afb2 100755
          )
          if ret == 'False':
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0047-fix-LinstorSR-create-diskless-path-if-necessary-duri.patch
+++ b/SOURCES/0047-fix-LinstorSR-create-diskless-path-if-necessary-duri.patch
@@ -1,7 +1,7 @@
 From 737859bcdbe9eda64059e53de554c4f8b1d7588f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 3 Nov 2021 14:59:31 +0100
-Subject: [PATCH 047/162] fix(LinstorSR): create diskless path if necessary
+Subject: [PATCH 047/170] fix(LinstorSR): create diskless path if necessary
  during VDI loading
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -32,5 +32,5 @@ index 519afb2..15b9dda 100755
              self.size = vhd_info.sizeVirt
              self.parent = vhd_info.parentUuid
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0048-feat-LinstorSR-use-HTTP-NBD-instead-of-DRBD-directly.patch
+++ b/SOURCES/0048-feat-LinstorSR-use-HTTP-NBD-instead-of-DRBD-directly.patch
@@ -1,7 +1,7 @@
 From caa0cd7e1c2fb370219af18b93cc3b05bdbd9f31 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 12 May 2022 17:52:35 +0200
-Subject: [PATCH 048/162] feat(LinstorSR): use HTTP/NBD instead of DRBD
+Subject: [PATCH 048/170] feat(LinstorSR): use HTTP/NBD instead of DRBD
  directly with heartbeat VDI
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -759,5 +759,5 @@ index 0000000..eb0f0b0
 +    finally:
 +        syslog.syslog(sys.argv[1] + ' is now terminated!')
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0049-fix-LinstorSR-find-controller-when-XAPI-unreachable-.patch
+++ b/SOURCES/0049-fix-LinstorSR-find-controller-when-XAPI-unreachable-.patch
@@ -1,7 +1,7 @@
 From 7429ffaf1ef8bf31a9e98f3c4d02465a3fc09c2f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 3 Mar 2022 15:02:17 +0100
-Subject: [PATCH 049/162] fix(LinstorSR): find controller when XAPI unreachable
+Subject: [PATCH 049/170] fix(LinstorSR): find controller when XAPI unreachable
  (XHA)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -183,5 +183,5 @@ index da98e0b..b4ee783 100755
                  linstor.errors.LinstorNetworkError,
                  LinstorVolumeManagerError
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0050-fix-LinstorSR-use-IPs-instead-of-hostnames-in-NBD-se.patch
+++ b/SOURCES/0050-fix-LinstorSR-use-IPs-instead-of-hostnames-in-NBD-se.patch
@@ -1,7 +1,7 @@
 From c32e6378ce589518849c3211cc3ecfb3a1e387c4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 24 Mar 2022 18:13:46 +0100
-Subject: [PATCH 050/162] fix(LinstorSR): use IPs instead of hostnames in NBD
+Subject: [PATCH 050/170] fix(LinstorSR): use IPs instead of hostnames in NBD
  server
 
 Without this patch we can't use XCP-ng hosts configured with static IPS.
@@ -204,5 +204,5 @@ index 50b6285..484c5f7 100755
      host_uuid = get_this_host()
      host_ref = session.xenapi.host.get_by_uuid(host_uuid)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0051-fix-LinstorVolumeManager-ensure-we-always-use-IPs-in.patch
+++ b/SOURCES/0051-fix-LinstorVolumeManager-ensure-we-always-use-IPs-in.patch
@@ -1,7 +1,7 @@
 From bb98f089065ee36bc0c244bd02015f7583a306c6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 31 Mar 2022 11:21:19 +0200
-Subject: [PATCH 051/162] fix(LinstorVolumeManager): ensure we always use IPs
+Subject: [PATCH 051/170] fix(LinstorVolumeManager): ensure we always use IPs
  in _get_controller_uri
 
 Otherwise if a hostname is returned, we can't use it if the XCP-ng pool
@@ -26,5 +26,5 @@ index b4ee783..2d5c63e 100755
          # Not found, maybe we are trying to create the SR...
          pass
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0052-feat-linstor-manager-add-methods-to-add-remove-host-.patch
+++ b/SOURCES/0052-feat-linstor-manager-add-methods-to-add-remove-host-.patch
@@ -1,7 +1,7 @@
 From 05f5f38bd8d15bdfc8d54edae2277f8d65c8be00 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 6 Apr 2022 17:53:02 +0200
-Subject: [PATCH 052/162] feat(linstor-manager): add methods to add remove/host
+Subject: [PATCH 052/170] feat(linstor-manager): add methods to add remove/host
  from LINSTOR SR
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -421,5 +421,5 @@ index 2d5c63e..6c0d5aa 100755
      def create_sr(
          cls, group_name, node_names, ips, redundancy,
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0053-feat-LinstorVolumeManager-support-SR-creation-with-d.patch
+++ b/SOURCES/0053-feat-LinstorVolumeManager-support-SR-creation-with-d.patch
@@ -1,7 +1,7 @@
 From 26eb304bf6da52ecd4512ef3543324177a4a4953 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 13 Apr 2022 15:56:42 +0200
-Subject: [PATCH 053/162] feat(LinstorVolumeManager): support SR creation with
+Subject: [PATCH 053/170] feat(LinstorVolumeManager): support SR creation with
  diskless nodes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -126,5 +126,5 @@ index 6c0d5aa..430e080 100755
                  node_name=node_name,
                  rsc_name=DATABASE_VOLUME_NAME,
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0054-feat-LinstorSR-add-a-config-var-to-disable-HTTP-NBD-.patch
+++ b/SOURCES/0054-feat-LinstorSR-add-a-config-var-to-disable-HTTP-NBD-.patch
@@ -1,7 +1,7 @@
 From ed2aa491120de96db274f2d88160e16262599928 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 14 Apr 2022 10:30:23 +0200
-Subject: [PATCH 054/162] feat(LinstorSR): add a config var to disable HTTP/NBD
+Subject: [PATCH 054/170] feat(LinstorSR): add a config var to disable HTTP/NBD
  servers
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -50,5 +50,5 @@ index 413c550..927e477 100755
          ]:
              if not self.path or not util.pathexists(self.path):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0055-feat-LinstorSr-ensure-LVM-group-is-activated-during-.patch
+++ b/SOURCES/0055-feat-LinstorSr-ensure-LVM-group-is-activated-during-.patch
@@ -1,7 +1,7 @@
 From bd232eb6a18840c9b68697f6206f0473304564c1 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 14 Apr 2022 15:45:20 +0200
-Subject: [PATCH 055/162] feat(LinstorSr): ensure LVM group is activated during
+Subject: [PATCH 055/170] feat(LinstorSr): ensure LVM group is activated during
  SR.attach/create
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -95,5 +95,5 @@ index 7e34ce6..91731b1 100755
          # We don't want to enable and start minidrbdcluster daemon during
          # SR creation.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0056-feat-linstor-manager-add-method-to-create-LinstorSR-.patch
+++ b/SOURCES/0056-feat-linstor-manager-add-method-to-create-LinstorSR-.patch
@@ -1,7 +1,7 @@
 From d292787d9db268b0c4637b1f392f6a7edb2592a1 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 25 Apr 2022 14:47:51 +0200
-Subject: [PATCH 056/162] feat(linstor-manager): add method to create LinstorSR
+Subject: [PATCH 056/170] feat(linstor-manager): add method to create LinstorSR
  + to list/destroy DRBD volumes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -243,5 +243,5 @@ index 91731b1..7893ebc 100755
 +        'destroyDrbdVolumes': destroy_drbd_volumes
      })
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0057-fix-LinstorSR-always-set-vdi_path-in-generate_config.patch
+++ b/SOURCES/0057-fix-LinstorSR-always-set-vdi_path-in-generate_config.patch
@@ -1,7 +1,7 @@
 From d582f1c81851ed7985def8b5d7e3e273f1a38f80 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 26 Apr 2022 11:20:08 +0200
-Subject: [PATCH 057/162] fix(LinstorSR): always set vdi_path in
+Subject: [PATCH 057/170] fix(LinstorSR): always set vdi_path in
  generate_config
 
 If the volume of a generated config is not related to HTTP/NBD
@@ -27,5 +27,5 @@ index e2d3d78..1855e3d 100755
              # Axiom: DRBD device is present on at least one host.
              resp['vdi_path'] = '/dev/http-nbd/' + volume_name
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0058-fix-minidrbdcluster-supports-new-properties-like-for.patch
+++ b/SOURCES/0058-fix-minidrbdcluster-supports-new-properties-like-for.patch
@@ -1,7 +1,7 @@
 From 853897fbcb513d4d5243ac96db61566e8e7ca49d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 13 May 2022 14:35:57 +0200
-Subject: [PATCH 058/162] fix(minidrbdcluster): supports new properties like
+Subject: [PATCH 058/170] fix(minidrbdcluster): supports new properties like
  `force-io-failures`
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -33,5 +33,5 @@ index a04b6c1..fb4de09 100755
  
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0059-fix-LinstorSR-enabled-disable-minidrbcluster-with-fi.patch
+++ b/SOURCES/0059-fix-LinstorSR-enabled-disable-minidrbcluster-with-fi.patch
@@ -1,7 +1,7 @@
 From 08440b3303fc98eb9388e120d785f3faafe4dd6e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:33 +0200
-Subject: [PATCH 059/162] fix(LinstorSR): enabled/disable minidrbcluster with
+Subject: [PATCH 059/170] fix(LinstorSR): enabled/disable minidrbcluster with
  fixed order
 
 Ensure we disable minidrbdcluster during SR destruction on all hosts
@@ -80,5 +80,5 @@ index 1855e3d..57280e3 100755
      # --------------------------------------------------------------------------
      # Metadata.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0060-fix-linstor-manager-change-linstor-satellite-start-b.patch
+++ b/SOURCES/0060-fix-linstor-manager-change-linstor-satellite-start-b.patch
@@ -1,7 +1,7 @@
 From 15af209d89a9157c62a31a67a24afa4b4c2b8317 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 31 May 2022 14:01:45 +0200
-Subject: [PATCH 060/162] fix(linstor-manager): change linstor satellite start
+Subject: [PATCH 060/170] fix(linstor-manager): change linstor satellite start
  behavior
 
 Ensure we don't have an invalid cache used by a satellite:
@@ -37,5 +37,5 @@ index 7893ebc..c6d622f 100755
  
  def update_minidrbdcluster_service(start):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0061-Fix-is_open-call-for-LinstorSR.patch
+++ b/SOURCES/0061-Fix-is_open-call-for-LinstorSR.patch
@@ -1,7 +1,7 @@
 From 2b9b22437dbcbf2bf8019537c9ecb6430e4e1b23 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Jun 2022 09:04:28 +0200
-Subject: [PATCH 061/162] Fix is_open call for LinstorSR
+Subject: [PATCH 061/170] Fix is_open call for LinstorSR
 
 1. Ensure LinstorSR driver is imported in `_is_open` definition to register it in the driver list.
 Otherwise this function always fails with a SRUnknownType exception.
@@ -102,5 +102,5 @@ index 54ebcd3..4c12d90 100644
      def fake_import(self, name, *args):
          print 'Asked to import {}'.format(name)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0062-fix-linstorvhdutil-fix-boolean-params-of-check-call.patch
+++ b/SOURCES/0062-fix-linstorvhdutil-fix-boolean-params-of-check-call.patch
@@ -1,7 +1,7 @@
 From 8f86e42342b222fea775268344b223b87313699c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Jun 2022 09:28:32 +0200
-Subject: [PATCH 062/162] fix(linstorvhdutil): fix boolean params of `check`
+Subject: [PATCH 062/170] fix(linstorvhdutil): fix boolean params of `check`
  call
 
 `ignoreMissingFooter` and `fast` must be string types to be used with XAPI plugin API.
@@ -46,5 +46,5 @@ index 9ba0ac3..f3d9870 100644
  
      @linstorhostcall(vhdutil.check, 'check')
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0063-feat-linstor-manager-robustify-exec_create_sr.patch
+++ b/SOURCES/0063-feat-linstor-manager-robustify-exec_create_sr.patch
@@ -1,7 +1,7 @@
 From e44c0f5a596846a9d253cbe0b886312b19ff9a58 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 30 Jun 2022 17:09:51 +0200
-Subject: [PATCH 063/162] feat(linstor-manager): robustify exec_create_sr
+Subject: [PATCH 063/170] feat(linstor-manager): robustify exec_create_sr
 
 - Use lvm.py XCP-ng xapi plugins instead of lvm (old name)
 - Check arguments to create the SR
@@ -202,5 +202,5 @@ index 63c0e3e..2930a9e 100755
          util.SMlog('linstor-manager:create_sr error: {}'.format(e))
          raise
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0064-fix-cleanup-print-LINSTOR-VDI-UUID-if-error-during-i.patch
+++ b/SOURCES/0064-fix-cleanup-print-LINSTOR-VDI-UUID-if-error-during-i.patch
@@ -1,7 +1,7 @@
 From 1e33439ce7625c6a15135c033496b06592b99df7 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 8 Jul 2022 14:52:25 +0200
-Subject: [PATCH 064/162] fix(cleanup): print LINSTOR VDI UUID if error during
+Subject: [PATCH 064/170] fix(cleanup): print LINSTOR VDI UUID if error during
  info loading (not SR UUID)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -23,5 +23,5 @@ index 0399389..77b38c2 100755
                  info = vhdutil.VHDInfo(vdi_uuid)
                  info.error = 1
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0065-feat-cleanup-raise-and-dump-DRBD-openers-in-case-of-.patch
+++ b/SOURCES/0065-feat-cleanup-raise-and-dump-DRBD-openers-in-case-of-.patch
@@ -1,7 +1,7 @@
 From 5d9ec7449370fc757375aff9ec4dac3ecb47e21a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 21 Jul 2022 11:39:20 +0200
-Subject: [PATCH 065/162] feat(cleanup): raise and dump DRBD openers in case of
+Subject: [PATCH 065/170] feat(cleanup): raise and dump DRBD openers in case of
  bad coalesce
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -142,5 +142,5 @@ index 430e080..d17845b 100755
          """
          Give a volume dictionnary that contains names actually owned.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0066-feat-linstorvhdutil-trace-DRBD-openers-in-case-of-ER.patch
+++ b/SOURCES/0066-feat-linstorvhdutil-trace-DRBD-openers-in-case-of-ER.patch
@@ -1,7 +1,7 @@
 From 0af045b9acf9fd3d8f3ac8d8e96b5017e36c34e9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 22 Jul 2022 10:26:20 +0200
-Subject: [PATCH 066/162] feat(linstorvhdutil): trace DRBD openers in case of
+Subject: [PATCH 066/170] feat(linstorvhdutil): trace DRBD openers in case of
  EROFS errors
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -131,5 +131,5 @@ index f3d9870..d6a21c2 100644
      # --------------------------------------------------------------------------
      # Helpers.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0067-fix-linstorvolumemanager-compute-correctly-size-in-a.patch
+++ b/SOURCES/0067-fix-linstorvolumemanager-compute-correctly-size-in-a.patch
@@ -1,7 +1,7 @@
 From 80a155ededcf8753c355e7c2348a103a20ba28b3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 29 Jul 2022 17:25:48 +0200
-Subject: [PATCH 067/162] fix(linstorvolumemanager): compute correctly size in
+Subject: [PATCH 067/170] fix(linstorvolumemanager): compute correctly size in
  allocated_volume_size
 
 Remove replication count in computation.
@@ -94,5 +94,5 @@ index d17845b..3806cc9 100755
      @property
      def metadata(self):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0068-feat-LinstorSR-use-DRBD-openers-instead-of-lsof-to-l.patch
+++ b/SOURCES/0068-feat-LinstorSR-use-DRBD-openers-instead-of-lsof-to-l.patch
@@ -1,7 +1,7 @@
 From ccd061b1379d8a32b1991f0d56c4f42a8f24064f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 9 Aug 2022 11:07:57 +0200
-Subject: [PATCH 068/162] feat(LinstorSR): use DRBD openers instead of lsof to
+Subject: [PATCH 068/170] feat(LinstorSR): use DRBD openers instead of lsof to
  log in blktap2
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -323,5 +323,5 @@ index 3806cc9..6f4c590 100755
 +            '`{}` is open: {}'.format(path, e)
 +        )
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0069-feat-LinstorSR-support-cProfile-to-trace-calls-when-.patch
+++ b/SOURCES/0069-feat-LinstorSR-support-cProfile-to-trace-calls-when-.patch
@@ -1,7 +1,7 @@
 From df532ff98a2ca941559b3c097d3c4c46ac1e577e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 25 Aug 2022 12:11:18 +0200
-Subject: [PATCH 069/162] feat(LinstorSR): support cProfile to trace calls when
+Subject: [PATCH 069/170] feat(LinstorSR): support cProfile to trace calls when
  a command is executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -89,5 +89,5 @@ index 484c5f7..2ccfe3d 100755
 +    finally:
 +        SMlog('* End profiling of {} ({}) *'.format(name, filename))
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0070-fix-LinstorJournaler-reset-namespace-when-get-is-cal.patch
+++ b/SOURCES/0070-fix-LinstorJournaler-reset-namespace-when-get-is-cal.patch
@@ -1,7 +1,7 @@
 From be6a19efb1dc688d0b8adc2d91782745f42900f7 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 24 Aug 2022 17:09:11 +0200
-Subject: [PATCH 070/162] fix(LinstorJournaler): reset namespace when `get` is
+Subject: [PATCH 070/170] fix(LinstorJournaler): reset namespace when `get` is
  called
 
 Otherwise, we can be in the wrong namespace and the key to find will be inaccessible.
@@ -22,5 +22,5 @@ index 3993f60..1e85ec9 100755
  
      def get_all(self, type):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0071-fix-linstorvhdutil-fix-coalesce-with-VM-running-unde.patch
+++ b/SOURCES/0071-fix-linstorvhdutil-fix-coalesce-with-VM-running-unde.patch
@@ -1,7 +1,7 @@
 From 9890e5f200aac7f995460df1b28d7916c2bfa762 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 25 Aug 2022 10:54:56 +0200
-Subject: [PATCH 071/162] fix(linstorvhdutil): fix coalesce with VM running
+Subject: [PATCH 071/170] fix(linstorvhdutil): fix coalesce with VM running
  under specific scenario:
 
 When a VM is running, we can't coalesce without this patch with a long chain
@@ -550,5 +550,5 @@ index 0a8fe91..d75edb1 100755
  def getVHDInfo(path, extractUuidFunction, includeParent = True):
      """Get the VHD info. The parent info may optionally be omitted: vhd-util
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0072-fix-linstorvolumemanager-_get_volumes_info-doesn-t-r.patch
+++ b/SOURCES/0072-fix-linstorvolumemanager-_get_volumes_info-doesn-t-r.patch
@@ -1,7 +1,7 @@
 From a06a01d85d69d5cd676b9ebe59c0230fca308acf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Sep 2022 15:09:17 +0200
-Subject: [PATCH 072/162] fix(linstorvolumemanager): `_get_volumes_info`
+Subject: [PATCH 072/170] fix(linstorvolumemanager): `_get_volumes_info`
  doesn't raise with offline host
 
 Ensure this method doesn't raise an exception when a host is offline.
@@ -46,5 +46,5 @@ index 6f4c590..a1bc151 100755
          for current in all_volume_info.values():
              current.allocated_size *= 1024
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0073-fix-linstorvolumemanager-remove-double-prefix-on-kv-.patch
+++ b/SOURCES/0073-fix-linstorvolumemanager-remove-double-prefix-on-kv-.patch
@@ -1,7 +1,7 @@
 From 2809c0e8e602aa1a72967aa88c96009dc93651c2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 12 Sep 2022 15:56:09 +0200
-Subject: [PATCH 073/162] fix(linstorvolumemanager): remove double prefix on kv
+Subject: [PATCH 073/170] fix(linstorvolumemanager): remove double prefix on kv
  group name
 
 - Before this patch, when the kv store was created/accessed, a double "xcp-sr-" prefix was used.
@@ -36,5 +36,5 @@ index a1bc151..3ee5d24 100755
      def _build_sr_namespace(cls):
          return '/{}/'.format(cls.NAMESPACE_SR)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0074-feat-LinstorSR-add-linstor-kv-dump-helper-to-print-k.patch
+++ b/SOURCES/0074-feat-LinstorSR-add-linstor-kv-dump-helper-to-print-k.patch
@@ -1,7 +1,7 @@
 From d6c620d3969c77f49f1331604a11450f3302d666 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 12 Sep 2022 17:54:57 +0200
-Subject: [PATCH 074/162] feat(LinstorSR): add linstor-kv-dump helper to print
+Subject: [PATCH 074/170] feat(LinstorSR): add linstor-kv-dump helper to print
  kv store
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -68,5 +68,5 @@ index 0000000..93598d7
 +if __name__ == '__main__':
 +    main()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0075-fix-LinstorSR-disable-VHD-key-hash-usage-to-limit-ex.patch
+++ b/SOURCES/0075-fix-LinstorSR-disable-VHD-key-hash-usage-to-limit-ex.patch
@@ -1,7 +1,7 @@
 From 6872886a900ddb25f2c34a7857c591f0885daced Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 14 Sep 2022 10:17:18 +0200
-Subject: [PATCH 075/162] fix(LinstorSR): disable VHD key hash usage to limit
+Subject: [PATCH 075/170] fix(LinstorSR): disable VHD key hash usage to limit
  exec time
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -33,5 +33,5 @@ index 47ac3c8..374d6cb 100755
                  # https://github.com/PyCQA/pylint/pull/2926
                  vdi.sm_config_override['key_hash'] = \
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0076-fix-minidrbdcluster-ensure-SIGINT-is-handled-correct.patch
+++ b/SOURCES/0076-fix-minidrbdcluster-ensure-SIGINT-is-handled-correct.patch
@@ -1,7 +1,7 @@
 From 832b8b4e4fab36c8c0b7b003ea4a1d26c40c6197 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 15 Sep 2022 11:34:25 +0200
-Subject: [PATCH 076/162] fix(minidrbdcluster): ensure SIGINT is handled
+Subject: [PATCH 076/170] fix(minidrbdcluster): ensure SIGINT is handled
  correctly
 
 This patch is here to make sure no LINSTOR controller survives when
@@ -95,5 +95,5 @@ index 3de6ac4..1ddf91f 100644
  StandardError=journal
  SyslogIdentifier=minidrbdcluster
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0077-feat-minidrbdcluster-stop-resource-services-at-start.patch
+++ b/SOURCES/0077-feat-minidrbdcluster-stop-resource-services-at-start.patch
@@ -1,7 +1,7 @@
 From 636855ee08dc843fcabb542e8e5e8736455e0a67 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 15 Sep 2022 11:49:34 +0200
-Subject: [PATCH 077/162] feat(minidrbdcluster): stop resource services at
+Subject: [PATCH 077/170] feat(minidrbdcluster): stop resource services at
  startup
 
 - Ensure all services are stopped when minidrbcluster is started.
@@ -131,5 +131,5 @@ index 4cdc59e..eae7cbf 100755
  if __name__ == '__main__':
      main()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0078-feat-linstor-manager-add-new-healthCheck-function-to.patch
+++ b/SOURCES/0078-feat-linstor-manager-add-new-healthCheck-function-to.patch
@@ -1,7 +1,7 @@
 From d3553ff5a9afdd77a644c0fe90b8b4f014b2cc78 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 23 Sep 2022 17:45:08 +0200
-Subject: [PATCH 078/162] feat(linstor-manager): add new `healthCheck` function
+Subject: [PATCH 078/170] feat(linstor-manager): add new `healthCheck` function
  to monitor pool (#26)
 
 Print a JSON output to monitor state of LINSTOR SRs:
@@ -357,5 +357,5 @@ index 3ee5d24..efe5d53 100755
      def create_sr(
          cls, group_name, node_names, ips, redundancy,
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0079-fix-LinstorSR-fix-xha-conf-parsing-return-host-ip-no.patch
+++ b/SOURCES/0079-fix-LinstorSR-fix-xha-conf-parsing-return-host-ip-no.patch
@@ -1,7 +1,7 @@
 From dc2488a78137cdb7b92771ea395017eedfd8c0b5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 4 Oct 2022 11:01:33 +0200
-Subject: [PATCH 079/162] fix(LinstorSR): fix xha conf parsing => return host
+Subject: [PATCH 079/170] fix(LinstorSR): fix xha conf parsing => return host
  ip, not the UUID
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -50,5 +50,5 @@ index 374d6cb..d32771f 100755
  
  def activate_lvm_group(group_name):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0080-fix-LinstorSR-start-correctly-HA-servers-HTTP-NBD-af.patch
+++ b/SOURCES/0080-fix-LinstorSR-start-correctly-HA-servers-HTTP-NBD-af.patch
@@ -1,7 +1,7 @@
 From 5608daa70d5c0064914633f3337ce2d977359238 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 4 Oct 2022 18:48:09 +0200
-Subject: [PATCH 080/162] fix(LinstorSR): start correctly HA servers (HTTP/NBD)
+Subject: [PATCH 080/170] fix(LinstorSR): start correctly HA servers (HTTP/NBD)
  after reboot
 
 Use a timeout call after a reboot to get a XAPI session because
@@ -40,5 +40,5 @@ index d32771f..ae25385 100755
              except Exception as e:
                  _, ips = get_ips_from_xha_config_file()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0081-fix-linstorvolumemanager-use-an-array-to-store-diskf.patch
+++ b/SOURCES/0081-fix-linstorvolumemanager-use-an-array-to-store-diskf.patch
@@ -1,7 +1,7 @@
 From e3b307674995e6fee6999ee60830b2595ea45ca4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 5 Oct 2022 10:45:50 +0200
-Subject: [PATCH 081/162] fix(linstorvolumemanager): use an array to store
+Subject: [PATCH 081/170] fix(linstorvolumemanager): use an array to store
  diskful volumes info
 
 Otherwise the `is_diskful` attr only reflects the info of one host
@@ -74,5 +74,5 @@ index efe5d53..e577f63 100755
              for volume in resource.volumes:
                  # We ignore diskless pools of the form "DfltDisklessStorPool".
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0082-feat-linstorvolumemanager-support-snaps-when-a-host-.patch
+++ b/SOURCES/0082-feat-linstorvolumemanager-support-snaps-when-a-host-.patch
@@ -1,7 +1,7 @@
 From 8e655c6b51a7d4b16381b63deb08cb2c63137fbb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 6 Oct 2022 17:54:10 +0200
-Subject: [PATCH 082/162] feat(linstorvolumemanager): support snaps when a host
+Subject: [PATCH 082/170] feat(linstorvolumemanager): support snaps when a host
  is offline
 
 - Don't create diskless volumes during clone, delay it.
@@ -29,5 +29,5 @@ index e577f63..09aad42 100755
          # 5. Create resources!
          def clean():
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0083-fix-linstorvolumemanager-support-offline-hosts-when-.patch
+++ b/SOURCES/0083-fix-linstorvolumemanager-support-offline-hosts-when-.patch
@@ -1,7 +1,7 @@
 From 2fc84857dcaadb6193ab1571eff474da59e6ecdf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 7 Oct 2022 17:18:37 +0200
-Subject: [PATCH 083/162] fix(linstorvolumemanager): support offline hosts when
+Subject: [PATCH 083/170] fix(linstorvolumemanager): support offline hosts when
  plugins are called
 
 - Robustify plugin calls
@@ -111,5 +111,5 @@ index 09aad42..58c0238 100755
  # ==============================================================================
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0084-fix-linstorvolumemanager-define-_base_group_name-mem.patch
+++ b/SOURCES/0084-fix-linstorvolumemanager-define-_base_group_name-mem.patch
@@ -1,7 +1,7 @@
 From aed261d7b441d76ea43c0eedfc5d9cdb754c6b31 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 7 Oct 2022 17:45:26 +0200
-Subject: [PATCH 084/162] fix(linstorvolumemanager): define _base_group_name
+Subject: [PATCH 084/170] fix(linstorvolumemanager): define _base_group_name
  member at SR creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -30,5 +30,5 @@ index 58c0238..d19effb 100755
          instance._volumes = set()
          instance._storage_pools_time = 0
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0085-feat-linstorvhdutil-modify-logic-of-local-vhdutil-ca.patch
+++ b/SOURCES/0085-feat-linstorvhdutil-modify-logic-of-local-vhdutil-ca.patch
@@ -1,7 +1,7 @@
 From c81193a7faefc8f38c25d362b975de1a0c5057d2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 10 Oct 2022 14:33:24 +0200
-Subject: [PATCH 085/162] feat(linstorvhdutil): modify logic of local vhdutil
+Subject: [PATCH 085/170] feat(linstorvhdutil): modify logic of local vhdutil
  calls
 
 - Always log openers when we can't call vhdutil locally
@@ -144,5 +144,5 @@ index 4d031e1..2687cad 100644
              )
          return util.retry(remote_call, 5, 2)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0086-fix-linstorvolumemanager-robustify-failed-snapshots.patch
+++ b/SOURCES/0086-fix-linstorvolumemanager-robustify-failed-snapshots.patch
@@ -1,7 +1,7 @@
 From fc8ee867ee6ee277ab1ddd31cad6724d86ba51ac Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 17 Oct 2022 18:14:16 +0200
-Subject: [PATCH 086/162] fix(linstorvolumemanager): robustify failed snapshots
+Subject: [PATCH 086/170] fix(linstorvolumemanager): robustify failed snapshots
 
 - Ensure we can always rename a failed snap, so we must check if
   we have metadata in the KV-store. Otherwise an error is triggered
@@ -49,5 +49,5 @@ index d19effb..44b247e 100755
              dest_namespace = self._build_volume_namespace(dest_uuid)
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0087-fix-linstorvolumemanager-use-a-namespace-for-volumes.patch
+++ b/SOURCES/0087-fix-linstorvolumemanager-use-a-namespace-for-volumes.patch
@@ -1,7 +1,7 @@
 From 7425db87fdd3a3e4b2c5996c2b3d82ff8116d2a6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 8 Nov 2022 17:31:45 +0100
-Subject: [PATCH 087/162] fix(linstorvolumemanager): use a namespace for
+Subject: [PATCH 087/170] fix(linstorvolumemanager): use a namespace for
  volumes
 
 - This change is not compatible with existing LINSTOR SR instances!
@@ -25,5 +25,5 @@ index 44b247e..8c253d4 100755
      # Regex to match properties.
      REG_PROP = '^([^/]+)/{}$'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0088-feat-linstor-kv-dump-rename-to-linstor-kv-tool-add-r.patch
+++ b/SOURCES/0088-feat-linstor-kv-dump-rename-to-linstor-kv-tool-add-r.patch
@@ -1,7 +1,7 @@
 From 29de3c5348aa96e5b414a55b8cce3016702b603a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 14 Nov 2022 17:18:48 +0100
-Subject: [PATCH 088/162] feat(linstor-kv-dump): rename to linstor-kv-tool +
+Subject: [PATCH 088/170] feat(linstor-kv-dump): rename to linstor-kv-tool +
  add remove volume helpers
 
 ---
@@ -93,5 +93,5 @@ index 93598d7..128d899 100755
  if __name__ == '__main__':
      main()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0089-fix-LinstorSR-handle-correctly-localhost-during-star.patch
+++ b/SOURCES/0089-fix-LinstorSR-handle-correctly-localhost-during-star.patch
@@ -1,7 +1,7 @@
 From 494d9c43eca674e1ace0d024762edd0a8ccb2db3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Nov 2022 12:12:12 +0100
-Subject: [PATCH 089/162] fix(LinstorSR): handle correctly localhost during
+Subject: [PATCH 089/170] fix(LinstorSR): handle correctly localhost during
  start/stop of minidrbdcluster
 
 Otherwise another controller can be started during `xe sr-destroy` call.
@@ -71,5 +71,5 @@ index b855807..ba28452 100755
              # the controller host last. Why? Otherwise the linstor-controller
              # of other nodes can be started, and we don't want that.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0090-fix-cleanup.py-call-repair-on-another-host-when-EROF.patch
+++ b/SOURCES/0090-fix-cleanup.py-call-repair-on-another-host-when-EROF.patch
@@ -1,7 +1,7 @@
 From d4ecb7a2794959edd538f4be31e92851b913f773 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 17 Nov 2022 15:43:25 +0100
-Subject: [PATCH 090/162] fix(cleanup.py): call repair on another host when
+Subject: [PATCH 090/170] fix(cleanup.py): call repair on another host when
  EROFS is returned (DRBD)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -58,5 +58,5 @@ index 9d55baa..bf0cc46 100755
          abortFlag = IPCFlag(self.sr.uuid)
          for child in self.children:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0091-fix-LinstorSR-avoid-introduction-of-DELETED-volumes.patch
+++ b/SOURCES/0091-fix-LinstorSR-avoid-introduction-of-DELETED-volumes.patch
@@ -1,7 +1,7 @@
 From 358c8b110e595f822366ee047f14b0645ecd21d9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 17 Nov 2022 15:46:02 +0100
-Subject: [PATCH 091/162] fix(LinstorSR): avoid introduction of DELETED volumes
+Subject: [PATCH 091/170] fix(LinstorSR): avoid introduction of DELETED volumes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
@@ -23,5 +23,5 @@ index ba28452..9e5b3cd 100755
                      'Trying to introduce VDI {} as it is present in '
                      'LINSTOR and not in XAPI...'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0092-feat-linstor-kv-tool-remove-all-volumes-supports-jou.patch
+++ b/SOURCES/0092-feat-linstor-kv-tool-remove-all-volumes-supports-jou.patch
@@ -1,7 +1,7 @@
 From 2a5462a741cfb96d3ee1efc59a784a1d7667dbf6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 18 Nov 2022 10:40:58 +0100
-Subject: [PATCH 092/162] feat(linstor-kv-tool): remove-all-volumes supports
+Subject: [PATCH 092/170] feat(linstor-kv-tool): remove-all-volumes supports
  journals now
 
 Not yet supported for remove-volume, not sure about the consequences
@@ -26,5 +26,5 @@ index 128d899..c907027 100755
              kv.namespace = key[:size]
              del kv[key[size + 1:]]
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0093-fix-linstorvhdutil-due-to-bad-refactoring-check-call.patch
+++ b/SOURCES/0093-fix-linstorvhdutil-due-to-bad-refactoring-check-call.patch
@@ -1,7 +1,7 @@
 From a5579f097a3c5a52553667a25fc0d8d7a934c74b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 23 Nov 2022 15:26:51 +0100
-Subject: [PATCH 093/162] fix(linstorvhdutil): due to bad refactoring, check
+Subject: [PATCH 093/170] fix(linstorvhdutil): due to bad refactoring, check
  call was broken
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -29,5 +29,5 @@ index 2687cad..a883ca4 100644
      def get_vhd_info(self, vdi_uuid, include_parent=True):
          kwargs = {'includeParent': str(include_parent)}
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0094-feat-linstorvhdutil-ensure-we-use-VHD-parent-to-find.patch
+++ b/SOURCES/0094-feat-linstorvhdutil-ensure-we-use-VHD-parent-to-find.patch
@@ -1,7 +1,7 @@
 From 51928b8d3ae2b35402e49eee9a0b3fb68f11de60 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 23 Nov 2022 15:28:23 +0100
-Subject: [PATCH 094/162] feat(linstorvhdutil): ensure we use VHD parent to
+Subject: [PATCH 094/170] feat(linstorvhdutil): ensure we use VHD parent to
  find host where to coalesce
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -65,5 +65,5 @@ index a883ca4..c2e9665 100644
                  raise xs_errors.XenError(
                      'VDIUnavailable',
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0095-feat-linstorvolumemanager-force-DRBD-demote-after-fa.patch
+++ b/SOURCES/0095-feat-linstorvolumemanager-force-DRBD-demote-after-fa.patch
@@ -1,7 +1,7 @@
 From 21e65118c6ddce4bab3816a6f32c87a7914a2efa Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Dec 2022 18:40:11 +0100
-Subject: [PATCH 095/162] feat(linstorvolumemanager): force DRBD demote after
+Subject: [PATCH 095/170] feat(linstorvolumemanager): force DRBD demote after
  failed volume creation/clone
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -235,5 +235,5 @@ index 8c253d4..2e2feb2 100755
                  # Assume this call is atomic.
                  properties.clear()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0096-fix-linstorvhdutil-ensure-we-retry-creation-in-all-s.patch
+++ b/SOURCES/0096-fix-linstorvhdutil-ensure-we-retry-creation-in-all-s.patch
@@ -1,7 +1,7 @@
 From 2815463f7aae0f5facf60132bfb76c633c3b4b81 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Dec 2022 11:22:15 +0100
-Subject: [PATCH 096/162] fix(linstorvhdutil): ensure we retry creation in all
+Subject: [PATCH 096/170] fix(linstorvhdutil): ensure we retry creation in all
  situations
 
 Without this patch, a basic resource creation is never restarted
@@ -117,5 +117,5 @@ index 2e2feb2..81cce80 100755
              except LinstorVolumeManagerError as e:
                  if e.code != LinstorVolumeManagerError.ERR_VOLUME_EXISTS:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0097-fix-linstorvhdutil-don-t-retry-local-vhdutil-call-wh.patch
+++ b/SOURCES/0097-fix-linstorvhdutil-don-t-retry-local-vhdutil-call-wh.patch
@@ -1,7 +1,7 @@
 From e9946a400b74208d598e8536edc83c548b5e284b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 7 Dec 2022 17:56:39 +0100
-Subject: [PATCH 097/162] fix(linstorvhdutil): don't retry local vhdutil call
+Subject: [PATCH 097/170] fix(linstorvhdutil): don't retry local vhdutil call
  when EROFS is detected
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -154,5 +154,5 @@ index c2e9665..63d59ab 100644
          # B. Execute the command on another host.
          # B.1. Get host list.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0098-feat-fork-log-daemon-ignore-SIGTERM.patch
+++ b/SOURCES/0098-feat-fork-log-daemon-ignore-SIGTERM.patch
@@ -1,7 +1,7 @@
 From 8a683f270d5cf30ad5ad1f2f163207681bdc5e83 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 15 Dec 2022 14:36:04 +0100
-Subject: [PATCH 098/162] feat(fork-log-daemon): ignore SIGTERM
+Subject: [PATCH 098/170] feat(fork-log-daemon): ignore SIGTERM
 
 Without this patch, the output logs of the fork-log-daemon child
 are never displayed when SIGTERM is sent to the PGID.
@@ -31,5 +31,5 @@ index eb0f0b0..665a60b 100755
  
      while process.poll() is None:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0099-feat-LinstorSR-wait-for-http-disk-server-startup.patch
+++ b/SOURCES/0099-feat-LinstorSR-wait-for-http-disk-server-startup.patch
@@ -1,7 +1,7 @@
 From 3a4f37788e555c8b36d7edfc35bd77a91d8f6e96 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 16 Dec 2022 16:52:50 +0100
-Subject: [PATCH 099/162] feat(LinstorSR): wait for http-disk-server startup
+Subject: [PATCH 099/170] feat(LinstorSR): wait for http-disk-server startup
 
 Avoid a race condition with NBD server.
 We must be sure the HTTP server is reachable before the NBD server execution,
@@ -112,5 +112,5 @@ index 9e5b3cd..f336534 100755
      @classmethod
      def _kill_persistent_server(self, type, volume_name, sig):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0100-fix-LinstorSR-handle-inflate-resize-actions-correctl.patch
+++ b/SOURCES/0100-fix-LinstorSR-handle-inflate-resize-actions-correctl.patch
@@ -1,7 +1,7 @@
 From 2d4eb5c04cd238ce94a1bb43ef8cd92c43f6e7fb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Jan 2023 17:58:51 +0100
-Subject: [PATCH 100/162] fix(LinstorSR): handle inflate + resize actions
+Subject: [PATCH 100/170] fix(LinstorSR): handle inflate + resize actions
  correctly
 
 - Ensure LINSTOR set the expected new volume size when inflate is executed,
@@ -130,5 +130,5 @@ index f336534..72ec9de 100755
                  # VDI is currently deflated, so keep it deflated.
                  new_volume_size = old_volume_size
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0101-fix-linstor-manager-add-a-static-iptables-rule-for-D.patch
+++ b/SOURCES/0101-fix-linstor-manager-add-a-static-iptables-rule-for-D.patch
@@ -1,7 +1,7 @@
 From 2654ba8de5d838b45d04760d5e151bac9929ca2e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 17 Jan 2023 11:55:00 +0100
-Subject: [PATCH 101/162] fix(linstor-manager): add a static iptables rule for
+Subject: [PATCH 101/170] fix(linstor-manager): add a static iptables rule for
  DRBD volumes
 
 Using the XAPI iptables firewall may drop DRBD packets when the connection
@@ -121,5 +121,5 @@ index 5c4c5c9..6ee435c 100755
          util.SMlog('Error while stopping services: {}'.format(e))
          pass
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0102-feat-LinstorSR-sync-with-last-http-nbd-transfer-vers.patch
+++ b/SOURCES/0102-feat-LinstorSR-sync-with-last-http-nbd-transfer-vers.patch
@@ -1,7 +1,7 @@
 From 4dbffe41ae626c1f3e79111844c51b2507412622 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 3 Feb 2023 16:38:49 +0100
-Subject: [PATCH 102/162] feat(LinstorSR): sync with last http-nbd-transfer
+Subject: [PATCH 102/170] feat(LinstorSR): sync with last http-nbd-transfer
  version
 
 - Increase auto promote timeout of heartbeat VDI to reduce CPU usage
@@ -118,5 +118,5 @@ index 81cce80..e0f39e7 100755
          """
          Get the volume info of a particular volume.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0103-fix-LinstorSR-don-t-check-VDI-metadata-while-listing.patch
+++ b/SOURCES/0103-fix-LinstorSR-don-t-check-VDI-metadata-while-listing.patch
@@ -1,7 +1,7 @@
 From dadcfdc954c4f00d5a15dd0abb787d1fd80e1f32 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 13 Feb 2023 17:24:16 +0100
-Subject: [PATCH 103/162] fix(LinstorSR): don't check VDI metadata while
+Subject: [PATCH 103/170] fix(LinstorSR): don't check VDI metadata while
  listing VDIs if it's deleted
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -34,5 +34,5 @@ index 31f4505..41ece82 100755
                      'Trying to introduce VDI {} as it is present in '
                      'LINSTOR and not in XAPI...'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0104-fix-LinstorSR-don-t-check-metadata-when-destroying-s.patch
+++ b/SOURCES/0104-fix-LinstorSR-don-t-check-metadata-when-destroying-s.patch
@@ -1,7 +1,7 @@
 From 16bf2ebb937da0b1beff0842c3be570c8faf592f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 13 Feb 2023 17:27:43 +0100
-Subject: [PATCH 104/162] fix(LinstorSR): don't check metadata when destroying
+Subject: [PATCH 104/170] fix(LinstorSR): don't check metadata when destroying
  snap in undo_clone
 
 Remove useless check in the snap rollback helper when there is an error
@@ -31,5 +31,5 @@ index 41ece82..94cf1b7 100755
              try:
                  self._linstor.destroy_volume(snap_uuid)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0105-fix-linstorvhdutil-handle-correctly-generic-exceptio.patch
+++ b/SOURCES/0105-fix-linstorvhdutil-handle-correctly-generic-exceptio.patch
@@ -1,7 +1,7 @@
 From 74a5a210f9f0187d6cdde7339fd41b99b921913c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 15 Feb 2023 11:34:54 +0100
-Subject: [PATCH 105/162] fix(linstorvhdutil): handle correctly generic
+Subject: [PATCH 105/170] fix(linstorvhdutil): handle correctly generic
  exceptions in _raise_openers_exception
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -59,5 +59,5 @@ index 63d59ab..05225e8 100644
      def _call_vhd_util(self, local_method, remote_method, device_path, use_parent, *args, **kwargs):
          # Note: `use_parent` exists to know if the VHD parent is used by the local/remote method.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0106-fix-minidrbdcluster-robustify-to-unmount-correctly-L.patch
+++ b/SOURCES/0106-fix-minidrbdcluster-robustify-to-unmount-correctly-L.patch
@@ -1,7 +1,7 @@
 From aaadb786525c3aed8223df9752e0788e80bf6697 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 16 Feb 2023 14:24:07 +0100
-Subject: [PATCH 106/162] fix(minidrbdcluster): robustify to unmount correctly
+Subject: [PATCH 106/170] fix(minidrbdcluster): robustify to unmount correctly
  LINSTOR DB
 
 There is a small delay during which the database may not be unmounted
@@ -85,5 +85,5 @@ index 0000000..9c1dcc4
 +    args = parser.parse_args()
 +    sys.exit(safe_umount(args.path))
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0107-fix-minidrbdcluster-handle-correctly-KeyboardInterru.patch
+++ b/SOURCES/0107-fix-minidrbdcluster-handle-correctly-KeyboardInterru.patch
@@ -1,7 +1,7 @@
 From e4eccbbd031998dba2ff8f535bd982655162c202 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Feb 2023 19:30:18 +0100
-Subject: [PATCH 107/162] fix(minidrbdcluster): handle correctly
+Subject: [PATCH 107/170] fix(minidrbdcluster): handle correctly
  KeyboardInterrupt with systemd units
 
 It's necessary to always add systemd services in the running list before
@@ -33,5 +33,5 @@ index eae7cbf..03d6b01 100755
      if m:
          res_name, conn_name, role = m.groups()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0108-feat-LinstorSR-use-drbd-reactor-instead-of-minidrbdc.patch
+++ b/SOURCES/0108-feat-LinstorSR-use-drbd-reactor-instead-of-minidrbdc.patch
@@ -1,7 +1,7 @@
 From 6ba5f31ef3b8aff96c02cbcfd7bcb4229ed577cc Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 24 Feb 2023 14:28:29 +0100
-Subject: [PATCH 108/162] feat(LinstorSR): use drbd-reactor instead of
+Subject: [PATCH 108/170] feat(LinstorSR): use drbd-reactor instead of
  minidrbdcluster
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -617,5 +617,5 @@ index 1ddf91f..0000000
 -[Install]
 -WantedBy=multi-user.target
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0109-fix-LinstorSR-ensure-vhdutil-calls-are-correctly-exe.patch
+++ b/SOURCES/0109-fix-LinstorSR-ensure-vhdutil-calls-are-correctly-exe.patch
@@ -1,7 +1,7 @@
 From a5dd1819ece48085aae5394ecc7ca5946e81465b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 1 Mar 2023 10:56:43 +0100
-Subject: [PATCH 109/162] fix(LinstorSR): ensure vhdutil calls are correctly
+Subject: [PATCH 109/170] fix(LinstorSR): ensure vhdutil calls are correctly
  executed on pools with > 3 hosts
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -143,5 +143,5 @@ index 4662043..5ab83c4 100755
      def invalidate_resource_cache(self):
          """
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0110-fix-LinstorSR-replace-bad-param-in-detach_thin-impl.patch
+++ b/SOURCES/0110-fix-LinstorSR-replace-bad-param-in-detach_thin-impl.patch
@@ -1,7 +1,7 @@
 From ebac41980ca0dd876a318078b64c00be2742b1dc Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 9 Mar 2023 17:06:59 +0100
-Subject: [PATCH 110/162] fix(LinstorSR): replace bad param in detach_thin impl
+Subject: [PATCH 110/170] fix(LinstorSR): replace bad param in detach_thin impl
 
 To get the physical size, the volume UUID must be used, not the path.
 
@@ -24,5 +24,5 @@ index 10e0f54..c42f07d 100755
  
          volume_info = linstor.get_volume_info(vdi_uuid)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0111-fix-linstorvolumemanager-remove-usage-of-realpath.patch
+++ b/SOURCES/0111-fix-linstorvolumemanager-remove-usage-of-realpath.patch
@@ -1,7 +1,7 @@
 From a3a50de6f06d3fbd94726de54a3bfefc4534d791 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 10 Mar 2023 18:11:10 +0100
-Subject: [PATCH 111/162] fix(linstorvolumemanager): remove usage of realpath
+Subject: [PATCH 111/170] fix(linstorvolumemanager): remove usage of realpath
 
 Because a diskless DRBD path not always exist, get_volume_name_from_device_path can fail.
 It's easy to reproduce using > 4 hosts and with a call to linstorvhdutil.get_vhd_info:
@@ -52,5 +52,5 @@ index 5ab83c4..8befb33 100755
      def update_volume_uuid(self, volume_uuid, new_volume_uuid, force=False):
          """
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0112-fix-linstorvhdutil-avoid-parent-path-resolution.patch
+++ b/SOURCES/0112-fix-linstorvhdutil-avoid-parent-path-resolution.patch
@@ -1,7 +1,7 @@
 From 364dd17447551afa39844db5b8cfcdc9298d14a2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 16 Mar 2023 18:54:46 +0100
-Subject: [PATCH 112/162] fix(linstorvhdutil): avoid parent path resolution
+Subject: [PATCH 112/170] fix(linstorvhdutil): avoid parent path resolution
 
 When many hosts are used (>= 4), we can fail to get
 VHD info (with parent option) because the local parent VDI
@@ -107,5 +107,5 @@ index d75edb1..48337f8 100755
      ret = ioretry(cmd)
      fields = ret.strip().split('\n')
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0113-fix-LinstorSR-create-parent-path-during-attach.patch
+++ b/SOURCES/0113-fix-LinstorSR-create-parent-path-during-attach.patch
@@ -1,7 +1,7 @@
 From a8d4da80a16e52d3a4cbca8ec81b246c8c66d6c9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 17 Mar 2023 12:06:08 +0100
-Subject: [PATCH 113/162] fix(LinstorSR): create parent path during attach
+Subject: [PATCH 113/170] fix(LinstorSR): create parent path during attach
 
 It's necessary to force DRBD diskless path creation when
 a VDI is attached. Otherwise the attach can fail on pool with
@@ -37,5 +37,5 @@ index c42f07d..48feec7 100755
          self.attached = True
          return VDI.VDI.attach(self, self.sr.uuid, self.uuid)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0114-fix-LinstorSR-retry-if-we-can-t-build-volume-cache.patch
+++ b/SOURCES/0114-fix-LinstorSR-retry-if-we-can-t-build-volume-cache.patch
@@ -1,7 +1,7 @@
 From 91a8092bf39709c48161268cc593bf950ea2fa7c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 3 Apr 2023 10:03:57 +0200
-Subject: [PATCH 114/162] fix(LinstorSR): retry if we can't build volume cache
+Subject: [PATCH 114/170] fix(LinstorSR): retry if we can't build volume cache
 
 Otherwise after SR creation, the master PBD can be unplugged.
 See: https://xcp-ng.org/forum/post/60726
@@ -29,5 +29,5 @@ index 48feec7..324033a 100755
      def _destroy_linstor_cache(self):
          self._all_volume_info_cache = None
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0115-fix-linstorvolumemanager-reduce-peer-slots-param-to-.patch
+++ b/SOURCES/0115-fix-linstorvolumemanager-reduce-peer-slots-param-to-.patch
@@ -1,7 +1,7 @@
 From 7e7794751a0c6c8e671e7b1d920291aaca663f4f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 25 Apr 2023 10:46:00 +0200
-Subject: [PATCH 115/162] fix(linstorvolumemanager): reduce peer-slots param to
+Subject: [PATCH 115/170] fix(linstorvolumemanager): reduce peer-slots param to
  3
 
 Because we use 3 backing disks at most, it's useless to increase the default linstor limit (8).
@@ -53,5 +53,5 @@ index 91db3d8..6f20c02 100755
          # Create real resources on the first nodes.
          resources = []
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0116-fix-LinstorSR-attach-a-valid-XAPI-session-is_open-is.patch
+++ b/SOURCES/0116-fix-LinstorSR-attach-a-valid-XAPI-session-is_open-is.patch
@@ -1,7 +1,7 @@
 From 361eb6950cd4ca68666877ef583f55be610eed72 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 25 Apr 2023 11:20:55 +0200
-Subject: [PATCH 116/162] fix(LinstorSR): attach a valid XAPI session is_open
+Subject: [PATCH 116/170] fix(LinstorSR): attach a valid XAPI session is_open
  is called
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -27,5 +27,5 @@ index 0633cff..7b8c55d 100755
      tapdisk = blktap2.Tapdisk.find_by_path(vdi.path)
      util.SMlog("Tapdisk for %s: %s" % (vdi.path, tapdisk))
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0117-fix-LinstorSR-ensure-we-always-have-a-DRBD-path-to-s.patch
+++ b/SOURCES/0117-fix-LinstorSR-ensure-we-always-have-a-DRBD-path-to-s.patch
@@ -1,7 +1,7 @@
 From 55eabe50cbfc5f7b669ba2c4dfdd2d6b7a9c7edb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 28 Apr 2023 10:43:27 +0200
-Subject: [PATCH 117/162] fix(LinstorSR): ensure we always have a DRBD path to
+Subject: [PATCH 117/170] fix(LinstorSR): ensure we always have a DRBD path to
  snap
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -24,5 +24,5 @@ index 324033a..8c0b007 100755
          if not util.pathexists(volume_path):
              raise xs_errors.XenError(
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0118-fix-LinstorSR-remove-hosts-ips-param.patch
+++ b/SOURCES/0118-fix-LinstorSR-remove-hosts-ips-param.patch
@@ -1,7 +1,7 @@
 From 7539f5fd6e9dfd4df4b5f67de48e96cf7572def5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 30 May 2023 11:19:13 +0200
-Subject: [PATCH 118/162] fix(LinstorSR): remove hosts/ips param
+Subject: [PATCH 118/170] fix(LinstorSR): remove hosts/ips param
 
 ---
  drivers/LinstorSR.py            | 47 +++++----------------------------
@@ -164,5 +164,5 @@ index 6f20c02..464ab2c 100755
                  # Try to create node.
                  result = lin.node_create(
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0119-fix-LinstorSR-compute-correctly-SR-size-using-pool-c.patch
+++ b/SOURCES/0119-fix-LinstorSR-compute-correctly-SR-size-using-pool-c.patch
@@ -1,7 +1,7 @@
 From 5bbaa66100f1bb4f9293bdbe587cef9e63a60158 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 1 Jun 2023 17:40:37 +0200
-Subject: [PATCH 119/162] fix(LinstorSR): compute correctly SR size using pool
+Subject: [PATCH 119/170] fix(LinstorSR): compute correctly SR size using pool
  count
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -89,5 +89,5 @@ index 464ab2c..ee637ae 100755
      def metadata(self):
          """
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0120-fix-blktap2-ensure-we-can-import-this-module-when-LI.patch
+++ b/SOURCES/0120-fix-blktap2-ensure-we-can-import-this-module-when-LI.patch
@@ -1,7 +1,7 @@
 From acb73ff725686e22c25f8623fcf19b3ce58f18fa Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Jun 2023 11:50:54 +0200
-Subject: [PATCH 120/162] fix(blktap2): ensure we can import this module when
+Subject: [PATCH 120/170] fix(blktap2): ensure we can import this module when
  LINSTOR is not installed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -44,5 +44,5 @@ index 719a152..2a37efb 100755
                              break
                      try:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0121-fix-LinstorSR-ensure-volume-cache-can-be-recreated.patch
+++ b/SOURCES/0121-fix-LinstorSR-ensure-volume-cache-can-be-recreated.patch
@@ -1,7 +1,7 @@
 From 3dd3b2d6bde149e8490ce8a4b2a96c8dbfdeb4b8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 21 Jun 2023 14:10:18 +0200
-Subject: [PATCH 121/162] fix(LinstorSR): ensure volume cache can be recreated
+Subject: [PATCH 121/170] fix(LinstorSR): ensure volume cache can be recreated
 
 After SR creation we may fail to load volumes with this exception:
 "Failed to get usable size of..." and so we can't plug the master PBD.
@@ -108,5 +108,5 @@ index f6c4356..0bccc16 100755
          space_available = self._linstor.max_volume_size_allowed
          if (space_available < amount_needed):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0122-fix-linstor-manager-remove-dead-useless-code-in-add-.patch
+++ b/SOURCES/0122-fix-linstor-manager-remove-dead-useless-code-in-add-.patch
@@ -1,7 +1,7 @@
 From bf31c31815dbc8f80f7cdda974cb51f8aec05896 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 20 Jul 2023 10:46:33 +0200
-Subject: [PATCH 122/162] fix(linstor-manager): remove dead/useless code in
+Subject: [PATCH 122/170] fix(linstor-manager): remove dead/useless code in
  add/remove_host helpers
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -205,5 +205,5 @@ index 9e96aac..45201ee 100755
      # 3. Stop services.
      try:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0123-fix-LinstorSR-Ensure-we-always-have-a-device-path-du.patch
+++ b/SOURCES/0123-fix-LinstorSR-Ensure-we-always-have-a-device-path-du.patch
@@ -1,7 +1,7 @@
 From c2c842c10b97ffb33d754dcc9b4060a42ce7ff8e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 1 Aug 2023 15:16:17 +0200
-Subject: [PATCH 123/162] fix(LinstorSR): Ensure we always have a device path
+Subject: [PATCH 123/170] fix(LinstorSR): Ensure we always have a device path
  during leaf-coalesce calls
 
 So we must not verify that we have a valid DRBD path in the load step,
@@ -55,5 +55,5 @@ index bf0cc46..8f40d45 100755
          entries = self.journaler.get_all(VDI.JRN_LEAF)
          for uuid, parentUuid in entries.iteritems():
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0124-fix-LinstorSR-always-use-lock.acquire-during-attach-.patch
+++ b/SOURCES/0124-fix-LinstorSR-always-use-lock.acquire-during-attach-.patch
@@ -1,7 +1,7 @@
 From 7b46ed5b0b6226397161cc7a699918c2dbd936a4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Aug 2023 12:04:01 +0200
-Subject: [PATCH 124/162] fix(LinstorSR): always use lock.acquire() during
+Subject: [PATCH 124/170] fix(LinstorSR): always use lock.acquire() during
  attach/detach
 
 We can't use a retry range on the lock because we can trigger a bad situation
@@ -55,5 +55,5 @@ index 0bccc16..98919a4 100755
          vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
          vbds = session.xenapi.VBD.get_all_records_where(
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0125-fix-LinstorSR-mare-sure-hostnames-are-unique-at-SR-c.patch
+++ b/SOURCES/0125-fix-LinstorSR-mare-sure-hostnames-are-unique-at-SR-c.patch
@@ -1,7 +1,7 @@
 From b85997ace61cbe184f9c4a5aade86aeff2696784 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 17 Aug 2023 14:52:13 +0200
-Subject: [PATCH 125/162] fix(LinstorSR): mare sure hostnames are unique at SR
+Subject: [PATCH 125/170] fix(LinstorSR): mare sure hostnames are unique at SR
  creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -27,5 +27,5 @@ index 98919a4..e512487 100755
          # are activated. In the same time the drbd-reactor instances
          # must be stopped.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0126-fix-LinstorSR-ensure-we-can-attach-non-special-stati.patch
+++ b/SOURCES/0126-fix-LinstorSR-ensure-we-can-attach-non-special-stati.patch
@@ -1,7 +1,7 @@
 From ba8f53b3bfac780be0a7b6bfec960d50fc29cdee Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 18 Aug 2023 11:06:56 +0200
-Subject: [PATCH 126/162] fix(LinstorSR): ensure we can attach non-special
+Subject: [PATCH 126/170] fix(LinstorSR): ensure we can attach non-special
  static VDIs
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -24,5 +24,5 @@ index e512487..1708370 100755
                      controller_uri = get_controller_uri()
                      if controller_uri:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0127-fix-LinstorSR-ensure-we-can-detach-when-deflate-call.patch
+++ b/SOURCES/0127-fix-LinstorSR-ensure-we-can-detach-when-deflate-call.patch
@@ -1,7 +1,7 @@
 From 90c8eaff529e4d5bfeec0aedf78c40dd8f72506c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 31 Aug 2023 18:00:27 +0200
-Subject: [PATCH 127/162] fix(LinstorSR): ensure we can detach when deflate
+Subject: [PATCH 127/170] fix(LinstorSR): ensure we can detach when deflate
  call is not possible
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -81,5 +81,5 @@ index 1708370..a6ca884 100755
      # Only inflate if the LINSTOR volume capacity is not enough.
      new_size = LinstorVolumeManager.round_up_volume_size(new_size)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0128-fix-LinstorSR-assume-VDI-is-always-a-VHD-when-the-in.patch
+++ b/SOURCES/0128-fix-LinstorSR-assume-VDI-is-always-a-VHD-when-the-in.patch
@@ -1,7 +1,7 @@
 From 02914524b9044070023e55a1aa6c60dc3569ae9a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 28 Sep 2023 16:00:02 +0200
-Subject: [PATCH 128/162] fix(LinstorSR): assume VDI is always a VHD when the
+Subject: [PATCH 128/170] fix(LinstorSR): assume VDI is always a VHD when the
  info is missing during cleanup
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -30,5 +30,5 @@ index 8f40d45..be61bfe 100755
                  Util.log(
                      ' [VDI {}: failed to load VDI info]: {}'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0129-fix-LinstorSR-remove-SR-lock-during-thin-attach-deta.patch
+++ b/SOURCES/0129-fix-LinstorSR-remove-SR-lock-during-thin-attach-deta.patch
@@ -1,7 +1,7 @@
 From b2bd72ef2055bbef1a24167055ffab2ef6e21bf3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 2 Oct 2023 16:48:49 +0200
-Subject: [PATCH 129/162] fix(LinstorSR): remove SR lock during thin
+Subject: [PATCH 129/170] fix(LinstorSR): remove SR lock during thin
  attach/detach
 
 This lock is normally useless and can create a dead lock when thin mode is activated:
@@ -148,5 +148,5 @@ index a6ca884..ed41e77 100755
  
  def detach_thin(session, linstor, sr_uuid, vdi_uuid):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0130-fix-LinstorSR-ensure-database-is-mounted-during-scan.patch
+++ b/SOURCES/0130-fix-LinstorSR-ensure-database-is-mounted-during-scan.patch
@@ -1,7 +1,7 @@
 From af8b26d3d16beb48c6b72f1aa32e15e429bbbf24 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 3 Oct 2023 18:42:42 +0200
-Subject: [PATCH 130/162] fix(LinstorSR): ensure database is mounted during
+Subject: [PATCH 130/170] fix(LinstorSR): ensure database is mounted during
  scan
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -65,5 +65,5 @@ index ee637ae..f1f3bce 100755
      def create_sr(
          cls, group_name, ips, redundancy,
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0131-fix-LinstorSR-restart-drbd-reactor-in-case-of-failur.patch
+++ b/SOURCES/0131-fix-LinstorSR-restart-drbd-reactor-in-case-of-failur.patch
@@ -1,7 +1,7 @@
 From 60bb09c10292ff6d78b984dd0f3d36fdda4aa768 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 4 Oct 2023 14:30:36 +0200
-Subject: [PATCH 131/162] fix(LinstorSR): restart drbd-reactor in case of
+Subject: [PATCH 131/170] fix(LinstorSR): restart drbd-reactor in case of
  failure
 
 Otherwise we can have all hosts unusable after a massive reboot:
@@ -49,5 +49,5 @@ index 0000000..2f99a46
 +Restart=always
 +RestartSec=2
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0132-fix-linstorvolumemanager-retry-in-case-of-failure-du.patch
+++ b/SOURCES/0132-fix-linstorvolumemanager-retry-in-case-of-failure-du.patch
@@ -1,7 +1,7 @@
 From a3a9d49c9066cb61934c639a5855491895a17201 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 9 Oct 2023 10:37:32 +0200
-Subject: [PATCH 132/162] fix(linstorvolumemanager): retry in case of failure
+Subject: [PATCH 132/170] fix(linstorvolumemanager): retry in case of failure
  during mkfs call on database
 
 The device is not always ready after creation.
@@ -29,5 +29,5 @@ index f1f3bce..23e80d9 100755
              raise LinstorVolumeManagerError(
                 'Failed to execute {} on database volume: {}'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0133-fix-linstorvolumemanager-avoid-diskless-creation-whe.patch
+++ b/SOURCES/0133-fix-linstorvolumemanager-avoid-diskless-creation-whe.patch
@@ -1,7 +1,7 @@
 From e6ffd5e9de53116d69fa2b3511166fc71954e6d4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 26 Sep 2023 11:48:38 +0200
-Subject: [PATCH 133/162] fix(linstorvolumemanager): avoid diskless creation
+Subject: [PATCH 133/170] fix(linstorvolumemanager): avoid diskless creation
  when a new resource is added
 
 Like said in this discussion https://github.com/xcp-ng/sm/pull/34 :
@@ -142,5 +142,5 @@ index 23e80d9..49ca83c 100755
  
              assert volume_properties.namespace == \
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0134-fix-LinstorSR-remove-diskless-after-VDI.detach-calls.patch
+++ b/SOURCES/0134-fix-LinstorSR-remove-diskless-after-VDI.detach-calls.patch
@@ -1,7 +1,7 @@
 From d89c970c3401019e5ab8e4f6bf6dc0ccb1aaca30 Mon Sep 17 00:00:00 2001
 From: Rene Peinthor <rene.peinthor@linbit.com>
 Date: Tue, 25 Jul 2023 11:19:39 +0200
-Subject: [PATCH 134/162] fix(LinstorSR): remove diskless after VDI.detach
+Subject: [PATCH 134/170] fix(LinstorSR): remove diskless after VDI.detach
  calls
 
 Signed-off-by: Rene Peinthor <rene.peinthor@linbit.com>
@@ -87,5 +87,5 @@ index 49ca83c..0f6fbcf 100755
              return
          errors = linstor.Linstor.filter_api_call_response_errors(result)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0135-fix-LinstorSR-robustify-_load_vdi_info-in-cleanup.py.patch
+++ b/SOURCES/0135-fix-LinstorSR-robustify-_load_vdi_info-in-cleanup.py.patch
@@ -1,7 +1,7 @@
 From 6958d82dbe9fb24e564e40249ec410f009fc1cf1 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 11 Oct 2023 12:39:56 +0200
-Subject: [PATCH 135/162] fix(LinstorSR): robustify _load_vdi_info in
+Subject: [PATCH 135/170] fix(LinstorSR): robustify _load_vdi_info in
  cleanup.py
 
 After a failed snapshot like that:
@@ -95,5 +95,5 @@ index be61bfe..8c37e15 100755
  
      # TODO: Maybe implement _liveLeafCoalesce/_prepareCoalesceLeaf/
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0136-fix-LinstorSR-ensure-detach-never-fails-on-plugin-fa.patch
+++ b/SOURCES/0136-fix-LinstorSR-ensure-detach-never-fails-on-plugin-fa.patch
@@ -1,7 +1,7 @@
 From 5042f81882c2426f4e9f2479ab9936209e5bb94d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 23 Oct 2023 14:31:27 +0200
-Subject: [PATCH 136/162] fix(LinstorSR): ensure detach never fails on plugin
+Subject: [PATCH 136/170] fix(LinstorSR): ensure detach never fails on plugin
  failure
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -28,5 +28,5 @@ index 7b9a8e5..d0fc421 100755
          # Reload size attrs after inflate or deflate!
          self._load_this()
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0137-fix-LinstorSR-ensure-we-coalesce-only-volumes-with-a.patch
+++ b/SOURCES/0137-fix-LinstorSR-ensure-we-coalesce-only-volumes-with-a.patch
@@ -1,7 +1,7 @@
 From 0c6aafb0f77e909ec94234e8b17756851bf6ddaf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 23 Oct 2023 15:52:23 +0200
-Subject: [PATCH 137/162] fix(LinstorSR): ensure we coalesce only volumes with
+Subject: [PATCH 137/170] fix(LinstorSR): ensure we coalesce only volumes with
  a valid size
 
 ---
@@ -136,5 +136,5 @@ index 8b6985d..5f3ae08 100644
          try:
              return self._call_local_vhd_util(local_method, device_path, *args, **kwargs)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0138-fix-LinstorSR-don-t-try-to-repair-persistent-volumes.patch
+++ b/SOURCES/0138-fix-LinstorSR-don-t-try-to-repair-persistent-volumes.patch
@@ -1,7 +1,7 @@
 From 90da7cd6b3ce5ab1dbfccab3e8a7a1394989ac2a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 24 Oct 2023 11:57:40 +0200
-Subject: [PATCH 138/162] fix(LinstorSR): don't try to repair persistent
+Subject: [PATCH 138/170] fix(LinstorSR): don't try to repair persistent
  volumes in GC
 
 Use constants to simplify maintenance.
@@ -195,5 +195,5 @@ index 0f6fbcf..47ca4e8 100755
  DATABASE_PATH = '/var/lib/linstor'
  DATABASE_MKFS = 'mkfs.ext4'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0139-fix-linstorvhdutil-format-correctly-message-if-vhd-u.patch
+++ b/SOURCES/0139-fix-linstorvhdutil-format-correctly-message-if-vhd-u.patch
@@ -1,7 +1,7 @@
 From d4bc883ff7f96b4f461b0fcf76f69e0081cadddf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 14 Nov 2023 18:21:53 +0100
-Subject: [PATCH 139/162] fix(linstorvhdutil): format correctly message if
+Subject: [PATCH 139/170] fix(linstorvhdutil): format correctly message if
  vhd-util cannot be run
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -24,5 +24,5 @@ index 5f3ae08..3ce7ab9 100644
              )
          return util.retry(remote_call, 5, 2)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0140-fix-LinstorSR-wait-during-attach-to-open-DRBD-path.patch
+++ b/SOURCES/0140-fix-LinstorSR-wait-during-attach-to-open-DRBD-path.patch
@@ -1,7 +1,7 @@
 From fe16c08ed26ef278e1216550abdf0f095fe95765 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 24 Oct 2023 23:07:23 +0200
-Subject: [PATCH 140/162] fix(LinstorSR): wait during attach to open DRBD path
+Subject: [PATCH 140/170] fix(LinstorSR): wait during attach to open DRBD path
 
 ENODATA and other errors like EROFS can be raised when
 a new DRBD path is created on the fly. So ensure to block before tapdisk starts.
@@ -42,5 +42,5 @@ index d0ce079..3063abf 100755
  
          self.attached = True
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0141-fix-LinstorSR-support-different-volume-sizes-in-clea.patch
+++ b/SOURCES/0141-fix-LinstorSR-support-different-volume-sizes-in-clea.patch
@@ -1,7 +1,7 @@
 From 8378d701449585793ef1a4c99f7381e12d572440 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 14 Nov 2023 18:08:26 +0100
-Subject: [PATCH 141/162] fix(LinstorSR): support different volume sizes in
+Subject: [PATCH 141/170] fix(LinstorSR): support different volume sizes in
  cleanup.py
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -513,5 +513,5 @@ index 3ce7ab9..239a10a 100644
      # Helpers.
      # --------------------------------------------------------------------------
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0142-fix-LinstorSR-remove-useless-IPS_XHA_CACHE-var.patch
+++ b/SOURCES/0142-fix-LinstorSR-remove-useless-IPS_XHA_CACHE-var.patch
@@ -1,7 +1,7 @@
 From e1c8be5b153d842e607f11b9fbc6b0062be3f884 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Nov 2023 10:52:27 +0100
-Subject: [PATCH 142/162] fix(LinstorSR): remove useless IPS_XHA_CACHE var
+Subject: [PATCH 142/170] fix(LinstorSR): remove useless IPS_XHA_CACHE var
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---
@@ -27,5 +27,5 @@ index 6802f49..c570925 100755
      host_id = None
      try:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0143-fix-LinstorSR-ensure-we-can-deflate-on-any-host-afte.patch
+++ b/SOURCES/0143-fix-LinstorSR-ensure-we-can-deflate-on-any-host-afte.patch
@@ -1,7 +1,7 @@
 From fdc8a04dc0a671b569778e994585ad61add7712a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 21 Nov 2023 13:50:24 +0100
-Subject: [PATCH 143/162] fix(LinstorSR): ensure we can deflate on any host
+Subject: [PATCH 143/170] fix(LinstorSR): ensure we can deflate on any host
  after a journal rollback
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -314,5 +314,5 @@ index 239a10a..23d8b6a 100644
 +                opterr='Failed to zero out VHD footer {}'.format(path)
 +            )
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0144-fix-LinstorSR-ensure-we-always-use-real-DRBD-VHD-siz.patch
+++ b/SOURCES/0144-fix-LinstorSR-ensure-we-always-use-real-DRBD-VHD-siz.patch
@@ -1,7 +1,7 @@
 From 06ad18c8f252200ddc148e10b77e720894fb61df Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 27 Nov 2023 12:15:43 +0100
-Subject: [PATCH 144/162] fix(LinstorSR): ensure we always use real DRBD/VHD
+Subject: [PATCH 144/170] fix(LinstorSR): ensure we always use real DRBD/VHD
  sizes in inflate/deflate GC calls
 
 ---
@@ -145,5 +145,5 @@ index d6c68a1..8ac06eb 100755
          entries = self.journaler.get_all(VDI.JRN_LEAF)
          for uuid, parentUuid in entries.iteritems():
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0145-feat-linstor-kv-tool-If-no-controller-uri-option-is-.patch
+++ b/SOURCES/0145-feat-linstor-kv-tool-If-no-controller-uri-option-is-.patch
@@ -1,7 +1,7 @@
 From 3bae8effdfb1244ac83a7d1c6085b13c3d027eef Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.tech>
 Date: Mon, 27 Nov 2023 14:23:57 +0100
-Subject: [PATCH 145/162] feat(linstor-kv-tool): If no controller uri option is
+Subject: [PATCH 145/170] feat(linstor-kv-tool): If no controller uri option is
  provided fetch it (#48)
 
 Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
@@ -52,5 +52,5 @@ index c907027..b845ec2 100755
  
  if __name__ == '__main__':
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0146-fix-linstorvolumemanager-robustify-SR-destroy-46.patch
+++ b/SOURCES/0146-fix-linstorvolumemanager-robustify-SR-destroy-46.patch
@@ -1,7 +1,7 @@
 From 5d46a43581ce6f1d6015869d4a5782662e630a40 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.tech>
 Date: Wed, 29 Nov 2023 15:45:32 +0100
-Subject: [PATCH 146/162] fix(linstorvolumemanager): robustify SR destroy (#46)
+Subject: [PATCH 146/170] fix(linstorvolumemanager): robustify SR destroy (#46)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 Co-authored-by: BenjiReis <benjamin.reis@vates.fr>
@@ -206,5 +206,5 @@ index 47ca4e8..d27c84e 100755
      def _get_filtered_properties(properties):
          return dict(properties.items())
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0147-feat-linstor-manager-extend-API-with-createNodeInter.patch
+++ b/SOURCES/0147-feat-linstor-manager-extend-API-with-createNodeInter.patch
@@ -1,7 +1,7 @@
 From b9c0e4371154a918c5da5cff034abb679137b35a Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.tech>
 Date: Wed, 29 Nov 2023 16:54:30 +0100
-Subject: [PATCH 147/162] feat(linstor-manager): extend API with
+Subject: [PATCH 147/170] feat(linstor-manager): extend API with
  createNodeInterface and setNodePreferredInterface (#47)
 
 Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
@@ -104,5 +104,5 @@ index d27c84e..fef34d3 100755
          """
          Get all nodes + statuses, used or not by the pool.
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0148-fix-LinstorSR-support-VDI.resize-on-thick-volumes.patch
+++ b/SOURCES/0148-fix-LinstorSR-support-VDI.resize-on-thick-volumes.patch
@@ -1,7 +1,7 @@
 From a869d38bc872acbeff18ded8762c01ecf8f4f015 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 1 Dec 2023 11:55:12 +0100
-Subject: [PATCH 148/162] fix(LinstorSR): support VDI.resize on thick volumes
+Subject: [PATCH 148/170] fix(LinstorSR): support VDI.resize on thick volumes
 
 ---
  drivers/LinstorSR.py | 3 +++
@@ -27,5 +27,5 @@ index 1d1b51a..a524338 100755
  
          space_needed = new_volume_size - old_volume_size
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0149-fix-linstorvolumemanager-format-correctly-exception-.patch
+++ b/SOURCES/0149-fix-linstorvolumemanager-format-correctly-exception-.patch
@@ -1,7 +1,7 @@
 From b71fcdebe016048cb9486a81cb121246c73f04b8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 4 Dec 2023 16:36:55 +0100
-Subject: [PATCH 149/162] fix(linstorvolumemanager): format correctly exception
+Subject: [PATCH 149/170] fix(linstorvolumemanager): format correctly exception
  during db mount
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -26,5 +26,5 @@ index fef34d3..a41314e 100755
                      )
          except Exception as e:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0150-fix-LinstorSR-ensure-we-can-skip-coalesces-if-device.patch
+++ b/SOURCES/0150-fix-LinstorSR-ensure-we-can-skip-coalesces-if-device.patch
@@ -1,7 +1,7 @@
 From 2e4f6a944581917c4185b9711ef21ac05aa07eaf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 4 Dec 2023 18:57:08 +0100
-Subject: [PATCH 150/162] fix(LinstorSR): ensure we can skip coalesces if
+Subject: [PATCH 150/170] fix(LinstorSR): ensure we can skip coalesces if
  device path can't be fetched
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -28,5 +28,5 @@ index 8ac06eb..b958599 100755
  
      def _setHidden(self, hidden=True):
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0151-feat-linstor-manager-add-methods-to-modify-destroy-l.patch
+++ b/SOURCES/0151-feat-linstor-manager-add-methods-to-modify-destroy-l.patch
@@ -1,7 +1,7 @@
 From d761397eddfd9692a6ff624034774f55a63e5523 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 19 Dec 2023 14:49:33 +0100
-Subject: [PATCH 151/162] feat(linstor-manager): add methods to
+Subject: [PATCH 151/170] feat(linstor-manager): add methods to
  modify/destroy/list net interfaces
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -251,5 +251,5 @@ index a41314e..32d1533 100755
      def get_nodes_info(self):
          """
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0152-fix-LinstorSR-force-a-defined-volume-prefix-if-we-ca.patch
+++ b/SOURCES/0152-fix-LinstorSR-force-a-defined-volume-prefix-if-we-ca.patch
@@ -1,7 +1,7 @@
 From 5e841f71245adff8cd7e25103558b45f9d055302 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 12 Jan 2024 10:28:20 +0100
-Subject: [PATCH 152/162] fix(LinstorSR): force a defined volume prefix if we
+Subject: [PATCH 152/170] fix(LinstorSR): force a defined volume prefix if we
  can't import libs
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -23,5 +23,5 @@ index a524338..a73ae5a 100755
  
  from lock import Lock
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0153-fix-LinstorSR-explicit-error-message-when-a-group-is.patch
+++ b/SOURCES/0153-fix-LinstorSR-explicit-error-message-when-a-group-is.patch
@@ -1,7 +1,7 @@
 From 2abfb78743fa00feecff45b93acfc45d11428425 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 18 Jan 2024 10:24:01 +0100
-Subject: [PATCH 153/162] fix(LinstorSR): explicit error message when a group
+Subject: [PATCH 153/170] fix(LinstorSR): explicit error message when a group
  is not unique during SR creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -25,5 +25,5 @@ index a73ae5a..fed1de2 100755
  
          if srs:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0154-fix-LinstorSR-make-sure-VDI.delete-doesn-t-throw-und.patch
+++ b/SOURCES/0154-fix-LinstorSR-make-sure-VDI.delete-doesn-t-throw-und.patch
@@ -1,7 +1,7 @@
 From 0dc3ed803da3d4c3a6f17c5c5257293220f6ea07 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 18 Jan 2024 11:18:11 +0100
-Subject: [PATCH 154/162] fix(LinstorSR): make sure VDI.delete doesn't throw
+Subject: [PATCH 154/170] fix(LinstorSR): make sure VDI.delete doesn't throw
  under specific conditions
 
 If we can update the volume state in the KV-store, there is no reason to raise
@@ -66,5 +66,5 @@ index 32d1533..97e5372 100755
      def lock_volume(self, volume_uuid, locked=True):
          """
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0155-fix-LinstorSR-add-drbd-in-the-blacklist-of-multipath.patch
+++ b/SOURCES/0155-fix-LinstorSR-add-drbd-in-the-blacklist-of-multipath.patch
@@ -1,7 +1,7 @@
 From 247bc3112950eed913bb5af4735fe39372bf84e8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 19 Jan 2024 14:39:17 +0100
-Subject: [PATCH 155/162] fix(LinstorSR): add drbd in the blacklist of
+Subject: [PATCH 155/170] fix(LinstorSR): add drbd in the blacklist of
  multipath.conf
 
 If DRBD is installed for the first time, and if the multipathd
@@ -30,5 +30,5 @@ index f1afa11..b2a3574 100644
  # Leave this section in place even if empty
  blacklist_exceptions {
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0156-fix-linstorvolumemanager-create-cloned-volumes-on-ho.patch
+++ b/SOURCES/0156-fix-linstorvolumemanager-create-cloned-volumes-on-ho.patch
@@ -1,7 +1,7 @@
 From 3511677bd53ed292a27d1b4604be0134eb557785 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 22 Jan 2024 11:25:25 +0100
-Subject: [PATCH 156/162] fix(linstorvolumemanager): create cloned volumes on
+Subject: [PATCH 156/170] fix(linstorvolumemanager): create cloned volumes on
  host selected by LINSTOR
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -122,5 +122,5 @@ index 97e5372..5de86a1 100755
      def remove_resourceless_volumes(self):
          """
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0157-fix-linstorvolumemanager-don-t-align-volumes-on-LVM-.patch
+++ b/SOURCES/0157-fix-linstorvolumemanager-don-t-align-volumes-on-LVM-.patch
@@ -1,7 +1,7 @@
 From baa422edb93cc4d73f16be2af44ee8cfb3d0140c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 26 Jan 2024 15:29:21 +0100
-Subject: [PATCH 157/162] fix(linstorvolumemanager): don't align volumes on LVM
+Subject: [PATCH 157/170] fix(linstorvolumemanager): don't align volumes on LVM
  sector size
 
 It's the goal of the LINSTOR stack to align properly on the LVM layer.
@@ -28,5 +28,5 @@ index 5de86a1..7410fd7 100755
      # List of volume properties.
      PROP_METADATA = 'metadata'
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0158-fix-linstorvolumemanager-assert-with-message-after-l.patch
+++ b/SOURCES/0158-fix-linstorvolumemanager-assert-with-message-after-l.patch
@@ -1,7 +1,7 @@
 From 009b30a7e84fb9c19b5eab618612d5fdd46b48bf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Feb 2024 18:01:22 +0100
-Subject: [PATCH 158/162] fix(linstorvolumemanager): assert with message after
+Subject: [PATCH 158/170] fix(linstorvolumemanager): assert with message after
  log in update_volume_uuid
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -29,5 +29,5 @@ index 7410fd7..5f2e06e 100755
              self._ensure_volume_exists(volume_uuid)
          self.ensure_volume_is_not_locked(volume_uuid)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0159-fix-linstorvolumemanager-retry-resize-if-volume-is-n.patch
+++ b/SOURCES/0159-fix-linstorvolumemanager-retry-resize-if-volume-is-n.patch
@@ -1,7 +1,7 @@
 From 381fa788e5c2a00b1f022f88ace8b053b569f55b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Feb 2024 23:13:06 +0100
-Subject: [PATCH 159/162] fix(linstorvolumemanager): retry resize if volume is
+Subject: [PATCH 159/170] fix(linstorvolumemanager): retry resize if volume is
  not up to date
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -54,5 +54,5 @@ index 5f2e06e..79ac84a 100755
                  'Could not resize volume `{}` from SR `{}`: {}'
                  .format(volume_uuid, self._group_name, error_str)
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0160-fix-LinstorSR-create-DRBD-diskless-if-necessary-for-.patch
+++ b/SOURCES/0160-fix-LinstorSR-create-DRBD-diskless-if-necessary-for-.patch
@@ -1,7 +1,7 @@
 From 72c69118dfdea91eb1b05b67f39a547cf652bf59 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Feb 2024 00:10:32 +0100
-Subject: [PATCH 160/162] fix(LinstorSR): create DRBD diskless if necessary for
+Subject: [PATCH 160/170] fix(LinstorSR): create DRBD diskless if necessary for
  each VHD parent
 
 It's necessary to have all parents during snapshot to create a new VHD child.
@@ -97,5 +97,5 @@ index 1e09e9b..53afbef 100755
  
  
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0161-fix-LinstorSR-fix-bad-call-to-vhdutil.inflate-bad-ex.patch
+++ b/SOURCES/0161-fix-LinstorSR-fix-bad-call-to-vhdutil.inflate-bad-ex.patch
@@ -1,7 +1,7 @@
 From 5d5ec1da0853a7dd00bfe4fb06ee8ac42f2f08cb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Feb 2024 00:14:11 +0100
-Subject: [PATCH 161/162] fix(LinstorSR): fix bad call to vhdutil.inflate + bad
+Subject: [PATCH 161/170] fix(LinstorSR): fix bad call to vhdutil.inflate + bad
  exception
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -32,5 +32,5 @@ index 53afbef..de10f42 100755
              try:
                  self.sr._handle_interrupted_clone(
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0162-fix-LinstorSR-activate-VG-if-attach-from-config-is-a.patch
+++ b/SOURCES/0162-fix-LinstorSR-activate-VG-if-attach-from-config-is-a.patch
@@ -1,7 +1,7 @@
 From f87c3eb6a386cb50d6474dc83fad5e95d865beb9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 12 Feb 2024 20:54:06 +0100
-Subject: [PATCH 162/162] fix(LinstorSR): activate VG if attach from config is
+Subject: [PATCH 162/170] fix(LinstorSR): activate VG if attach from config is
  asked
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
@@ -23,5 +23,5 @@ index de10f42..b6b1529 100755
  
              if not self._has_session:
 -- 
-2.43.0
+2.44.0
 

--- a/SOURCES/0163-feat-LinstorSR-use-a-specific-resource-group-for-DB-.patch
+++ b/SOURCES/0163-feat-LinstorSR-use-a-specific-resource-group-for-DB-.patch
@@ -1,0 +1,521 @@
+From a8c51e521a19bd017ae1b56548023b8195959bcd Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Tue, 19 Mar 2024 23:09:54 +0100
+Subject: [PATCH 163/170] feat(LinstorSR): use a specific resource group for DB
+ and HA
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/LinstorSR.py            |   7 +-
+ drivers/linstorvolumemanager.py | 253 ++++++++++++++++++++++----------
+ 2 files changed, 182 insertions(+), 78 deletions(-)
+
+diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
+index b6b1529..3421f79 100755
+--- a/drivers/LinstorSR.py
++++ b/drivers/LinstorSR.py
+@@ -1662,8 +1662,11 @@ class LinstorVDI(VDI.VDI):
+                 volume_name = REDO_LOG_VOLUME_NAME
+ 
+             self._linstor.create_volume(
+-                self.uuid, volume_size, persistent=False,
+-                volume_name=volume_name
++                self.uuid,
++                volume_size,
++                persistent=False,
++                volume_name=volume_name,
++                high_availability=volume_name is not None
+             )
+             volume_info = self._linstor.get_volume_info(self.uuid)
+ 
+diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
+index 79ac84a..b4edc95 100755
+--- a/drivers/linstorvolumemanager.py
++++ b/drivers/linstorvolumemanager.py
+@@ -273,7 +273,8 @@ class LinstorVolumeManagerError(Exception):
+     ERR_GENERIC = 0,
+     ERR_VOLUME_EXISTS = 1,
+     ERR_VOLUME_NOT_EXISTS = 2,
+-    ERR_VOLUME_DESTROY = 3
++    ERR_VOLUME_DESTROY = 3,
++    ERR_GROUP_NOT_EXISTS = 4
+ 
+     def __init__(self, message, code=ERR_GENERIC):
+         super(LinstorVolumeManagerError, self).__init__(message)
+@@ -298,11 +299,9 @@ class LinstorVolumeManager(object):
+     """
+ 
+     __slots__ = (
+-        '_linstor', '_logger',
+-        '_uri', '_base_group_name',
+-        '_redundancy', '_group_name',
+-        '_volumes', '_storage_pools',
+-        '_storage_pools_time',
++        '_linstor', '_logger', '_redundancy',
++        '_base_group_name', '_group_name', '_ha_group_name',
++        '_volumes', '_storage_pools', '_storage_pools_time',
+         '_kv_cache', '_resource_cache', '_volume_info_cache',
+         '_kv_cache_dirty', '_resource_cache_dirty', '_volume_info_cache_dirty'
+     )
+@@ -348,6 +347,7 @@ class LinstorVolumeManager(object):
+     # A LINSTOR (resource, group, ...) name cannot start with a number.
+     # So we add a prefix behind our SR/VOLUME uuids.
+     PREFIX_SR = 'xcp-sr-'
++    PREFIX_HA = 'xcp-ha-'
+     PREFIX_VOLUME = 'xcp-volume-'
+ 
+     # Limit request number when storage pool info is asked, we fetch
+@@ -406,8 +406,7 @@ class LinstorVolumeManager(object):
+ 
+         # Ensure group exists.
+         group_name = self._build_group_name(group_name)
+-        groups = self._linstor.resource_group_list_raise([group_name])
+-        groups = groups.resource_groups
++        groups = self._linstor.resource_group_list_raise([group_name]).resource_groups
+         if not groups:
+             raise LinstorVolumeManagerError(
+                 'Unable to find `{}` Linstor SR'.format(group_name)
+@@ -417,6 +416,7 @@ class LinstorVolumeManager(object):
+         self._logger = logger
+         self._redundancy = groups[0].select_filter.place_count
+         self._group_name = group_name
++        self._ha_group_name = self._build_ha_group_name(group_name)
+         self._volumes = set()
+         self._storage_pools_time = 0
+ 
+@@ -617,7 +617,12 @@ class LinstorVolumeManager(object):
+         return volume_uuid in self._volumes
+ 
+     def create_volume(
+-        self, volume_uuid, size, persistent=True, volume_name=None
++        self,
++        volume_uuid,
++        size,
++        persistent=True,
++        volume_name=None,
++        high_availability=False
+     ):
+         """
+         Create a new volume on the SR.
+@@ -627,6 +632,8 @@ class LinstorVolumeManager(object):
+         on the next constructor call LinstorSR(...).
+         :param str volume_name: If set, this name is used in the LINSTOR
+         database instead of a generated name.
++        :param bool high_availability: If set, the volume is created in
++        the HA group.
+         :return: The current device path of the volume.
+         :rtype: str
+         """
+@@ -635,7 +642,11 @@ class LinstorVolumeManager(object):
+         if not volume_name:
+             volume_name = self.build_volume_name(util.gen_uuid())
+         volume_properties = self._create_volume_with_properties(
+-            volume_uuid, volume_name, size, place_resources=True
++            volume_uuid,
++            volume_name,
++            size,
++            True,  # place_resources
++            high_availability
+         )
+ 
+         # Volume created! Now try to find the device path.
+@@ -651,7 +662,7 @@ class LinstorVolumeManager(object):
+                 'LINSTOR volume {} created!'.format(volume_uuid)
+             )
+             return device_path
+-        except Exception as e:
++        except Exception:
+             # There is an issue to find the path.
+             # At this point the volume has just been created, so force flag can be used.
+             self._destroy_volume(volume_uuid, force=True)
+@@ -1359,6 +1370,7 @@ class LinstorVolumeManager(object):
+ 
+             # 4.5. Destroy group and storage pools.
+             self._destroy_resource_group(self._linstor, self._group_name)
++            self._destroy_resource_group(self._linstor, self._ha_group_name)
+             for pool in self._get_storage_pools(force=True):
+                 self._destroy_storage_pool(
+                     self._linstor, pool.name, pool.node_name
+@@ -1659,6 +1671,16 @@ class LinstorVolumeManager(object):
+         """
+         return self._request_database_path(self._linstor)
+ 
++    @classmethod
++    def get_all_group_names(cls, base_name):
++        """
++        Get all group names. I.e. list of current group + HA.
++        :param str base_name: The SR group_name to use.
++        :return: List of group names.
++        :rtype: list
++        """
++        return [cls._build_group_name(base_name), cls._build_ha_group_name(base_name)]
++
+     @classmethod
+     def create_sr(
+         cls, group_name, ips, redundancy,
+@@ -1744,8 +1766,8 @@ class LinstorVolumeManager(object):
+         driver_pool_name = group_name
+         base_group_name = group_name
+         group_name = cls._build_group_name(group_name)
+-        pools = lin.storage_pool_list_raise(filter_by_stor_pools=[group_name])
+-        pools = pools.storage_pools
++        storage_pool_name = group_name
++        pools = lin.storage_pool_list_raise(filter_by_stor_pools=[storage_pool_name]).storage_pools
+         if pools:
+             existing_node_names = map(lambda pool: pool.node_name, pools)
+             raise LinstorVolumeManagerError(
+@@ -1754,7 +1776,7 @@ class LinstorVolumeManager(object):
+             )
+ 
+         if lin.resource_group_list_raise(
+-            [group_name]
++            cls.get_all_group_names(base_group_name)
+         ).resource_groups:
+             if not lin.resource_dfn_list_raise().resource_definitions:
+                 backup_path = cls._create_database_backup_path()
+@@ -1791,7 +1813,7 @@ class LinstorVolumeManager(object):
+ 
+                 result = lin.storage_pool_create(
+                     node_name=node_name,
+-                    storage_pool_name=group_name,
++                    storage_pool_name=storage_pool_name,
+                     storage_driver='LVM_THIN' if thin_provisioning else 'LVM',
+                     driver_pool_name=driver_pool_name
+                 )
+@@ -1807,7 +1829,7 @@ class LinstorVolumeManager(object):
+                             'Volume group `{}` not found on `{}`. Ignoring...'
+                             .format(group_name, node_name)
+                         )
+-                        cls._destroy_storage_pool(lin, group_name, node_name)
++                        cls._destroy_storage_pool(lin, storage_pool_name, node_name)
+                     else:
+                         error_str = cls._get_error_str(result)
+                         raise LinstorVolumeManagerError(
+@@ -1825,49 +1847,28 @@ class LinstorVolumeManager(object):
+                     )
+                 )
+ 
+-            # 2.b. Create resource group.
+-            rg_creation_attempt = 0
+-            while True:
+-                result = lin.resource_group_create(
+-                    name=group_name,
+-                    place_count=redundancy,
+-                    storage_pool=group_name,
+-                    diskless_on_remaining=False
+-                )
+-                error_str = cls._get_error_str(result)
+-                if not error_str:
+-                    break
+-
+-                errors = cls._filter_errors(result)
+-                if cls._check_errors(errors, [linstor.consts.FAIL_EXISTS_RSC_GRP]):
+-                    rg_creation_attempt += 1
+-                    if rg_creation_attempt < 2:
+-                        try:
+-                            cls._destroy_resource_group(lin, group_name)
+-                        except Exception as e:
+-                            error_str = 'Failed to destroy old and empty RG: {}'.format(e)
+-                        else:
+-                            continue
+-
+-                raise LinstorVolumeManagerError(
+-                    'Could not create RG `{}`: {}'.format(group_name, error_str)
+-                )
+-
+-            # 2.c. Create volume group.
+-            result = lin.volume_group_create(group_name)
+-            error_str = cls._get_error_str(result)
+-            if error_str:
+-                raise LinstorVolumeManagerError(
+-                    'Could not create VG `{}`: {}'.format(
+-                        group_name, error_str
+-                    )
+-                )
++            # 2.b. Create resource groups.
++            ha_group_name = cls._build_ha_group_name(base_group_name)
++            cls._create_resource_group(
++              lin,
++              group_name,
++              storage_pool_name,
++              redundancy,
++              True
++            )
++            cls._create_resource_group(
++              lin,
++              ha_group_name,
++              storage_pool_name,
++              3,
++              True
++            )
+ 
+             # 3. Create the LINSTOR database volume and mount it.
+             try:
+                 logger('Creating database volume...')
+                 volume_path = cls._create_database_volume(
+-                    lin, group_name, node_names, redundancy, auto_quorum
++                    lin, ha_group_name, storage_pool_name, node_names, redundancy, auto_quorum
+                 )
+             except LinstorVolumeManagerError as e:
+                 if e.code != LinstorVolumeManagerError.ERR_VOLUME_EXISTS:
+@@ -1907,6 +1908,7 @@ class LinstorVolumeManager(object):
+             logger('Destroying resource group and storage pools after fail...')
+             try:
+                 cls._destroy_resource_group(lin, group_name)
++                cls._destroy_resource_group(lin, ha_group_name)
+             except Exception as e2:
+                 logger('Failed to destroy resource group: {}'.format(e2))
+                 pass
+@@ -1914,7 +1916,7 @@ class LinstorVolumeManager(object):
+             i = min(i, len(node_names) - 1)
+             while j <= i:
+                 try:
+-                    cls._destroy_storage_pool(lin, group_name, node_names[j])
++                    cls._destroy_storage_pool(lin, storage_pool_name, node_names[j])
+                 except Exception as e2:
+                     logger('Failed to destroy resource group: {}'.format(e2))
+                     pass
+@@ -1952,7 +1954,7 @@ class LinstorVolumeManager(object):
+     def build_volume_name(cls, base_name):
+         """
+         Build a volume name given a base name (i.e. a UUID).
+-        :param str volume_name: The volume name to use.
++        :param str base_name: The volume name to use.
+         :return: A valid or not device path.
+         :rtype: str
+         """
+@@ -2031,7 +2033,7 @@ class LinstorVolumeManager(object):
+         resource_names = set()
+         dfns = self._linstor.resource_dfn_list_raise().resource_definitions
+         for dfn in dfns:
+-            if dfn.resource_group_name == self._group_name and (
++            if dfn.resource_group_name in self.get_all_group_names(self._base_group_name) and (
+                 ignore_deleted or
+                 linstor.consts.FLAG_DELETE not in dfn.flags
+             ):
+@@ -2149,27 +2151,54 @@ class LinstorVolumeManager(object):
+         return self._storage_pools
+ 
+     def _create_volume(
+-        self, volume_uuid, volume_name, size, place_resources
++        self,
++        volume_uuid,
++        volume_name,
++        size,
++        place_resources,
++        high_availability
+     ):
+         size = self.round_up_volume_size(size)
+         self._mark_resource_cache_as_dirty()
+ 
++        group_name = self._ha_group_name if high_availability else self._group_name
+         def create_definition():
+-            self._check_volume_creation_errors(
+-                self._linstor.resource_group_spawn(
+-                    rsc_grp_name=self._group_name,
+-                    rsc_dfn_name=volume_name,
+-                    vlm_sizes=['{}B'.format(size)],
+-                    definitions_only=True
+-                ),
+-                volume_uuid,
+-                self._group_name
+-            )
++            first_attempt = True
++            while True:
++                try:
++                    self._check_volume_creation_errors(
++                        self._linstor.resource_group_spawn(
++                            rsc_grp_name=group_name,
++                            rsc_dfn_name=volume_name,
++                            vlm_sizes=['{}B'.format(size)],
++                            definitions_only=True
++                        ),
++                        volume_uuid,
++                        self._group_name
++                    )
++                    break
++                except LinstorVolumeManagerError as e:
++                    if (
++                        not first_attempt or
++                        not high_availability or
++                        e.code != LinstorVolumeManagerError.ERR_GROUP_NOT_EXISTS
++                    ):
++                        raise
++
++                    first_attempt = False
++                    self._create_resource_group(
++                        self._linstor,
++                        group_name,
++                        self._group_name,
++                        3,
++                        True
++                    )
++
+             self._configure_volume_peer_slots(self._linstor, volume_name)
+ 
+         def clean():
+             try:
+-                self._destroy_volume(volume_uuid, force=True)
++                self._destroy_volume(volume_uuid, force=True, preserve_properties=True)
+             except Exception as e:
+                 self._logger(
+                     'Unable to destroy volume {} after creation fail: {}'
+@@ -2201,7 +2230,12 @@ class LinstorVolumeManager(object):
+         util.retry(create, maxretry=5)
+ 
+     def _create_volume_with_properties(
+-        self, volume_uuid, volume_name, size, place_resources
++        self,
++        volume_uuid,
++        volume_name,
++        size,
++        place_resources,
++        high_availability
+     ):
+         if self.check_volume_exists(volume_uuid):
+             raise LinstorVolumeManagerError(
+@@ -2230,7 +2264,11 @@ class LinstorVolumeManager(object):
+             volume_properties[self.PROP_VOLUME_NAME] = volume_name
+ 
+             self._create_volume(
+-                volume_uuid, volume_name, size, place_resources
++                volume_uuid,
++                volume_name,
++                size,
++                place_resources,
++                high_availability
+             )
+ 
+             assert volume_properties.namespace == \
+@@ -2331,7 +2369,7 @@ class LinstorVolumeManager(object):
+                 break
+         self._destroy_resource(resource_name)
+ 
+-    def _destroy_volume(self, volume_uuid, force=False):
++    def _destroy_volume(self, volume_uuid, force=False, preserve_properties=False):
+         volume_properties = self._get_volume_properties(volume_uuid)
+         try:
+             volume_name = volume_properties.get(self.PROP_VOLUME_NAME)
+@@ -2339,7 +2377,8 @@ class LinstorVolumeManager(object):
+                 self._destroy_resource(volume_name, force)
+ 
+             # Assume this call is atomic.
+-            volume_properties.clear()
++            if not preserve_properties:
++                volume_properties.clear()
+         except Exception as e:
+             raise LinstorVolumeManagerError(
+                 'Cannot destroy volume `{}`: {}'.format(volume_uuid, e)
+@@ -2599,7 +2638,7 @@ class LinstorVolumeManager(object):
+ 
+     @classmethod
+     def _create_database_volume(
+-        cls, lin, group_name, node_names, redundancy, auto_quorum
++        cls, lin, group_name, storage_pool_name, node_names, redundancy, auto_quorum
+     ):
+         try:
+             dfns = lin.resource_dfn_list_raise().resource_definitions
+@@ -2621,7 +2660,7 @@ class LinstorVolumeManager(object):
+         # I don't understand why but this command protect against this bug.
+         try:
+             pools = lin.storage_pool_list_raise(
+-                filter_by_stor_pools=[group_name]
++                filter_by_stor_pools=[storage_pool_name]
+             )
+         except Exception as e:
+             raise LinstorVolumeManagerError(
+@@ -2663,7 +2702,7 @@ class LinstorVolumeManager(object):
+             resources.append(linstor.ResourceData(
+                 node_name=node_name,
+                 rsc_name=DATABASE_VOLUME_NAME,
+-                storage_pool=group_name
++                storage_pool=storage_pool_name
+             ))
+         # Create diskless resources on the remaining set.
+         for node_name in diskful_nodes[redundancy:] + diskless_nodes:
+@@ -2825,6 +2864,55 @@ class LinstorVolumeManager(object):
+         # after LINSTOR database volume destruction.
+         return util.retry(destroy, maxretry=10)
+ 
++    @classmethod
++    def _create_resource_group(
++        cls,
++        lin,
++        group_name,
++        storage_pool_name,
++        redundancy,
++        destroy_old_group
++    ):
++        rg_creation_attempt = 0
++        while True:
++            result = lin.resource_group_create(
++                name=group_name,
++                place_count=redundancy,
++                storage_pool=storage_pool_name,
++                diskless_on_remaining=False
++            )
++            error_str = cls._get_error_str(result)
++            if not error_str:
++                break
++
++            errors = cls._filter_errors(result)
++            if destroy_old_group and cls._check_errors(errors, [
++                linstor.consts.FAIL_EXISTS_RSC_GRP
++            ]):
++                rg_creation_attempt += 1
++                if rg_creation_attempt < 2:
++                    try:
++                        cls._destroy_resource_group(lin, group_name)
++                    except Exception as e:
++                        error_str = 'Failed to destroy old and empty RG: {}'.format(e)
++                    else:
++                        continue
++
++            raise LinstorVolumeManagerError(
++                'Could not create RG `{}`: {}'.format(
++                    group_name, error_str
++                )
++            )
++
++        result = lin.volume_group_create(group_name)
++        error_str = cls._get_error_str(result)
++        if error_str:
++            raise LinstorVolumeManagerError(
++                'Could not create VG `{}`: {}'.format(
++                    group_name, error_str
++                )
++            )
++
+     @classmethod
+     def _destroy_resource_group(cls, lin, group_name):
+         def destroy():
+@@ -2849,6 +2937,12 @@ class LinstorVolumeManager(object):
+         # `VG/LV`. "/" is not accepted by LINSTOR.
+         return '{}{}'.format(cls.PREFIX_SR, base_name.replace('/', '_'))
+ 
++    # Used to store important data in a HA context,
++    # i.e. a replication count of 3.
++    @classmethod
++    def _build_ha_group_name(cls, base_name):
++        return '{}{}'.format(cls.PREFIX_HA, base_name.replace('/', '_'))
++
+     @classmethod
+     def _check_volume_creation_errors(cls, result, volume_uuid, group_name):
+         errors = cls._filter_errors(result)
+@@ -2861,6 +2955,13 @@ class LinstorVolumeManager(object):
+                 LinstorVolumeManagerError.ERR_VOLUME_EXISTS
+             )
+ 
++        if cls._check_errors(errors, [linstor.consts.FAIL_NOT_FOUND_RSC_GRP]):
++            raise LinstorVolumeManagerError(
++                'Failed to create volume `{}` from SR `{}`, resource group doesn\'t exist'
++                .format(volume_uuid, group_name),
++                LinstorVolumeManagerError.ERR_GROUP_NOT_EXISTS
++            )
++
+         if errors:
+             raise LinstorVolumeManagerError(
+                 'Failed to create volume `{}` from SR `{}`: {}'.format(
+-- 
+2.44.0
+

--- a/SOURCES/0164-feat-linstor-manager-add-getNodePreferredInterface-h.patch
+++ b/SOURCES/0164-feat-linstor-manager-add-getNodePreferredInterface-h.patch
@@ -1,0 +1,76 @@
+From 9d4a4f3b9aa15b98bef3fdfbd8874af47bbe709c Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Mon, 15 Apr 2024 11:22:18 +0200
+Subject: [PATCH 164/170] feat(linstor-manager): add
+ `getNodePreferredInterface` helper
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/linstor-manager         | 16 ++++++++++++++++
+ drivers/linstorvolumemanager.py | 17 +++++++++++++++++
+ 2 files changed, 33 insertions(+)
+
+diff --git a/drivers/linstor-manager b/drivers/linstor-manager
+index 6b45875..a2501d7 100755
+--- a/drivers/linstor-manager
++++ b/drivers/linstor-manager
+@@ -1062,6 +1062,21 @@ def list_node_interfaces(session, args):
+         raise XenAPIPlugin.Failure('-1', [str(e)])
+ 
+ 
++def get_node_preferred_interface(session, args):
++    group_name = args['groupName']
++    hostname = args['hostname']
++
++    linstor = LinstorVolumeManager(
++        get_controller_uri(),
++        group_name,
++        logger=util.SMlog
++    )
++    try:
++        return linstor.get_node_preferred_interface(hostname)
++    except Exception as e:
++        raise XenAPIPlugin.Failure('-1', [str(e)])
++
++
+ def set_node_preferred_interface(session, args):
+     group_name = args['groupName']
+     hostname = args['hostname']
+@@ -1132,5 +1147,6 @@ if __name__ == '__main__':
+         'destroyNodeInterface': destroy_node_interface,
+         'modifyNodeInterface': modify_node_interface,
+         'listNodeInterfaces': list_node_interfaces,
++        'getNodePreferredInterface': get_node_preferred_interface,
+         'setNodePreferredInterface': set_node_preferred_interface
+     })
+diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
+index b4edc95..223bba3 100755
+--- a/drivers/linstorvolumemanager.py
++++ b/drivers/linstorvolumemanager.py
+@@ -1544,6 +1544,23 @@ class LinstorVolumeManager(object):
+             }
+         return interfaces
+ 
++    def get_node_preferred_interface(self, node_name):
++        """
++        Get the preferred interface used by a node.
++        :param str node_name: Node name of the interface to get.
++        :rtype: str
++        """
++        try:
++            nodes = self._linstor.node_list_raise([node_name]).nodes
++            if nodes:
++                properties = nodes[0].props
++                return properties.get('PrefNic', 'default')
++            return nodes
++        except Exception as e:
++            raise LinstorVolumeManagerError(
++                'Failed to get preferred interface: `{}`'.format(e)
++            )
++
+     def set_node_preferred_interface(self, node_name, name):
+         """
+         Set the preferred interface to use on a node.
+-- 
+2.44.0
+

--- a/SOURCES/0165-fix-linstorvolumemanager-blocks-deletion-of-default-.patch
+++ b/SOURCES/0165-fix-linstorvolumemanager-blocks-deletion-of-default-.patch
@@ -1,0 +1,31 @@
+From 317cc64465c76de173d630cc8dce622fc75a3863 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Mon, 15 Apr 2024 11:26:00 +0200
+Subject: [PATCH 165/170] fix(linstorvolumemanager): blocks deletion of default
+ network interface
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/linstorvolumemanager.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
+index 223bba3..5012b54 100755
+--- a/drivers/linstorvolumemanager.py
++++ b/drivers/linstorvolumemanager.py
+@@ -1491,6 +1491,12 @@ class LinstorVolumeManager(object):
+         :param str node_name: Node name of the interface to remove.
+         :param str name: Interface to remove.
+         """
++
++        if name == 'default':
++            raise LinstorVolumeManagerError(
++                'Unable to delete the default interface of a node!'
++            )
++
+         result = self._linstor.netinterface_delete(node_name, name)
+         errors = self._filter_errors(result)
+         if errors:
+-- 
+2.44.0
+

--- a/SOURCES/0166-feat-linstorvolumemanager-change-logic-of-get_resour.patch
+++ b/SOURCES/0166-feat-linstorvolumemanager-change-logic-of-get_resour.patch
@@ -1,0 +1,104 @@
+From 55093148fcc420bed51e39dfab9071306aa5a994 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Mon, 15 Apr 2024 17:56:47 +0200
+Subject: [PATCH 166/170] feat(linstorvolumemanager): change logic of
+ `get_resources_info`: - Add a nested level "nodes" for each resource - Add a
+ "uuid" attr on resources - Rename LINSTOR "uuid" to "linstor-uuid" - Optimize
+ code
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/linstor-manager         |  1 +
+ drivers/linstorvolumemanager.py | 34 ++++++++++++++++++++-------------
+ 2 files changed, 22 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/linstor-manager b/drivers/linstor-manager
+index a2501d7..ed85525 100755
+--- a/drivers/linstor-manager
++++ b/drivers/linstor-manager
+@@ -884,6 +884,7 @@ def health_check(session, args):
+        'controller-uri': '',
+        'nodes': {},
+        'storage-pools': {},
++       'resources': {},
+        'warnings': [],
+        'errors': []
+     }
+diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
+index 5012b54..ebce6eb 100755
+--- a/drivers/linstorvolumemanager.py
++++ b/drivers/linstorvolumemanager.py
+@@ -1624,7 +1624,7 @@ class LinstorVolumeManager(object):
+ 
+             storage_pools[pool.node_name].append({
+                 'storage-pool-name': pool.name,
+-                'uuid': pool.uuid,
++                'linstor-uuid': pool.uuid,
+                 'free-size': size,
+                 'capacity': capacity
+             })
+@@ -1637,16 +1637,19 @@ class LinstorVolumeManager(object):
+         :rtype: dict(str, list)
+         """
+         resources = {}
+-        resource_list = self._linstor.resource_list_raise()
++        resource_list = self._get_resource_cache()
++        volume_names = self.get_volumes_with_name()
+         for resource in resource_list.resources:
+             if resource.name not in resources:
+-                resources[resource.name] = {}
++                resources[resource.name] = { 'nodes': {}, 'uuid': '' }
++            resource_nodes = resources[resource.name]['nodes']
+ 
+-            resources[resource.name][resource.node_name] = {
++            resource_nodes[resource.node_name] = {
+                 'volumes': [],
+                 'diskful': linstor.consts.FLAG_DISKLESS not in resource.flags,
+                 'tie-breaker': linstor.consts.FLAG_TIE_BREAKER in resource.flags
+             }
++            resource_volumes = resource_nodes[resource.node_name]['volumes']
+ 
+             for volume in resource.volumes:
+                 # We ignore diskless pools of the form "DfltDisklessStorPool".
+@@ -1665,17 +1668,17 @@ class LinstorVolumeManager(object):
+                 else:
+                     allocated_size *= 1024
+ 
+-            resources[resource.name][resource.node_name]['volumes'].append({
+-                'storage-pool-name': volume.storage_pool_name,
+-                'uuid': volume.uuid,
+-                'number': volume.number,
+-                'device-path': volume.device_path,
+-                'usable-size': usable_size,
+-                'allocated-size': allocated_size
+-            })
++                resource_volumes.append({
++                    'storage-pool-name': volume.storage_pool_name,
++                    'linstor-uuid': volume.uuid,
++                    'number': volume.number,
++                    'device-path': volume.device_path,
++                    'usable-size': usable_size,
++                    'allocated-size': allocated_size
++                })
+ 
+         for resource_state in resource_list.resource_states:
+-            resource = resources[resource_state.rsc_name][resource_state.node_name]
++            resource = resources[resource_state.rsc_name]['nodes'][resource_state.node_name]
+             resource['in-use'] = resource_state.in_use
+ 
+             volumes = resource['volumes']
+@@ -1684,6 +1687,11 @@ class LinstorVolumeManager(object):
+                 if volume:
+                     volume['disk-state'] = volume_state.disk_state
+ 
++        for volume_uuid, volume_name in volume_names.items():
++            resource = resources.get(volume_name)
++            if resource:
++                resource['uuid'] = volume_uuid
++
+         return resources
+ 
+     def get_database_path(self):
+-- 
+2.44.0
+

--- a/SOURCES/0167-feat-linstor-manager-add-error-codes-to-healthCheck-.patch
+++ b/SOURCES/0167-feat-linstor-manager-add-error-codes-to-healthCheck-.patch
@@ -1,0 +1,251 @@
+From ac97d774d19b056ee940a1781e62451dc3b75ee7 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Thu, 18 Apr 2024 13:57:37 +0200
+Subject: [PATCH 167/170] feat(linstor-manager): add error codes to healthCheck
+ helper
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/linstor-manager         | 153 +++++++++++++++++++++++++-------
+ drivers/linstorvolumemanager.py |   2 +-
+ 2 files changed, 120 insertions(+), 35 deletions(-)
+
+diff --git a/drivers/linstor-manager b/drivers/linstor-manager
+index ed85525..94aa4fb 100755
+--- a/drivers/linstor-manager
++++ b/drivers/linstor-manager
+@@ -27,6 +27,7 @@ import socket
+ import XenAPI
+ import XenAPIPlugin
+ 
++from json import JSONEncoder
+ from linstorjournaler import LinstorJournaler
+ from linstorvhdutil import LinstorVhdUtil
+ from linstorvolumemanager import get_controller_uri, get_local_volume_openers, LinstorVolumeManager
+@@ -877,6 +878,64 @@ def get_drbd_openers(session, args):
+         raise
+ 
+ 
++class HealthCheckError(object):
++    __slots__ = ('data')
++
++    MASK_REPORT_LEVEL = 0x7000000
++    MASK_TYPE         = 0xFF0000
++    MASK_VALUE        = 0XFFFF
++
++    # 24-26 bits
++    REPORT_LEVEL_WARN = 0x1000000
++    REPORT_LEVEL_ERR  = 0x2000000
++
++    # 16-23 bits
++    TYPE_GENERIC      = 0x10000
++    TYPE_NODE         = 0x20000
++    TYPE_STORAGE_POOL = 0x30000
++    TYPE_VOLUME       = 0x40000
++    TYPE_RESOURCE     = 0x50000
++
++    # 1-15 bits
++    GENERIC_UNEXPECTED          = REPORT_LEVEL_ERR | TYPE_GENERIC | 0
++    GENERIC_LINSTOR_UNREACHABLE = REPORT_LEVEL_ERR | TYPE_GENERIC | 1
++
++    NODE_NOT_ONLINE = REPORT_LEVEL_WARN | TYPE_NODE | 0
++
++    STORAGE_POOL_UNKNOWN_FREE_SIZE = REPORT_LEVEL_ERR  | TYPE_STORAGE_POOL | 0
++    STORAGE_POOL_UNKNOWN_CAPACITY  = REPORT_LEVEL_ERR  | TYPE_STORAGE_POOL | 1
++    STORAGE_POOL_LOW_FREE_SIZE     = REPORT_LEVEL_WARN | TYPE_STORAGE_POOL | 2
++
++    VOLUME_UNKNOWN_STATE             = REPORT_LEVEL_WARN | TYPE_VOLUME | 0
++    VOLUME_INVALID_STATE             = REPORT_LEVEL_ERR  | TYPE_VOLUME | 1
++    VOLUME_WRONG_DISKLESS_STATE      = REPORT_LEVEL_WARN | TYPE_VOLUME | 2
++    VOLUME_INTERNAL_UNVERIFIED_STATE = REPORT_LEVEL_WARN | TYPE_VOLUME | 3
++
++    MAP_CODE_TO_PARAMS = {
++        GENERIC_UNEXPECTED: { 'message' },
++        GENERIC_LINSTOR_UNREACHABLE: { 'message' },
++        NODE_NOT_ONLINE: { 'name', 'status' },
++        STORAGE_POOL_UNKNOWN_FREE_SIZE: { 'name' },
++        STORAGE_POOL_UNKNOWN_CAPACITY: { 'name' },
++        STORAGE_POOL_LOW_FREE_SIZE: { 'name', 'threshold' },
++        VOLUME_UNKNOWN_STATE: { 'node', 'resource', 'number' },
++        VOLUME_INVALID_STATE: { 'node', 'resource', 'number', 'state' },
++        VOLUME_WRONG_DISKLESS_STATE: { 'node', 'resource', 'number', 'state' },
++        VOLUME_INTERNAL_UNVERIFIED_STATE: { 'node', 'resource', 'number', 'state' }
++    }
++
++    def __init__(self, code, **kwargs):
++        attributes = self.MAP_CODE_TO_PARAMS[code]
++        data = { 'code': code }
++        for attr_name, attr_value in kwargs.items():
++            assert attr_name in attributes
++            data[attr_name] = attr_value
++        self.data = data
++
++    def to_json(self):
++        return self.data
++
++
+ def health_check(session, args):
+     group_name = args['groupName']
+ 
+@@ -885,11 +944,15 @@ def health_check(session, args):
+        'nodes': {},
+        'storage-pools': {},
+        'resources': {},
+-       'warnings': [],
+        'errors': []
+     }
+ 
+     def format_result():
++        # See: https://stackoverflow.com/questions/18478287/making-object-json-serializable-with-regular-encoder/18561055#18561055
++        def _default(self, obj):
++            return getattr(obj.__class__, 'to_json', _default.default)(obj)
++        _default.default = JSONEncoder().default
++        JSONEncoder.default = _default
+         return json.dumps(result)
+ 
+     # 1. Get controller.
+@@ -912,7 +975,10 @@ def health_check(session, args):
+         )
+     except Exception as e:
+         # Probably a network issue, or offline controller.
+-        result['errors'].append('Cannot join SR: `{}`.'.format(e))
++        result['errors'].append(HealthCheckError(
++            code=HealthCheckError.GENERIC_LINSTOR_UNREACHABLE,
++            message=str(e)
++        ))
+         return format_result()
+ 
+     try:
+@@ -921,7 +987,11 @@ def health_check(session, args):
+         result['nodes'] = nodes
+         for node_name, status in nodes.items():
+             if status != 'ONLINE':
+-                result['warnings'].append('Node `{}` is {}.'.format(node_name, status))
++                result['errors'].append(HealthCheckError(
++                    code=HealthCheckError.NODE_NOT_ONLINE,
++                    name=node_name,
++                    status=status
++                ))
+ 
+         # 3. Check storage pool statuses.
+         storage_pools_per_node = linstor.get_storage_pools_info()
+@@ -931,23 +1001,25 @@ def health_check(session, args):
+                 free_size = storage_pool['free-size']
+                 capacity = storage_pool['capacity']
+                 if free_size < 0 or capacity <= 0:
+-                    result['errors'].append(
+-                        'Cannot get free size and/or capacity of storage pool `{}`.'
+-                        .format(storage_pool['uuid'])
+-                    )
+-                elif free_size > capacity:
+-                    result['errors'].append(
+-                        'Free size of storage pool `{}` is greater than capacity.'
+-                        .format(storage_pool['uuid'])
+-                    )
++                    if free_size < 0:
++                        result['errors'].append(HealthCheckError(
++                            code=HealthCheckError.STORAGE_POOL_UNKNOWN_FREE_SIZE,
++                            name=storage_pool['name']
++                        ))
++                    elif capacity < 0:
++                        result['errors'].append(HealthCheckError(
++                            code=HealthCheckError.STORAGE_POOL_UNKNOWN_CAPACITY,
++                            name=storage_pool['name']
++                        ))
+                 else:
+                     remaining_percent = free_size / float(capacity) * 100.0
+                     threshold = 10.0
+                     if remaining_percent < threshold:
+-                        result['warnings'].append(
+-                            'Remaining size of storage pool `{}` is below {}% of its capacity.'
+-                            .format(storage_pool['uuid'], threshold)
+-                        )
++                        result['errors'].append(HealthCheckError(
++                            code=HealthCheckError.STORAGE_POOL_LOW_FREE_SIZE,
++                            name=storage_pool['name'],
++                            threshold=threshold
++                        ))
+ 
+         # 4. Check resource statuses.
+         all_resources = linstor.get_resources_info()
+@@ -960,33 +1032,46 @@ def health_check(session, args):
+                     if disk_state in ['UpToDate', 'Created', 'Attached']:
+                         continue
+                     if disk_state == 'DUnknown':
+-                        result['warnings'].append(
+-                            'Unknown state for volume `{}` at index {} for resource `{}` on node `{}`'
+-                            .format(volume['device-path'], volume_index, resource_name, node_name)
+-                        )
++                        result['errors'].append(HealthCheckError(
++                            code=HealthCheckError.VOLUME_UNKNOWN_STATE,
++                            node=node_name,
++                            resource=resource_name,
++                            number=volume_index
++                        ))
+                         continue
+                     if disk_state in ['Inconsistent', 'Failed', 'To: Creating', 'To: Attachable', 'To: Attaching']:
+-                        result['errors'].append(
+-                            'Invalid state `{}` for volume `{}` at index {} for resource `{}` on node `{}`'
+-                            .format(disk_state, volume['device-path'], volume_index, resource_name, node_name)
+-                        )
++                        result['errors'].append(HealthCheckError(
++                            code=HealthCheckError.VOLUME_INVALID_STATE,
++                            node=node_name,
++                            resource=resource_name,
++                            number=volume_index,
++                            state=disk_state
++                        ))
+                         continue
+                     if disk_state == 'Diskless':
+                         if resource['diskful']:
+-                            result['errors'].append(
+-                                'Unintentional diskless state detected for volume `{}` at index {} for resource `{}` on node `{}`'
+-                                .format(volume['device-path'], volume_index, resource_name, node_name)
+-                            )
++                            result['errors'].append(HealthCheckError(
++                                code=HealthCheckError.VOLUME_WRONG_DISKLESS_STATE,
++                                node=node_name,
++                                resource=resource_name,
++                                number=volume_index,
++                                state=disk_state
++                            ))
+                         elif resource['tie-breaker']:
+                             volume['disk-state'] = 'TieBreaker'
+                         continue
+-                    result['warnings'].append(
+-                        'Unhandled state `{}` for volume `{}` at index {} for resource `{}` on node `{}`'
+-                        .format(disk_state, volume['device-path'], volume_index, resource_name, node_name)
+-                    )
+-
++                    result['errors'].append(HealthCheckError(
++                        code=HealthCheckError.VOLUME_INTERNAL_UNVERIFIED_STATE,
++                        node=node_name,
++                        resource=resource_name,
++                        number=volume_index,
++                        state=disk_state
++                    ))
+     except Exception as e:
+-        result['errors'].append('Unexpected error: `{}`'.format(e))
++        result['errors'].append(HealthCheckError(
++            code=HealthCheckError.GENERIC_UNEXPECTED,
++            message=str(e)
++        ))
+ 
+     return format_result()
+ 
+diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
+index ebce6eb..e70221f 100755
+--- a/drivers/linstorvolumemanager.py
++++ b/drivers/linstorvolumemanager.py
+@@ -1623,7 +1623,7 @@ class LinstorVolumeManager(object):
+                     capacity *= 1024
+ 
+             storage_pools[pool.node_name].append({
+-                'storage-pool-name': pool.name,
++                'name': pool.name,
+                 'linstor-uuid': pool.uuid,
+                 'free-size': size,
+                 'capacity': capacity
+-- 
+2.44.0
+

--- a/SOURCES/0168-fix-LinstorSR-fix-bad-exception-reference-during-sna.patch
+++ b/SOURCES/0168-fix-LinstorSR-fix-bad-exception-reference-during-sna.patch
@@ -1,0 +1,39 @@
+From 68fa4cbfb53e3fd1266457e35961da9d3387db38 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Wed, 24 Apr 2024 15:10:49 +0200
+Subject: [PATCH 168/170] fix(LinstorSR): fix bad exception reference during
+ snapshot
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/LinstorSR.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
+index 3421f79..3bd31e9 100755
+--- a/drivers/LinstorSR.py
++++ b/drivers/LinstorSR.py
+@@ -2500,17 +2500,17 @@ class LinstorVDI(VDI.VDI):
+             self.session.xenapi.VDI.set_sm_config(
+                 vdi_ref, active_vdi.sm_config
+             )
+-        except Exception:
++        except Exception as e:
+             util.logException('Failed to snapshot!')
+             try:
+                 self.sr._handle_interrupted_clone(
+                     active_uuid, clone_info, force_undo=True
+                 )
+                 self.sr._journaler.remove(LinstorJournaler.CLONE, active_uuid)
+-            except Exception as e:
++            except Exception as clean_error:
+                 util.SMlog(
+                     'WARNING: Failed to clean up failed snapshot: {}'
+-                    .format(e)
++                    .format(clean_error)
+                 )
+             raise xs_errors.XenError('VDIClone', opterr=str(e))
+ 
+-- 
+2.44.0
+

--- a/SOURCES/0169-fix-tapdisk-pause-ensure-LINSTOR-VHD-chain-is-availa.patch
+++ b/SOURCES/0169-fix-tapdisk-pause-ensure-LINSTOR-VHD-chain-is-availa.patch
@@ -1,0 +1,159 @@
+From 2c50709d6be261a3115b5484d1d48debe7d618c9 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Wed, 24 Apr 2024 17:29:26 +0200
+Subject: [PATCH 169/170] fix(tapdisk-pause): ensure LINSTOR VHD chain is
+ available
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/LinstorSR.py      | 35 ++---------------------------------
+ drivers/linstorvhdutil.py | 38 ++++++++++++++++++++++++++++++++++++++
+ drivers/tapdisk-pause     |  6 ++++--
+ 3 files changed, 44 insertions(+), 35 deletions(-)
+
+diff --git a/drivers/LinstorSR.py b/drivers/LinstorSR.py
+index 3bd31e9..c5ed7c5 100755
+--- a/drivers/LinstorSR.py
++++ b/drivers/LinstorSR.py
+@@ -1830,7 +1830,7 @@ class LinstorVDI(VDI.VDI):
+             return self._attach_using_http_nbd()
+ 
+         # Ensure we have a path...
+-        self._create_chain_paths(self.uuid)
++        self.sr._vhdutil.create_chain_paths(self.uuid)
+ 
+         self.attached = True
+         return VDI.VDI.attach(self, self.sr.uuid, self.uuid)
+@@ -2357,7 +2357,7 @@ class LinstorVDI(VDI.VDI):
+             raise xs_errors.XenError('SnapshotChainTooLong')
+ 
+         # Ensure we have a valid path if we don't have a local diskful.
+-        self._create_chain_paths(self.uuid)
++        self.sr._vhdutil.create_chain_paths(self.uuid)
+ 
+         volume_path = self.path
+         if not util.pathexists(volume_path):
+@@ -2820,37 +2820,6 @@ class LinstorVDI(VDI.VDI):
+         self._kill_persistent_nbd_server(volume_name)
+         self._kill_persistent_http_server(volume_name)
+ 
+-    def _create_chain_paths(self, vdi_uuid):
+-        # OPTIMIZE: Add a limit_to_first_allocated_block param to limit vhdutil calls.
+-        # Useful for the snapshot code algorithm.
+-
+-        while vdi_uuid:
+-            path = self._linstor.get_device_path(vdi_uuid)
+-            if not util.pathexists(path):
+-                raise xs_errors.XenError(
+-                    'VDIUnavailable', opterr='Could not find: {}'.format(path)
+-                )
+-
+-            # Diskless path can be created on the fly, ensure we can open it.
+-            def check_volume_usable():
+-                while True:
+-                    try:
+-                        with open(path, 'r+'):
+-                            pass
+-                    except IOError as e:
+-                        if e.errno == errno.ENODATA:
+-                            time.sleep(2)
+-                            continue
+-                        if e.errno == errno.EROFS:
+-                            util.SMlog('Volume not attachable because RO. Openers: {}'.format(
+-                                self.sr._linstor.get_volume_openers(vdi_uuid)
+-                            ))
+-                        raise
+-                    break
+-            util.retry(check_volume_usable, 15, 2)
+-
+-            vdi_uuid = self.sr._vhdutil.get_vhd_info(vdi_uuid).parentUuid
+-
+ # ------------------------------------------------------------------------------
+ 
+ 
+diff --git a/drivers/linstorvhdutil.py b/drivers/linstorvhdutil.py
+index 23d8b6a..17b7790 100644
+--- a/drivers/linstorvhdutil.py
++++ b/drivers/linstorvhdutil.py
+@@ -21,6 +21,7 @@ import distutils.util
+ import errno
+ import json
+ import socket
++import time
+ import util
+ import vhdutil
+ import xs_errors
+@@ -141,6 +142,43 @@ class LinstorVhdUtil:
+         self._session = session
+         self._linstor = linstor
+ 
++    def create_chain_paths(self, vdi_uuid):
++        # OPTIMIZE: Add a limit_to_first_allocated_block param to limit vhdutil calls.
++        # Useful for the snapshot code algorithm.
++
++        leaf_vdi_path = self._linstor.get_device_path(vdi_uuid)
++        path = leaf_vdi_path
++        while True:
++            if not util.pathexists(path):
++                raise xs_errors.XenError(
++                    'VDIUnavailable', opterr='Could not find: {}'.format(path)
++                )
++
++            # Diskless path can be created on the fly, ensure we can open it.
++            def check_volume_usable():
++                while True:
++                    try:
++                        with open(path, 'r+'):
++                            pass
++                    except IOError as e:
++                        if e.errno == errno.ENODATA:
++                            time.sleep(2)
++                            continue
++                        if e.errno == errno.EROFS:
++                            util.SMlog('Volume not attachable because RO. Openers: {}'.format(
++                                self._linstor.get_volume_openers(vdi_uuid)
++                            ))
++                        raise
++                    break
++            util.retry(check_volume_usable, 15, 2)
++
++            vdi_uuid = self.get_vhd_info(vdi_uuid).parentUuid
++            if not vdi_uuid:
++                break
++            path = self._linstor.get_device_path(vdi_uuid)
++
++        return leaf_vdi_path
++
+     # --------------------------------------------------------------------------
+     # Getters: read locally and try on another host in case of failure.
+     # --------------------------------------------------------------------------
+diff --git a/drivers/tapdisk-pause b/drivers/tapdisk-pause
+index e0bca7b..c316cdf 100755
+--- a/drivers/tapdisk-pause
++++ b/drivers/tapdisk-pause
+@@ -30,6 +30,7 @@ import vhdutil
+ import lvmcache
+ 
+ try:
++    from linstorvhdutil import LinstorVhdUtil
+     from linstorvolumemanager import get_controller_uri, LinstorVolumeManager
+     LINSTOR_AVAILABLE = True
+ except ImportError:
+@@ -162,11 +163,12 @@ class Tapdisk:
+             dconf = session.xenapi.PBD.get_device_config(pbd)
+             group_name = dconf['group-name']
+ 
+-            device_path = LinstorVolumeManager(
++            linstor = LinstorVolumeManager(
+                 get_controller_uri(),
+                 group_name,
+                 logger=util.SMlog
+-            ).get_device_path(self.vdi_uuid)
++            )
++            device_path = LinstorVhdUtil(session, linstor).create_chain_paths(self.vdi_uuid)
+ 
+             if realpath != device_path:
+                 util.SMlog(
+-- 
+2.44.0
+

--- a/SOURCES/0170-fix-LVHDoISCSISR-disable-restart-of-ISCSI-daemon.patch
+++ b/SOURCES/0170-fix-LVHDoISCSISR-disable-restart-of-ISCSI-daemon.patch
@@ -1,0 +1,96 @@
+From f36a7a2bac7db952b0173b30dd3d5557932b136f Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Fri, 26 Apr 2024 14:20:04 +0200
+Subject: [PATCH 170/170] fix(LVHDoISCSISR): disable restart of ISCSI daemon
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/LVHDoISCSISR.py    |  2 ++
+ tests/test_LVHDoISCSISR.py | 51 --------------------------------------
+ 2 files changed, 2 insertions(+), 51 deletions(-)
+
+diff --git a/drivers/LVHDoISCSISR.py b/drivers/LVHDoISCSISR.py
+index 1fa6f6f..da2c9ed 100755
+--- a/drivers/LVHDoISCSISR.py
++++ b/drivers/LVHDoISCSISR.py
+@@ -553,6 +553,8 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
+         return out
+ 
+     def check_sr(self, sr_uuid):
++        # Disable to prevent daemon restart.
++        return
+         """Hook to check SR health"""
+         pbdref = util.find_my_pbd(self.session, self.host_ref, self.sr_ref)
+         if pbdref:
+diff --git a/tests/test_LVHDoISCSISR.py b/tests/test_LVHDoISCSISR.py
+index ba668d0..c876ed8 100644
+--- a/tests/test_LVHDoISCSISR.py
++++ b/tests/test_LVHDoISCSISR.py
+@@ -167,15 +167,6 @@ class TestLVHDoISCSISR(ISCSITestCase):
+ 
+         super(TestLVHDoISCSISR, self).setUp()
+ 
+-    @property
+-    def mock_baseiscsi(self):
+-        assert len(self.base_srs) == 1
+-        single_sr = None
+-        for sr in self.base_srs:
+-            single_sr = sr
+-
+-        return single_sr
+-
+     def baseiscsi(self, srcmd, sr_uuid):
+         new_baseiscsi = mock.create_autospec(BaseISCSISR)
+         local_iqn = srcmd.dconf['localIQN']
+@@ -199,48 +190,6 @@ class TestLVHDoISCSISR(ISCSITestCase):
+         self.subject = LVHDoISCSISR.LVHDoISCSISR(
+             sr_cmd, self.sr_uuid)
+ 
+-    def test_check_sr_pbd_not_found(self):
+-        # Arrange
+-        self.mock_util.find_my_pbd.return_value = None
+-        self.create_test_sr(self.create_sr_command())
+-
+-        # Act
+-        self.subject.check_sr(TEST_SR_UUID)
+-
+-        # Assert
+-        self.mock_util.find_my_pbd.assert_called_with(
+-            self.mock_session, 'test_host', 'sr_ref')
+-
+-    def test_check_sr_correct_sessions_count(self):
+-        # Arrange
+-        self.mock_util.find_my_pbd.return_value = 'my_pbd'
+-        self.mock_session.xenapi.PBD.get_other_config.return_value = {
+-            'iscsi_sessions': 2
+-        }
+-        self.create_test_sr(self.create_sr_command())
+-
+-        # Act
+-        self.subject.check_sr(TEST_SR_UUID)
+-
+-        # Assert
+-        self.mock_session.xenapi.PBD.get_other_config.assert_called_with('my_pbd')
+-
+-    def test_check_sr_not_enough_sessions(self):
+-        # Arrange
+-        self.mock_util.find_my_pbd.return_value = 'my_pbd'
+-        self.mock_session.xenapi.PBD.get_other_config.return_value = {
+-            'iscsi_sessions': 1
+-        }
+-        self.create_test_sr(self.create_sr_command())
+-
+-        # Act
+-        self.subject.check_sr(TEST_SR_UUID)
+-
+-        # Assert
+-        self.mock_baseiscsi.attach.assert_called_with(
+-            TEST_SR_UUID
+-        )
+-
+     def test_sr_attach_multi_session(self):
+         # Arrange
+         self.mock_util.find_my_pbd.return_value = 'my_pbd'
+-- 
+2.44.0
+

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -11,7 +11,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 2.30.8
-Release: %{?xsrel}.1.0.linstor.1%{?dist}
+Release: %{?xsrel}.1.0.linstor.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -250,6 +250,14 @@ Patch1159: 0159-fix-linstorvolumemanager-retry-resize-if-volume-is-n.patch
 Patch1160: 0160-fix-LinstorSR-create-DRBD-diskless-if-necessary-for-.patch
 Patch1161: 0161-fix-LinstorSR-fix-bad-call-to-vhdutil.inflate-bad-ex.patch
 Patch1162: 0162-fix-LinstorSR-activate-VG-if-attach-from-config-is-a.patch
+Patch1163: 0163-feat-LinstorSR-use-a-specific-resource-group-for-DB-.patch
+Patch1164: 0164-feat-linstor-manager-add-getNodePreferredInterface-h.patch
+Patch1165: 0165-fix-linstorvolumemanager-blocks-deletion-of-default-.patch
+Patch1166: 0166-feat-linstorvolumemanager-change-logic-of-get_resour.patch
+Patch1167: 0167-feat-linstor-manager-add-error-codes-to-healthCheck-.patch
+Patch1168: 0168-fix-LinstorSR-fix-bad-exception-reference-during-sna.patch
+Patch1169: 0169-fix-tapdisk-pause-ensure-LINSTOR-VHD-chain-is-availa.patch
+Patch1170: 0170-fix-LVHDoISCSISR-disable-restart-of-ISCSI-daemon.patch
 
 %description
 This package contains storage backends used in XCP
@@ -654,6 +662,16 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
+* Mon Apr 29 2024 Ronan Abhamon <ronan.abhamon@vates.fr> - 2.30.8-10.1.0.linstor.2
+- Add 0163-feat-LinstorSR-use-a-specific-resource-group-for-DB-.patch
+- Add 0164-feat-linstor-manager-add-getNodePreferredInterface-h.patch
+- Add 0165-fix-linstorvolumemanager-blocks-deletion-of-default-.patch
+- Add 0166-feat-linstorvolumemanager-change-logic-of-get_resour.patch
+- Add 0167-feat-linstor-manager-add-error-codes-to-healthCheck-.patch
+- Add 0168-fix-LinstorSR-fix-bad-exception-reference-during-sna.patch
+- Add 0169-fix-tapdisk-pause-ensure-LINSTOR-VHD-chain-is-availa.patch
+- Add 0170-fix-LVHDoISCSISR-disable-restart-of-ISCSI-daemon.patch
+
 * Tue Feb 06 2024 Ronan Abhamon <ronan.abhamon@vates.fr> - 2.30.8-10.1.0.linstor.1
 - Add "Provides": sm-linstor (necessary for the "Requires" of xcp-ng-linstor)
 - Add LINSTOR patches


### PR DESCRIPTION
- Robustify HA and force a replication of 3 of the database
- Change linstor-manager API:
  - Add a `getNodePreferredInterface` helper
  - Protect against deletion of default interface
  - `healthCheck` now returns formatted output and better error handling
- Robustify pause/unpause between snapshots