### PR TITLE
8.2: Packaging fixes, notably proper disabling of the removed sr_health_check.timer

### DIFF
--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -11,7 +11,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 2.30.8
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -180,10 +180,11 @@ systemctl enable linstor-monitor.service
 if [ $1 -eq 0 ] ; then
     update-alternatives --remove multipath.conf /etc/multipath.xenserver/multipath.conf
 fi
-exit 0
 
 # XCP-ng
 %systemd_preun linstor-monitor.service
+
+exit 0
 
 %postun
 %systemd_postun make-dummy-sr.service
@@ -505,6 +506,9 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
+* Mon Aug 19 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - WIP - 2.30.8-12.3
+- %%preun: Move command above exit 0 so that it's executed
+
 * Thu Jun 27 2024 Benjamin Reis <benjamin.reis@vates.tech> - 2.30.8-12.2
 - Add 0024-Revert-CA-379329-check-for-missing-iSCSI-sessions-an.patch
 

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -166,6 +166,21 @@ update-alternatives --install /etc/multipath.conf multipath.conf /etc/multipath.
 # However it won't start without linstor-controller.service
 systemctl enable linstor-monitor.service
 
+if [ $1 -gt 1 ]; then
+    # XCP-ng: we temporarily removed sr_health_check.timer,
+    # so we need to disable and stop it if it is present on the system
+    TIMER_LINK=/etc/systemd/system/timers.target.wants/sr_health_check.timer
+    if [ -e "$TIMER_LINK" ]; then
+        systemctl --no-reload disable sr_health_check.timer 2>&1 || :
+        systemctl stop sr_health_check.timer 2>&1 || :
+    elif [ -L "$TIMER_LINK" ]; then
+        # Remove dangling symlink left by previous build that removed
+        # the timer without disabling it first.
+        rm -f "$TIMER_LINK"
+        systemctl reset-failed sr_health_check.timer
+    fi
+fi
+
 %preun
 %systemd_preun make-dummy-sr.service
 %systemd_preun mpcount.service
@@ -506,8 +521,11 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
-* Mon Aug 19 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - WIP - 2.30.8-12.3
+* Mon Aug 19 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 2.30.8-12.3
 - %%preun: Move command above exit 0 so that it's executed
+- Properly disable the removed sr_health_check.timer
+- Also remove the dangling symlink if still present due to improper removal
+  of the timer in sm-2.30.8-12.2
 
 * Thu Jun 27 2024 Benjamin Reis <benjamin.reis@vates.tech> - 2.30.8-12.2
 - Add 0024-Revert-CA-379329-check-for-missing-iSCSI-sessions-an.patch


### PR DESCRIPTION
8.2 backport of #58