### PR TITLE
Release 2.30.8-13.2.0.linstor.1

### DIFF
--- a/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
+++ b/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
@@ -1,7 +1,7 @@
 From 705a6d9deed2ba862577681fc54df144060f3816 Mon Sep 17 00:00:00 2001
 From: Mark Syms <mark.syms@citrix.com>
 Date: Thu, 20 May 2021 17:40:06 +0100
-Subject: [PATCH 001/177] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
+Subject: [PATCH 001/180] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
  CA-354692: check for device parameter in create/probe calls
 
 Signed-off-by: Mark Syms <mark.syms@citrix.com>

--- a/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From fd898b82d880619f0acd9d1b8f1d55b3967bc339 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 002/177] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 002/180] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0003-Add-TrueNAS-multipath-config.patch
+++ b/SOURCES/0003-Add-TrueNAS-multipath-config.patch
@@ -1,7 +1,7 @@
 From bd709621897bda8d9f14820fb3d52eecfe51facb Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:26:43 +0200
-Subject: [PATCH 003/177] Add TrueNAS multipath config
+Subject: [PATCH 003/180] Add TrueNAS multipath config
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
+++ b/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
@@ -1,7 +1,7 @@
 From 574897552a11af6fc92e145df0bacb42a2ac6b53 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 004/177] feat(drivers): add CephFS, GlusterFS and XFS drivers
+Subject: [PATCH 004/180] feat(drivers): add CephFS, GlusterFS and XFS drivers
 
 ---
  Makefile               |   3 +

--- a/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From 3a948fe3ff75146c3a9c960768ca4791c109a6b6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 005/177] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 005/180] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---

--- a/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
+++ b/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
@@ -1,7 +1,7 @@
 From 8b1962f5d6d8b092525e94241df033e4a78872b1 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 17:10:12 +0200
-Subject: [PATCH 006/177] Re-add the ext4 driver for users who need to
+Subject: [PATCH 006/180] Re-add the ext4 driver for users who need to
  transition
 
 The driver is needed to transition to the ext driver.

--- a/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From 9b836e9e503354796a7f975bb44f10a0920f33e3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 007/177] feat(drivers): add LinstorSR driver
+Subject: [PATCH 007/180] feat(drivers): add LinstorSR driver
 
 Some important points:
 

--- a/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From c756b29ce80da0cd38f88bbaaddf4e1130962af9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 008/177] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 008/180] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages

--- a/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
+++ b/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
@@ -1,7 +1,7 @@
 From c4402ded6d0dd748435c621c7d7840cb7886bc3f Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Thu, 25 Feb 2021 09:54:52 +0100
-Subject: [PATCH 009/177] If no NFS ACLs provided, assume everyone:
+Subject: [PATCH 009/180] If no NFS ACLs provided, assume everyone:
 
 Some QNAP devices do not provide ACL when fetching NFS mounts.
 In this case the assumed ACL should be: "*".

--- a/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From ba6e2bace64965d7d9f89e6dd9a94bf22ae075a2 Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 010/177] Added SM Driver for MooseFS
+Subject: [PATCH 010/180] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>

--- a/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From dc7619735961b1fc0b7075cdc02ba375b76aa011 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 011/177] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 011/180] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir

--- a/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From a1341e33251ec40a12e0971ffeda8b935af0be93 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 012/177] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 012/180] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior

--- a/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From 58c1e5a82d1b943a94a1524e52fd8bf43e916e3e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 013/177] Fix is_open call for many drivers (#25)
+Subject: [PATCH 013/180] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.

--- a/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From 9d45a0e68acbcaec82a36c74f91dfa176b4fc7bf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 014/177] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 014/180] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.

--- a/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
+++ b/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
@@ -1,7 +1,7 @@
 From ee2433b00bea733c8ec0d294ffb476e04e7e5bdb Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Fri, 4 Aug 2023 12:10:08 +0200
-Subject: [PATCH 015/177] Remove `SR_PROBE` from ZFS capabilities (#37)
+Subject: [PATCH 015/180] Remove `SR_PROBE` from ZFS capabilities (#37)
 
 The probe method is not implemented so we
 shouldn't advertise it.

--- a/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,7 +1,7 @@
 From a14e7dbb656f0c722e85cacf4ad658695e086502 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Wed, 16 Aug 2023 13:42:21 +0200
-Subject: [PATCH 016/177] Fix vdi-ref when static vdis are used
+Subject: [PATCH 016/180] Fix vdi-ref when static vdis are used
 
 When static vdis are used there is no snapshots and we don't want to
 call method from XAPI.

--- a/SOURCES/0017-Tell-users-not-to-edit-multipath.conf-directly.patch
+++ b/SOURCES/0017-Tell-users-not-to-edit-multipath.conf-directly.patch
@@ -1,7 +1,7 @@
 From 1cf0c93a4e8c1de3688115954a8d4a8d4c25830d Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 27 Jan 2023 12:03:15 +0100
-Subject: [PATCH 017/177] Tell users not to edit multipath.conf directly
+Subject: [PATCH 017/180] Tell users not to edit multipath.conf directly
 
 This file is meant to remain unchanged and regularly updated along with
 the SM component. Users can create a custom configuration file in

--- a/SOURCES/0018-Add-custom.conf-multipath-configuration-file.patch
+++ b/SOURCES/0018-Add-custom.conf-multipath-configuration-file.patch
@@ -1,7 +1,7 @@
 From c8e7d59b6c9b68f9e5ef89d0ad87c157bb35c736 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 27 Jan 2023 12:23:13 +0100
-Subject: [PATCH 018/177] Add custom.conf multipath configuration file
+Subject: [PATCH 018/180] Add custom.conf multipath configuration file
 
 Meant to be installed as /etc/multipath/conf.d/custom.conf for users
 to have an easy entry point for editing, as well as information on what

--- a/SOURCES/0019-Install-etc-multipath-conf.d-custom.conf.patch
+++ b/SOURCES/0019-Install-etc-multipath-conf.d-custom.conf.patch
@@ -1,7 +1,7 @@
 From 81b847dca6a48d73936592820a1a7b88ae1ff5cc Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 25 Aug 2023 17:47:34 +0200
-Subject: [PATCH 019/177] Install /etc/multipath/conf.d/custom.conf
+Subject: [PATCH 019/180] Install /etc/multipath/conf.d/custom.conf
 
 Update Makefile so that the file is installed along with sm.
 

--- a/SOURCES/0020-Backport-NFS4-only-support.patch
+++ b/SOURCES/0020-Backport-NFS4-only-support.patch
@@ -1,7 +1,7 @@
 From fe5a7b355ea6820036cfeef3847b2bec28567632 Mon Sep 17 00:00:00 2001
 From: Benjamin Reis <benjamin.reis@vates.tech>
 Date: Mon, 18 Dec 2023 10:22:26 +0100
-Subject: [PATCH 020/177] Backport NFS4 only support
+Subject: [PATCH 020/180] Backport NFS4 only support
 
 See: https://github.com/xapi-project/sm/pull/617
 

--- a/SOURCES/0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
+++ b/SOURCES/0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
@@ -1,7 +1,7 @@
 From eea13526d4e202e395d1a4289f837b0171a73b8e Mon Sep 17 00:00:00 2001
 From: Benjamin Reis <benjamin.reis@vates.tech>
 Date: Mon, 18 Dec 2023 10:35:46 +0100
-Subject: [PATCH 021/177] Backport probe for NFS4 when rpcinfo does not include
+Subject: [PATCH 021/180] Backport probe for NFS4 when rpcinfo does not include
  it
 
 See: https://github.com/xapi-project/sm/pull/655

--- a/SOURCES/0022-feat-LargeBlock-backport-of-largeblocksr-51-55.patch
+++ b/SOURCES/0022-feat-LargeBlock-backport-of-largeblocksr-51-55.patch
@@ -1,7 +1,7 @@
 From 05e5ce03d6fd4523a942345cf49cc41eebaa78f7 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Tue, 7 May 2024 15:20:22 +0200
-Subject: [PATCH 022/177] feat(LargeBlock): backport of largeblocksr (#51)
+Subject: [PATCH 022/180] feat(LargeBlock): backport of largeblocksr (#51)
  (#55)
 
 A SR inheriting from a EXTSR allowing to use a 4KiB blocksize device as

--- a/SOURCES/0023-feat-LVHDSR-add-a-way-to-modify-config-of-LVMs-56.patch
+++ b/SOURCES/0023-feat-LVHDSR-add-a-way-to-modify-config-of-LVMs-56.patch
@@ -1,7 +1,7 @@
 From bc8ee2e18aa6ba1a8923c09ff0d765f931ddc348 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 28 May 2024 15:17:21 +0200
-Subject: [PATCH 023/177] feat(LVHDSR): add a way to modify config of LVMs
+Subject: [PATCH 023/180] feat(LVHDSR): add a way to modify config of LVMs
  (#56)
 
 With this change the driver supports a "lvm-conf" param on "other-config".

--- a/SOURCES/0024-Fix-timeout_call-alarm-must-be-reset-in-case-of-succ.patch
+++ b/SOURCES/0024-Fix-timeout_call-alarm-must-be-reset-in-case-of-succ.patch
@@ -1,7 +1,7 @@
 From f76ccb66f769ca352bf1dea9abdaaea5ec1b7942 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Feb 2022 18:24:56 +0100
-Subject: [PATCH 024/177] Fix timeout_call: alarm must be reset in case of
+Subject: [PATCH 024/180] Fix timeout_call: alarm must be reset in case of
  success
 
 Otherwise the SIGALRM signal can be emitted after the execution

--- a/SOURCES/0025-timeout_call-returns-the-result-of-user-function-now.patch
+++ b/SOURCES/0025-timeout_call-returns-the-result-of-user-function-now.patch
@@ -1,7 +1,7 @@
 From 3db6e67815f3c85768cf253e3d78d01c416fc16f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Feb 2022 18:28:06 +0100
-Subject: [PATCH 025/177] timeout_call returns the result of user function now
+Subject: [PATCH 025/180] timeout_call returns the result of user function now
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0026-Always-remove-the-pause-tag-from-VDIs-in-case-of-fai.patch
+++ b/SOURCES/0026-Always-remove-the-pause-tag-from-VDIs-in-case-of-fai.patch
@@ -1,7 +1,7 @@
 From 7ebdef745b90fe8479555bc44d8d7ce594fc209f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Feb 2024 23:16:16 +0100
-Subject: [PATCH 026/177] Always remove the pause tag from VDIs in case of
+Subject: [PATCH 026/180] Always remove the pause tag from VDIs in case of
  failure
 
 During VDI activation in the blktap module and in case of failure

--- a/SOURCES/0027-fix-LinstorSR-repair-volumes-only-if-an-exclusive-co.patch
+++ b/SOURCES/0027-fix-LinstorSR-repair-volumes-only-if-an-exclusive-co.patch
@@ -1,7 +1,7 @@
 From e3f11afdfdc43aa871a7d4f8c6d25564150fd0e4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 20 Nov 2020 16:42:52 +0100
-Subject: [PATCH 027/177] fix(LinstorSR): repair volumes only if an exclusive
+Subject: [PATCH 027/180] fix(LinstorSR): repair volumes only if an exclusive
  command is executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0028-feat-LinstorSR-Improve-LINSTOR-performance.patch
+++ b/SOURCES/0028-feat-LinstorSR-Improve-LINSTOR-performance.patch
@@ -1,7 +1,7 @@
 From fa743060d859c6bcdff75293bfee749b3eaf734c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 10 Dec 2020 17:56:15 +0100
-Subject: [PATCH 028/177] feat(LinstorSR): Improve LINSTOR performance
+Subject: [PATCH 028/180] feat(LinstorSR): Improve LINSTOR performance
 
 Details:
 - vdi_attach and vdi_detach are now exclusive

--- a/SOURCES/0029-feat-LinstorSR-robustify-scan-to-avoid-losing-VDIs-i.patch
+++ b/SOURCES/0029-feat-LinstorSR-robustify-scan-to-avoid-losing-VDIs-i.patch
@@ -1,7 +1,7 @@
 From 045d23321e99b135556cb3d9872c1f3c8ae4b9af Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 7 Jan 2021 11:17:08 +0100
-Subject: [PATCH 029/177] feat(LinstorSR): robustify scan to avoid losing VDIs
+Subject: [PATCH 029/180] feat(LinstorSR): robustify scan to avoid losing VDIs
  if function is called outside module
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0030-feat-LinstorSR-display-a-correctly-readable-size-for.patch
+++ b/SOURCES/0030-feat-LinstorSR-display-a-correctly-readable-size-for.patch
@@ -1,7 +1,7 @@
 From 6594b0cfd56df7d8beed5442b7932e6d46623f5f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 8 Jan 2021 16:12:15 +0100
-Subject: [PATCH 030/177] feat(LinstorSR): display a correctly readable size
+Subject: [PATCH 030/180] feat(LinstorSR): display a correctly readable size
  for the user
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0031-feat-linstor-monitord-scan-all-LINSTOR-SRs-every-12-.patch
+++ b/SOURCES/0031-feat-linstor-monitord-scan-all-LINSTOR-SRs-every-12-.patch
@@ -1,7 +1,7 @@
 From bf497ab757571bdb722323cfb98aaa500ec68c44 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 12 Jan 2021 14:06:34 +0100
-Subject: [PATCH 031/177] feat(linstor-monitord): scan all LINSTOR SRs every 12
+Subject: [PATCH 031/180] feat(linstor-monitord): scan all LINSTOR SRs every 12
  minutes to update allocated size stats
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0032-fix-LinstorSR-call-correctly-method-in-_locked_load-.patch
+++ b/SOURCES/0032-fix-LinstorSR-call-correctly-method-in-_locked_load-.patch
@@ -1,7 +1,7 @@
 From 4d41a373da1b9e62d727553cc16f994362d7c5d2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 15 Jan 2021 17:01:05 +0100
-Subject: [PATCH 032/177] fix(LinstorSR): call correctly method in _locked_load
+Subject: [PATCH 032/180] fix(LinstorSR): call correctly method in _locked_load
  when vdi_attach_from_config is executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0033-feat-LinstorSR-integrate-minidrbdcluster-daemon.patch
+++ b/SOURCES/0033-feat-LinstorSR-integrate-minidrbdcluster-daemon.patch
@@ -1,7 +1,7 @@
 From 2390152b1ccf081874356ded5ee9ae5bad0f00b6 Mon Sep 17 00:00:00 2001
 From: Wescoeur <ronan.abhamon@vates.fr>
 Date: Wed, 20 Jan 2021 18:04:26 +0100
-Subject: [PATCH 033/177] feat(LinstorSR): integrate minidrbdcluster daemon
+Subject: [PATCH 033/180] feat(LinstorSR): integrate minidrbdcluster daemon
 
 Now, we can:
 - Start a controller on any node

--- a/SOURCES/0034-feat-LinstorSR-ensure-heartbeat-and-redo_log-VDIs-ar.patch
+++ b/SOURCES/0034-feat-LinstorSR-ensure-heartbeat-and-redo_log-VDIs-ar.patch
@@ -1,7 +1,7 @@
 From 392a7fc2cefde386c048c2daf1250d3b6fc70584 Mon Sep 17 00:00:00 2001
 From: Wescoeur <ronan.abhamon@vates.fr>
 Date: Wed, 24 Feb 2021 11:17:23 +0100
-Subject: [PATCH 034/177] feat(LinstorSR): ensure heartbeat and redo_log VDIs
+Subject: [PATCH 034/180] feat(LinstorSR): ensure heartbeat and redo_log VDIs
  are not diskless
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0035-feat-LinstorSR-protect-sr-commands-to-avoid-forgetti.patch
+++ b/SOURCES/0035-feat-LinstorSR-protect-sr-commands-to-avoid-forgetti.patch
@@ -1,7 +1,7 @@
 From ad4076e7333d047a54a0fb6055d9b00d9030ae28 Mon Sep 17 00:00:00 2001
 From: Wescoeur <ronan.abhamon@vates.fr>
 Date: Thu, 25 Feb 2021 17:52:57 +0100
-Subject: [PATCH 035/177] feat(LinstorSR): protect sr commands to avoid
+Subject: [PATCH 035/180] feat(LinstorSR): protect sr commands to avoid
  forgetting LINSTOR volumes when master satellite is down
 
 Steps to reproduce:

--- a/SOURCES/0036-fix-LinstorJournaler-ensure-uri-is-not-None-during-l.patch
+++ b/SOURCES/0036-fix-LinstorJournaler-ensure-uri-is-not-None-during-l.patch
@@ -1,7 +1,7 @@
 From dba2e9c951a47c4193a779a934c5a2d415675b10 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 8 Mar 2021 13:25:28 +0100
-Subject: [PATCH 036/177] fix(LinstorJournaler): ensure uri is not None during
+Subject: [PATCH 036/180] fix(LinstorJournaler): ensure uri is not None during
  linstor.KV creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0037-feat-LinstorSR-add-an-option-to-disable-auto-quorum-.patch
+++ b/SOURCES/0037-feat-LinstorSR-add-an-option-to-disable-auto-quorum-.patch
@@ -1,7 +1,7 @@
 From 70bb114f08a6957946ab653bef674d5cbe870998 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 22 Mar 2021 17:32:26 +0100
-Subject: [PATCH 037/177] feat(LinstorSR): add an option to disable auto-quorum
+Subject: [PATCH 037/180] feat(LinstorSR): add an option to disable auto-quorum
  on volume DB + fix doc
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0038-fix-LinstorVolumeManager-add-a-workaround-to-create-.patch
+++ b/SOURCES/0038-fix-LinstorVolumeManager-add-a-workaround-to-create-.patch
@@ -1,7 +1,7 @@
 From 5144ab80e4ec0af9e7c23c9ef508390b4900d1fd Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 23 Mar 2021 14:49:39 +0100
-Subject: [PATCH 038/177] fix(LinstorVolumeManager): add a workaround to create
+Subject: [PATCH 038/180] fix(LinstorVolumeManager): add a workaround to create
  properly SR with thin LVM
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0039-feat-LinstorSR-add-optional-ips-parameter.patch
+++ b/SOURCES/0039-feat-LinstorSR-add-optional-ips-parameter.patch
@@ -1,7 +1,7 @@
 From c888113ede59c03474468767d28df14cb0e0bf73 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 24 Mar 2021 10:06:58 +0100
-Subject: [PATCH 039/177] feat(LinstorSR): add optional ips parameter
+Subject: [PATCH 039/180] feat(LinstorSR): add optional ips parameter
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0040-feat-LinstorSR-add-a-helper-log_drbd_erofs-to-trace-.patch
+++ b/SOURCES/0040-feat-LinstorSR-add-a-helper-log_drbd_erofs-to-trace-.patch
@@ -1,7 +1,7 @@
 From f6ed0e05e330f28d09819bf8085d171dfee84d71 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 26 Mar 2021 16:13:20 +0100
-Subject: [PATCH 040/177] feat(LinstorSR): add a helper `log_drbd_erofs` to
+Subject: [PATCH 040/180] feat(LinstorSR): add a helper `log_drbd_erofs` to
  trace EROFS errno code with DRBD resources + check EROFS error
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0041-fix-LinstorSR-try-to-restart-the-services-again-if-t.patch
+++ b/SOURCES/0041-fix-LinstorSR-try-to-restart-the-services-again-if-t.patch
@@ -1,7 +1,7 @@
 From 910405472a57989f5f3b9d6015e0c11970123b44 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 28 Apr 2021 15:15:58 +0200
-Subject: [PATCH 041/177] fix(LinstorSR): try to restart the services again if
+Subject: [PATCH 041/180] fix(LinstorSR): try to restart the services again if
  there is a failure in linstor-manager
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0042-fix-LinstorSR-robustify-linstor-manager-to-never-inc.patch
+++ b/SOURCES/0042-fix-LinstorSR-robustify-linstor-manager-to-never-inc.patch
@@ -1,7 +1,7 @@
 From 262c9328fe625aa44416b2795047584de7611f18 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 26 Aug 2021 15:26:11 +0200
-Subject: [PATCH 042/177] fix(LinstorSR): robustify linstor-manager to never
+Subject: [PATCH 042/180] fix(LinstorSR): robustify linstor-manager to never
  include from plugins path
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0043-fix-LinstorSR-prevent-starting-controller-during-fai.patch
+++ b/SOURCES/0043-fix-LinstorSR-prevent-starting-controller-during-fai.patch
@@ -1,7 +1,7 @@
 From 855fb10643225cae3ec8e6b89c20972eefaee607 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 26 Aug 2021 16:52:01 +0200
-Subject: [PATCH 043/177] fix(LinstorSR): prevent starting controller during
+Subject: [PATCH 043/180] fix(LinstorSR): prevent starting controller during
  fail in linstor manager destroy method
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0044-feat-LinstorVolumeManager-increase-peer-slots-limit-.patch
+++ b/SOURCES/0044-feat-LinstorVolumeManager-increase-peer-slots-limit-.patch
@@ -1,7 +1,7 @@
 From 02c4a4a0a092f9ae8d387a4773fbf0fc5b09cb11 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 19 Oct 2021 14:48:17 +0200
-Subject: [PATCH 044/177] feat(LinstorVolumeManager): increase peer slots limit
+Subject: [PATCH 044/180] feat(LinstorVolumeManager): increase peer slots limit
  (support 31 connections to a DRBD)
 
 - Also, create diskless devices when db is created

--- a/SOURCES/0045-feat-LinstorVolumeManager-add-a-fallback-to-find-con.patch
+++ b/SOURCES/0045-feat-LinstorVolumeManager-add-a-fallback-to-find-con.patch
@@ -1,7 +1,7 @@
 From 8ae786437072d4328825c97b0786d7caa1f4ca35 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 20 Oct 2021 14:33:04 +0200
-Subject: [PATCH 045/177] feat(LinstorVolumeManager): add a fallback to find
+Subject: [PATCH 045/180] feat(LinstorVolumeManager): add a fallback to find
  controller uri (when len(hosts) >= 4)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0046-fix-var-lib-linstor.mount-ensure-we-always-mount-dat.patch
+++ b/SOURCES/0046-fix-var-lib-linstor.mount-ensure-we-always-mount-dat.patch
@@ -1,7 +1,7 @@
 From 7731198de9a684e000a7c70b19dca1cdd330e9c5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 21 Oct 2021 11:13:07 +0200
-Subject: [PATCH 046/177] fix(var-lib-linstor.mount): ensure we always mount
+Subject: [PATCH 046/180] fix(var-lib-linstor.mount): ensure we always mount
  database with RW flags
 
 Sometimes systemd fallback to read only FS if the volume can't be mounted, we must

--- a/SOURCES/0047-feat-LinstorVolumeManager-add-a-fallback-to-find-nod.patch
+++ b/SOURCES/0047-feat-LinstorVolumeManager-add-a-fallback-to-find-nod.patch
@@ -1,7 +1,7 @@
 From 5273224cab21953acab55e07d2fa6941bfa19bba Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 21 Oct 2021 11:51:32 +0200
-Subject: [PATCH 047/177] feat(LinstorVolumeManager): add a fallback to find
+Subject: [PATCH 047/180] feat(LinstorVolumeManager): add a fallback to find
  node name (when len(hosts) >= 4)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0048-feat-LinstorSR-explain-on-which-host-plugins-command.patch
+++ b/SOURCES/0048-feat-LinstorSR-explain-on-which-host-plugins-command.patch
@@ -1,7 +1,7 @@
 From c6328ccfe37e9ad5318dc6a7149ece8705f4a8b5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 26 Oct 2021 10:44:00 +0200
-Subject: [PATCH 048/177] feat(LinstorSR): explain on which host, plugins
+Subject: [PATCH 048/180] feat(LinstorSR): explain on which host, plugins
  commands are executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0049-fix-LinstorSR-create-diskless-path-if-necessary-duri.patch
+++ b/SOURCES/0049-fix-LinstorSR-create-diskless-path-if-necessary-duri.patch
@@ -1,7 +1,7 @@
 From 0125298399ffa92e214ed3b059d3f7cb5443e08b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 3 Nov 2021 14:59:31 +0100
-Subject: [PATCH 049/177] fix(LinstorSR): create diskless path if necessary
+Subject: [PATCH 049/180] fix(LinstorSR): create diskless path if necessary
  during VDI loading
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0050-feat-LinstorSR-use-HTTP-NBD-instead-of-DRBD-directly.patch
+++ b/SOURCES/0050-feat-LinstorSR-use-HTTP-NBD-instead-of-DRBD-directly.patch
@@ -1,7 +1,7 @@
 From 7983be637bf274036cd89552891cc406bf20ea0a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 12 May 2022 17:52:35 +0200
-Subject: [PATCH 050/177] feat(LinstorSR): use HTTP/NBD instead of DRBD
+Subject: [PATCH 050/180] feat(LinstorSR): use HTTP/NBD instead of DRBD
  directly with heartbeat VDI
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0051-fix-LinstorSR-find-controller-when-XAPI-unreachable-.patch
+++ b/SOURCES/0051-fix-LinstorSR-find-controller-when-XAPI-unreachable-.patch
@@ -1,7 +1,7 @@
 From 44393c71d8419d61c746fc2699c450bd08183b3b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 3 Mar 2022 15:02:17 +0100
-Subject: [PATCH 051/177] fix(LinstorSR): find controller when XAPI unreachable
+Subject: [PATCH 051/180] fix(LinstorSR): find controller when XAPI unreachable
  (XHA)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0052-fix-LinstorSR-use-IPs-instead-of-hostnames-in-NBD-se.patch
+++ b/SOURCES/0052-fix-LinstorSR-use-IPs-instead-of-hostnames-in-NBD-se.patch
@@ -1,7 +1,7 @@
 From 58bf1f4dbf2f7860d18a55ff313363c6fa3f1305 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 24 Mar 2022 18:13:46 +0100
-Subject: [PATCH 052/177] fix(LinstorSR): use IPs instead of hostnames in NBD
+Subject: [PATCH 052/180] fix(LinstorSR): use IPs instead of hostnames in NBD
  server
 
 Without this patch we can't use XCP-ng hosts configured with static IPS.

--- a/SOURCES/0053-fix-LinstorVolumeManager-ensure-we-always-use-IPs-in.patch
+++ b/SOURCES/0053-fix-LinstorVolumeManager-ensure-we-always-use-IPs-in.patch
@@ -1,7 +1,7 @@
 From 972954832674cdd9c4792868a2fe4771a5c7eda0 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 31 Mar 2022 11:21:19 +0200
-Subject: [PATCH 053/177] fix(LinstorVolumeManager): ensure we always use IPs
+Subject: [PATCH 053/180] fix(LinstorVolumeManager): ensure we always use IPs
  in _get_controller_uri
 
 Otherwise if a hostname is returned, we can't use it if the XCP-ng pool

--- a/SOURCES/0054-feat-linstor-manager-add-methods-to-add-remove-host-.patch
+++ b/SOURCES/0054-feat-linstor-manager-add-methods-to-add-remove-host-.patch
@@ -1,7 +1,7 @@
 From df1b37be2e1b33838aa843f922de1de6cec3a793 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 6 Apr 2022 17:53:02 +0200
-Subject: [PATCH 054/177] feat(linstor-manager): add methods to add remove/host
+Subject: [PATCH 054/180] feat(linstor-manager): add methods to add remove/host
  from LINSTOR SR
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0055-feat-LinstorVolumeManager-support-SR-creation-with-d.patch
+++ b/SOURCES/0055-feat-LinstorVolumeManager-support-SR-creation-with-d.patch
@@ -1,7 +1,7 @@
 From 1cacb61d45a0e8de6d99788a86eeffb7028edd85 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 13 Apr 2022 15:56:42 +0200
-Subject: [PATCH 055/177] feat(LinstorVolumeManager): support SR creation with
+Subject: [PATCH 055/180] feat(LinstorVolumeManager): support SR creation with
  diskless nodes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0056-feat-LinstorSR-add-a-config-var-to-disable-HTTP-NBD-.patch
+++ b/SOURCES/0056-feat-LinstorSR-add-a-config-var-to-disable-HTTP-NBD-.patch
@@ -1,7 +1,7 @@
 From 2e4d783b1d7cd7dd9a7ac40504ac6ec71dcde60c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 14 Apr 2022 10:30:23 +0200
-Subject: [PATCH 056/177] feat(LinstorSR): add a config var to disable HTTP/NBD
+Subject: [PATCH 056/180] feat(LinstorSR): add a config var to disable HTTP/NBD
  servers
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0057-feat-LinstorSr-ensure-LVM-group-is-activated-during-.patch
+++ b/SOURCES/0057-feat-LinstorSr-ensure-LVM-group-is-activated-during-.patch
@@ -1,7 +1,7 @@
 From c241c1495897b952e6ea11fd062cac28109394aa Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 14 Apr 2022 15:45:20 +0200
-Subject: [PATCH 057/177] feat(LinstorSr): ensure LVM group is activated during
+Subject: [PATCH 057/180] feat(LinstorSr): ensure LVM group is activated during
  SR.attach/create
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0058-feat-linstor-manager-add-method-to-create-LinstorSR-.patch
+++ b/SOURCES/0058-feat-linstor-manager-add-method-to-create-LinstorSR-.patch
@@ -1,7 +1,7 @@
 From cac2dda720b05ba479b272c9c65b5f14af180956 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 25 Apr 2022 14:47:51 +0200
-Subject: [PATCH 058/177] feat(linstor-manager): add method to create LinstorSR
+Subject: [PATCH 058/180] feat(linstor-manager): add method to create LinstorSR
  + to list/destroy DRBD volumes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0059-fix-LinstorSR-always-set-vdi_path-in-generate_config.patch
+++ b/SOURCES/0059-fix-LinstorSR-always-set-vdi_path-in-generate_config.patch
@@ -1,7 +1,7 @@
 From f990493afc8187a52faab4913a6b353f70ab1583 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 26 Apr 2022 11:20:08 +0200
-Subject: [PATCH 059/177] fix(LinstorSR): always set vdi_path in
+Subject: [PATCH 059/180] fix(LinstorSR): always set vdi_path in
  generate_config
 
 If the volume of a generated config is not related to HTTP/NBD

--- a/SOURCES/0060-fix-minidrbdcluster-supports-new-properties-like-for.patch
+++ b/SOURCES/0060-fix-minidrbdcluster-supports-new-properties-like-for.patch
@@ -1,7 +1,7 @@
 From ed527602dea427ea63080a07395aaf7d99572953 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 13 May 2022 14:35:57 +0200
-Subject: [PATCH 060/177] fix(minidrbdcluster): supports new properties like
+Subject: [PATCH 060/180] fix(minidrbdcluster): supports new properties like
  `force-io-failures`
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0061-fix-LinstorSR-enabled-disable-minidrbcluster-with-fi.patch
+++ b/SOURCES/0061-fix-LinstorSR-enabled-disable-minidrbcluster-with-fi.patch
@@ -1,7 +1,7 @@
 From 4a1220b9552323f2e79f9512ed030ae45ab4c800 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:33 +0200
-Subject: [PATCH 061/177] fix(LinstorSR): enabled/disable minidrbcluster with
+Subject: [PATCH 061/180] fix(LinstorSR): enabled/disable minidrbcluster with
  fixed order
 
 Ensure we disable minidrbdcluster during SR destruction on all hosts

--- a/SOURCES/0062-fix-linstor-manager-change-linstor-satellite-start-b.patch
+++ b/SOURCES/0062-fix-linstor-manager-change-linstor-satellite-start-b.patch
@@ -1,7 +1,7 @@
 From 77eddf395a3248f479ece8223c11da473ba7992b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 31 May 2022 14:01:45 +0200
-Subject: [PATCH 062/177] fix(linstor-manager): change linstor satellite start
+Subject: [PATCH 062/180] fix(linstor-manager): change linstor satellite start
  behavior
 
 Ensure we don't have an invalid cache used by a satellite:

--- a/SOURCES/0063-Fix-is_open-call-for-LinstorSR.patch
+++ b/SOURCES/0063-Fix-is_open-call-for-LinstorSR.patch
@@ -1,7 +1,7 @@
 From 4ee79f2016b9816380baaba51b75c4b35830ab5f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Jun 2022 09:04:28 +0200
-Subject: [PATCH 063/177] Fix is_open call for LinstorSR
+Subject: [PATCH 063/180] Fix is_open call for LinstorSR
 
 1. Ensure LinstorSR driver is imported in `_is_open` definition to register it in the driver list.
 Otherwise this function always fails with a SRUnknownType exception.

--- a/SOURCES/0064-fix-linstorvhdutil-fix-boolean-params-of-check-call.patch
+++ b/SOURCES/0064-fix-linstorvhdutil-fix-boolean-params-of-check-call.patch
@@ -1,7 +1,7 @@
 From 1c0757759ea80cbf9ff35cc487a0b7d3cc2bfeb6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Jun 2022 09:28:32 +0200
-Subject: [PATCH 064/177] fix(linstorvhdutil): fix boolean params of `check`
+Subject: [PATCH 064/180] fix(linstorvhdutil): fix boolean params of `check`
  call
 
 `ignoreMissingFooter` and `fast` must be string types to be used with XAPI plugin API.

--- a/SOURCES/0065-feat-linstor-manager-robustify-exec_create_sr.patch
+++ b/SOURCES/0065-feat-linstor-manager-robustify-exec_create_sr.patch
@@ -1,7 +1,7 @@
 From 2f674984e2454621bd71eb4c3a0573f40704bb45 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 30 Jun 2022 17:09:51 +0200
-Subject: [PATCH 065/177] feat(linstor-manager): robustify exec_create_sr
+Subject: [PATCH 065/180] feat(linstor-manager): robustify exec_create_sr
 
 - Use lvm.py XCP-ng xapi plugins instead of lvm (old name)
 - Check arguments to create the SR

--- a/SOURCES/0066-fix-cleanup-print-LINSTOR-VDI-UUID-if-error-during-i.patch
+++ b/SOURCES/0066-fix-cleanup-print-LINSTOR-VDI-UUID-if-error-during-i.patch
@@ -1,7 +1,7 @@
 From 21f073b1a262414c1910773a02ca54cd6f92c57e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 8 Jul 2022 14:52:25 +0200
-Subject: [PATCH 066/177] fix(cleanup): print LINSTOR VDI UUID if error during
+Subject: [PATCH 066/180] fix(cleanup): print LINSTOR VDI UUID if error during
  info loading (not SR UUID)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0067-feat-cleanup-raise-and-dump-DRBD-openers-in-case-of-.patch
+++ b/SOURCES/0067-feat-cleanup-raise-and-dump-DRBD-openers-in-case-of-.patch
@@ -1,7 +1,7 @@
 From 7b48c2a2c1635be52db7ab1625bc5d6d3b6c635e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 21 Jul 2022 11:39:20 +0200
-Subject: [PATCH 067/177] feat(cleanup): raise and dump DRBD openers in case of
+Subject: [PATCH 067/180] feat(cleanup): raise and dump DRBD openers in case of
  bad coalesce
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0068-feat-linstorvhdutil-trace-DRBD-openers-in-case-of-ER.patch
+++ b/SOURCES/0068-feat-linstorvhdutil-trace-DRBD-openers-in-case-of-ER.patch
@@ -1,7 +1,7 @@
 From 17e39c0d21e3e0385d51d27c3192f8a28022bb3c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 22 Jul 2022 10:26:20 +0200
-Subject: [PATCH 068/177] feat(linstorvhdutil): trace DRBD openers in case of
+Subject: [PATCH 068/180] feat(linstorvhdutil): trace DRBD openers in case of
  EROFS errors
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0069-fix-linstorvolumemanager-compute-correctly-size-in-a.patch
+++ b/SOURCES/0069-fix-linstorvolumemanager-compute-correctly-size-in-a.patch
@@ -1,7 +1,7 @@
 From 28090053e877e2bfb9bedf42af9a65a70b355ff5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 29 Jul 2022 17:25:48 +0200
-Subject: [PATCH 069/177] fix(linstorvolumemanager): compute correctly size in
+Subject: [PATCH 069/180] fix(linstorvolumemanager): compute correctly size in
  allocated_volume_size
 
 Remove replication count in computation.

--- a/SOURCES/0070-feat-LinstorSR-use-DRBD-openers-instead-of-lsof-to-l.patch
+++ b/SOURCES/0070-feat-LinstorSR-use-DRBD-openers-instead-of-lsof-to-l.patch
@@ -1,7 +1,7 @@
 From 97e4f95765285fcd3a860d66a8f02f170a4e8e73 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 9 Aug 2022 11:07:57 +0200
-Subject: [PATCH 070/177] feat(LinstorSR): use DRBD openers instead of lsof to
+Subject: [PATCH 070/180] feat(LinstorSR): use DRBD openers instead of lsof to
  log in blktap2
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0071-feat-LinstorSR-support-cProfile-to-trace-calls-when-.patch
+++ b/SOURCES/0071-feat-LinstorSR-support-cProfile-to-trace-calls-when-.patch
@@ -1,7 +1,7 @@
 From 7af2ef8980077fc54ee58661502c9b49f7b973c9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 25 Aug 2022 12:11:18 +0200
-Subject: [PATCH 071/177] feat(LinstorSR): support cProfile to trace calls when
+Subject: [PATCH 071/180] feat(LinstorSR): support cProfile to trace calls when
  a command is executed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0072-fix-LinstorJournaler-reset-namespace-when-get-is-cal.patch
+++ b/SOURCES/0072-fix-LinstorJournaler-reset-namespace-when-get-is-cal.patch
@@ -1,7 +1,7 @@
 From ff1e4c6c25e4d804f7b4635dbf8cd4d696beef0a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 24 Aug 2022 17:09:11 +0200
-Subject: [PATCH 072/177] fix(LinstorJournaler): reset namespace when `get` is
+Subject: [PATCH 072/180] fix(LinstorJournaler): reset namespace when `get` is
  called
 
 Otherwise, we can be in the wrong namespace and the key to find will be inaccessible.

--- a/SOURCES/0073-fix-linstorvhdutil-fix-coalesce-with-VM-running-unde.patch
+++ b/SOURCES/0073-fix-linstorvhdutil-fix-coalesce-with-VM-running-unde.patch
@@ -1,7 +1,7 @@
 From 3bda00e34c79c8448b61d3f02c09ae7d910eb9ce Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 25 Aug 2022 10:54:56 +0200
-Subject: [PATCH 073/177] fix(linstorvhdutil): fix coalesce with VM running
+Subject: [PATCH 073/180] fix(linstorvhdutil): fix coalesce with VM running
  under specific scenario:
 
 When a VM is running, we can't coalesce without this patch with a long chain

--- a/SOURCES/0074-fix-linstorvolumemanager-_get_volumes_info-doesn-t-r.patch
+++ b/SOURCES/0074-fix-linstorvolumemanager-_get_volumes_info-doesn-t-r.patch
@@ -1,7 +1,7 @@
 From 94ede43831ca0996b88a27626a9559d3f6b1f403 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Sep 2022 15:09:17 +0200
-Subject: [PATCH 074/177] fix(linstorvolumemanager): `_get_volumes_info`
+Subject: [PATCH 074/180] fix(linstorvolumemanager): `_get_volumes_info`
  doesn't raise with offline host
 
 Ensure this method doesn't raise an exception when a host is offline.

--- a/SOURCES/0075-fix-linstorvolumemanager-remove-double-prefix-on-kv-.patch
+++ b/SOURCES/0075-fix-linstorvolumemanager-remove-double-prefix-on-kv-.patch
@@ -1,7 +1,7 @@
 From 5d26e090abc329bd612d52e2c82fd4607c01ef17 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 12 Sep 2022 15:56:09 +0200
-Subject: [PATCH 075/177] fix(linstorvolumemanager): remove double prefix on kv
+Subject: [PATCH 075/180] fix(linstorvolumemanager): remove double prefix on kv
  group name
 
 - Before this patch, when the kv store was created/accessed, a double "xcp-sr-" prefix was used.

--- a/SOURCES/0076-feat-LinstorSR-add-linstor-kv-dump-helper-to-print-k.patch
+++ b/SOURCES/0076-feat-LinstorSR-add-linstor-kv-dump-helper-to-print-k.patch
@@ -1,7 +1,7 @@
 From cbe616a7450f988cc267eb02b73de8e03f546fd6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 12 Sep 2022 17:54:57 +0200
-Subject: [PATCH 076/177] feat(LinstorSR): add linstor-kv-dump helper to print
+Subject: [PATCH 076/180] feat(LinstorSR): add linstor-kv-dump helper to print
  kv store
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0077-fix-LinstorSR-disable-VHD-key-hash-usage-to-limit-ex.patch
+++ b/SOURCES/0077-fix-LinstorSR-disable-VHD-key-hash-usage-to-limit-ex.patch
@@ -1,7 +1,7 @@
 From 5232782abcfd52a3ff75a8f83906af61c5a0a77d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 14 Sep 2022 10:17:18 +0200
-Subject: [PATCH 077/177] fix(LinstorSR): disable VHD key hash usage to limit
+Subject: [PATCH 077/180] fix(LinstorSR): disable VHD key hash usage to limit
  exec time
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0078-fix-minidrbdcluster-ensure-SIGINT-is-handled-correct.patch
+++ b/SOURCES/0078-fix-minidrbdcluster-ensure-SIGINT-is-handled-correct.patch
@@ -1,7 +1,7 @@
 From 9c9b5a3ea111d22c550e6f983ca7539b14908737 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 15 Sep 2022 11:34:25 +0200
-Subject: [PATCH 078/177] fix(minidrbdcluster): ensure SIGINT is handled
+Subject: [PATCH 078/180] fix(minidrbdcluster): ensure SIGINT is handled
  correctly
 
 This patch is here to make sure no LINSTOR controller survives when

--- a/SOURCES/0079-feat-minidrbdcluster-stop-resource-services-at-start.patch
+++ b/SOURCES/0079-feat-minidrbdcluster-stop-resource-services-at-start.patch
@@ -1,7 +1,7 @@
 From 5f8a99eff7f2f137b7afac5738d45c1c56a8846b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 15 Sep 2022 11:49:34 +0200
-Subject: [PATCH 079/177] feat(minidrbdcluster): stop resource services at
+Subject: [PATCH 079/180] feat(minidrbdcluster): stop resource services at
  startup
 
 - Ensure all services are stopped when minidrbcluster is started.

--- a/SOURCES/0080-feat-linstor-manager-add-new-healthCheck-function-to.patch
+++ b/SOURCES/0080-feat-linstor-manager-add-new-healthCheck-function-to.patch
@@ -1,7 +1,7 @@
 From 488877ba4b8602148c23e3238a7530e67ad5ea8f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 23 Sep 2022 17:45:08 +0200
-Subject: [PATCH 080/177] feat(linstor-manager): add new `healthCheck` function
+Subject: [PATCH 080/180] feat(linstor-manager): add new `healthCheck` function
  to monitor pool (#26)
 
 Print a JSON output to monitor state of LINSTOR SRs:

--- a/SOURCES/0081-fix-LinstorSR-fix-xha-conf-parsing-return-host-ip-no.patch
+++ b/SOURCES/0081-fix-LinstorSR-fix-xha-conf-parsing-return-host-ip-no.patch
@@ -1,7 +1,7 @@
 From a5be376a1404d031c41abd728e758f8d296a09db Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 4 Oct 2022 11:01:33 +0200
-Subject: [PATCH 081/177] fix(LinstorSR): fix xha conf parsing => return host
+Subject: [PATCH 081/180] fix(LinstorSR): fix xha conf parsing => return host
  ip, not the UUID
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0082-fix-LinstorSR-start-correctly-HA-servers-HTTP-NBD-af.patch
+++ b/SOURCES/0082-fix-LinstorSR-start-correctly-HA-servers-HTTP-NBD-af.patch
@@ -1,7 +1,7 @@
 From 65d5ff02da3d1c084573924a82735da84f1ec5c4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 4 Oct 2022 18:48:09 +0200
-Subject: [PATCH 082/177] fix(LinstorSR): start correctly HA servers (HTTP/NBD)
+Subject: [PATCH 082/180] fix(LinstorSR): start correctly HA servers (HTTP/NBD)
  after reboot
 
 Use a timeout call after a reboot to get a XAPI session because

--- a/SOURCES/0083-fix-linstorvolumemanager-use-an-array-to-store-diskf.patch
+++ b/SOURCES/0083-fix-linstorvolumemanager-use-an-array-to-store-diskf.patch
@@ -1,7 +1,7 @@
 From 90cd3fd85ce5c73b4727a579acda75721252963a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 5 Oct 2022 10:45:50 +0200
-Subject: [PATCH 083/177] fix(linstorvolumemanager): use an array to store
+Subject: [PATCH 083/180] fix(linstorvolumemanager): use an array to store
  diskful volumes info
 
 Otherwise the `is_diskful` attr only reflects the info of one host

--- a/SOURCES/0084-feat-linstorvolumemanager-support-snaps-when-a-host-.patch
+++ b/SOURCES/0084-feat-linstorvolumemanager-support-snaps-when-a-host-.patch
@@ -1,7 +1,7 @@
 From 8e4f41d2b6caa3830f1073e3ab463657e9bb0d67 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 6 Oct 2022 17:54:10 +0200
-Subject: [PATCH 084/177] feat(linstorvolumemanager): support snaps when a host
+Subject: [PATCH 084/180] feat(linstorvolumemanager): support snaps when a host
  is offline
 
 - Don't create diskless volumes during clone, delay it.

--- a/SOURCES/0085-fix-linstorvolumemanager-support-offline-hosts-when-.patch
+++ b/SOURCES/0085-fix-linstorvolumemanager-support-offline-hosts-when-.patch
@@ -1,7 +1,7 @@
 From 53755a3d8e40a2493bc006139e9631ed7c3ae531 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 7 Oct 2022 17:18:37 +0200
-Subject: [PATCH 085/177] fix(linstorvolumemanager): support offline hosts when
+Subject: [PATCH 085/180] fix(linstorvolumemanager): support offline hosts when
  plugins are called
 
 - Robustify plugin calls

--- a/SOURCES/0086-fix-linstorvolumemanager-define-_base_group_name-mem.patch
+++ b/SOURCES/0086-fix-linstorvolumemanager-define-_base_group_name-mem.patch
@@ -1,7 +1,7 @@
 From 61f2aa4e8c0ee7ed0a7bb514a8c5d6e7d8b1e789 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 7 Oct 2022 17:45:26 +0200
-Subject: [PATCH 086/177] fix(linstorvolumemanager): define _base_group_name
+Subject: [PATCH 086/180] fix(linstorvolumemanager): define _base_group_name
  member at SR creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0087-feat-linstorvhdutil-modify-logic-of-local-vhdutil-ca.patch
+++ b/SOURCES/0087-feat-linstorvhdutil-modify-logic-of-local-vhdutil-ca.patch
@@ -1,7 +1,7 @@
 From f42a4f663b05544178d929d46740a16abc5d6ca9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 10 Oct 2022 14:33:24 +0200
-Subject: [PATCH 087/177] feat(linstorvhdutil): modify logic of local vhdutil
+Subject: [PATCH 087/180] feat(linstorvhdutil): modify logic of local vhdutil
  calls
 
 - Always log openers when we can't call vhdutil locally

--- a/SOURCES/0088-fix-linstorvolumemanager-robustify-failed-snapshots.patch
+++ b/SOURCES/0088-fix-linstorvolumemanager-robustify-failed-snapshots.patch
@@ -1,7 +1,7 @@
 From f5a1ae173fe0af8c91f125796f1785b6971d1405 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 17 Oct 2022 18:14:16 +0200
-Subject: [PATCH 088/177] fix(linstorvolumemanager): robustify failed snapshots
+Subject: [PATCH 088/180] fix(linstorvolumemanager): robustify failed snapshots
 
 - Ensure we can always rename a failed snap, so we must check if
   we have metadata in the KV-store. Otherwise an error is triggered

--- a/SOURCES/0089-fix-linstorvolumemanager-use-a-namespace-for-volumes.patch
+++ b/SOURCES/0089-fix-linstorvolumemanager-use-a-namespace-for-volumes.patch
@@ -1,7 +1,7 @@
 From f7cf38ee5935f024250d13a40be3f2b81eaf6a7e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 8 Nov 2022 17:31:45 +0100
-Subject: [PATCH 089/177] fix(linstorvolumemanager): use a namespace for
+Subject: [PATCH 089/180] fix(linstorvolumemanager): use a namespace for
  volumes
 
 - This change is not compatible with existing LINSTOR SR instances!

--- a/SOURCES/0090-feat-linstor-kv-dump-rename-to-linstor-kv-tool-add-r.patch
+++ b/SOURCES/0090-feat-linstor-kv-dump-rename-to-linstor-kv-tool-add-r.patch
@@ -1,7 +1,7 @@
 From ef7f0c07eab1c25393611a57162e1290c6b54308 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 14 Nov 2022 17:18:48 +0100
-Subject: [PATCH 090/177] feat(linstor-kv-dump): rename to linstor-kv-tool +
+Subject: [PATCH 090/180] feat(linstor-kv-dump): rename to linstor-kv-tool +
  add remove volume helpers
 
 ---

--- a/SOURCES/0091-fix-LinstorSR-handle-correctly-localhost-during-star.patch
+++ b/SOURCES/0091-fix-LinstorSR-handle-correctly-localhost-during-star.patch
@@ -1,7 +1,7 @@
 From 196dce016c304f57e9e60a60397fc58c992d459f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Nov 2022 12:12:12 +0100
-Subject: [PATCH 091/177] fix(LinstorSR): handle correctly localhost during
+Subject: [PATCH 091/180] fix(LinstorSR): handle correctly localhost during
  start/stop of minidrbdcluster
 
 Otherwise another controller can be started during `xe sr-destroy` call.

--- a/SOURCES/0092-fix-cleanup.py-call-repair-on-another-host-when-EROF.patch
+++ b/SOURCES/0092-fix-cleanup.py-call-repair-on-another-host-when-EROF.patch
@@ -1,7 +1,7 @@
 From 628668575b779ebb479e4621170b78ae2636b928 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 17 Nov 2022 15:43:25 +0100
-Subject: [PATCH 092/177] fix(cleanup.py): call repair on another host when
+Subject: [PATCH 092/180] fix(cleanup.py): call repair on another host when
  EROFS is returned (DRBD)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0093-fix-LinstorSR-avoid-introduction-of-DELETED-volumes.patch
+++ b/SOURCES/0093-fix-LinstorSR-avoid-introduction-of-DELETED-volumes.patch
@@ -1,7 +1,7 @@
 From a7b89628ae53027de00b1cfe03d6bedc38e02f4a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 17 Nov 2022 15:46:02 +0100
-Subject: [PATCH 093/177] fix(LinstorSR): avoid introduction of DELETED volumes
+Subject: [PATCH 093/180] fix(LinstorSR): avoid introduction of DELETED volumes
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0094-feat-linstor-kv-tool-remove-all-volumes-supports-jou.patch
+++ b/SOURCES/0094-feat-linstor-kv-tool-remove-all-volumes-supports-jou.patch
@@ -1,7 +1,7 @@
 From e609d0fca2a6dd7efbadf3d97ff9b0f85549a216 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 18 Nov 2022 10:40:58 +0100
-Subject: [PATCH 094/177] feat(linstor-kv-tool): remove-all-volumes supports
+Subject: [PATCH 094/180] feat(linstor-kv-tool): remove-all-volumes supports
  journals now
 
 Not yet supported for remove-volume, not sure about the consequences

--- a/SOURCES/0095-fix-linstorvhdutil-due-to-bad-refactoring-check-call.patch
+++ b/SOURCES/0095-fix-linstorvhdutil-due-to-bad-refactoring-check-call.patch
@@ -1,7 +1,7 @@
 From fb05d2668ccc6f24109d5c30611fbfc167e34340 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 23 Nov 2022 15:26:51 +0100
-Subject: [PATCH 095/177] fix(linstorvhdutil): due to bad refactoring, check
+Subject: [PATCH 095/180] fix(linstorvhdutil): due to bad refactoring, check
  call was broken
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0096-feat-linstorvhdutil-ensure-we-use-VHD-parent-to-find.patch
+++ b/SOURCES/0096-feat-linstorvhdutil-ensure-we-use-VHD-parent-to-find.patch
@@ -1,7 +1,7 @@
 From a765c54efe219c79f7a40550aadd7311f29757fe Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 23 Nov 2022 15:28:23 +0100
-Subject: [PATCH 096/177] feat(linstorvhdutil): ensure we use VHD parent to
+Subject: [PATCH 096/180] feat(linstorvhdutil): ensure we use VHD parent to
  find host where to coalesce
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0097-feat-linstorvolumemanager-force-DRBD-demote-after-fa.patch
+++ b/SOURCES/0097-feat-linstorvolumemanager-force-DRBD-demote-after-fa.patch
@@ -1,7 +1,7 @@
 From be33740647adac8be43e998a0ce620524f43db24 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Dec 2022 18:40:11 +0100
-Subject: [PATCH 097/177] feat(linstorvolumemanager): force DRBD demote after
+Subject: [PATCH 097/180] feat(linstorvolumemanager): force DRBD demote after
  failed volume creation/clone
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0098-fix-linstorvhdutil-ensure-we-retry-creation-in-all-s.patch
+++ b/SOURCES/0098-fix-linstorvhdutil-ensure-we-retry-creation-in-all-s.patch
@@ -1,7 +1,7 @@
 From 11cd26e0cd28d9aa622bdc31ace20008c11ab02e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Dec 2022 11:22:15 +0100
-Subject: [PATCH 098/177] fix(linstorvhdutil): ensure we retry creation in all
+Subject: [PATCH 098/180] fix(linstorvhdutil): ensure we retry creation in all
  situations
 
 Without this patch, a basic resource creation is never restarted

--- a/SOURCES/0099-fix-linstorvhdutil-don-t-retry-local-vhdutil-call-wh.patch
+++ b/SOURCES/0099-fix-linstorvhdutil-don-t-retry-local-vhdutil-call-wh.patch
@@ -1,7 +1,7 @@
 From 9a688cb7ccdf0d6dacda5f92caff8fe6a058967d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 7 Dec 2022 17:56:39 +0100
-Subject: [PATCH 099/177] fix(linstorvhdutil): don't retry local vhdutil call
+Subject: [PATCH 099/180] fix(linstorvhdutil): don't retry local vhdutil call
  when EROFS is detected
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0100-feat-fork-log-daemon-ignore-SIGTERM.patch
+++ b/SOURCES/0100-feat-fork-log-daemon-ignore-SIGTERM.patch
@@ -1,7 +1,7 @@
 From 3ff1971e28327c89e72f1df2d952339aed48ebeb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 15 Dec 2022 14:36:04 +0100
-Subject: [PATCH 100/177] feat(fork-log-daemon): ignore SIGTERM
+Subject: [PATCH 100/180] feat(fork-log-daemon): ignore SIGTERM
 
 Without this patch, the output logs of the fork-log-daemon child
 are never displayed when SIGTERM is sent to the PGID.

--- a/SOURCES/0101-feat-LinstorSR-wait-for-http-disk-server-startup.patch
+++ b/SOURCES/0101-feat-LinstorSR-wait-for-http-disk-server-startup.patch
@@ -1,7 +1,7 @@
 From 2023aa15d2bbd899eb6af814584b88a3deb3f6bf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 16 Dec 2022 16:52:50 +0100
-Subject: [PATCH 101/177] feat(LinstorSR): wait for http-disk-server startup
+Subject: [PATCH 101/180] feat(LinstorSR): wait for http-disk-server startup
 
 Avoid a race condition with NBD server.
 We must be sure the HTTP server is reachable before the NBD server execution,

--- a/SOURCES/0102-fix-LinstorSR-handle-inflate-resize-actions-correctl.patch
+++ b/SOURCES/0102-fix-LinstorSR-handle-inflate-resize-actions-correctl.patch
@@ -1,7 +1,7 @@
 From 574565e1b754b653ab88a8ad6d897a5725462fb4 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Jan 2023 17:58:51 +0100
-Subject: [PATCH 102/177] fix(LinstorSR): handle inflate + resize actions
+Subject: [PATCH 102/180] fix(LinstorSR): handle inflate + resize actions
  correctly
 
 - Ensure LINSTOR set the expected new volume size when inflate is executed,

--- a/SOURCES/0103-fix-linstor-manager-add-a-static-iptables-rule-for-D.patch
+++ b/SOURCES/0103-fix-linstor-manager-add-a-static-iptables-rule-for-D.patch
@@ -1,7 +1,7 @@
 From 01efc1b1f0655e160932bb3667c0fa74733ec84c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 17 Jan 2023 11:55:00 +0100
-Subject: [PATCH 103/177] fix(linstor-manager): add a static iptables rule for
+Subject: [PATCH 103/180] fix(linstor-manager): add a static iptables rule for
  DRBD volumes
 
 Using the XAPI iptables firewall may drop DRBD packets when the connection

--- a/SOURCES/0104-feat-LinstorSR-sync-with-last-http-nbd-transfer-vers.patch
+++ b/SOURCES/0104-feat-LinstorSR-sync-with-last-http-nbd-transfer-vers.patch
@@ -1,7 +1,7 @@
 From 511280dc71a3766cead7f37138cc3b8f843a187b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 3 Feb 2023 16:38:49 +0100
-Subject: [PATCH 104/177] feat(LinstorSR): sync with last http-nbd-transfer
+Subject: [PATCH 104/180] feat(LinstorSR): sync with last http-nbd-transfer
  version
 
 - Increase auto promote timeout of heartbeat VDI to reduce CPU usage

--- a/SOURCES/0105-fix-LinstorSR-don-t-check-VDI-metadata-while-listing.patch
+++ b/SOURCES/0105-fix-LinstorSR-don-t-check-VDI-metadata-while-listing.patch
@@ -1,7 +1,7 @@
 From 344d0c58408c89f48fb41cb1bfd70e5bed56781e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 13 Feb 2023 17:24:16 +0100
-Subject: [PATCH 105/177] fix(LinstorSR): don't check VDI metadata while
+Subject: [PATCH 105/180] fix(LinstorSR): don't check VDI metadata while
  listing VDIs if it's deleted
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0106-fix-LinstorSR-don-t-check-metadata-when-destroying-s.patch
+++ b/SOURCES/0106-fix-LinstorSR-don-t-check-metadata-when-destroying-s.patch
@@ -1,7 +1,7 @@
 From a00ccf6b47da3012b77dcba6cc22e21124434ec9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 13 Feb 2023 17:27:43 +0100
-Subject: [PATCH 106/177] fix(LinstorSR): don't check metadata when destroying
+Subject: [PATCH 106/180] fix(LinstorSR): don't check metadata when destroying
  snap in undo_clone
 
 Remove useless check in the snap rollback helper when there is an error

--- a/SOURCES/0107-fix-linstorvhdutil-handle-correctly-generic-exceptio.patch
+++ b/SOURCES/0107-fix-linstorvhdutil-handle-correctly-generic-exceptio.patch
@@ -1,7 +1,7 @@
 From 04722ec04e536210e0504bb784e649639d6af306 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 15 Feb 2023 11:34:54 +0100
-Subject: [PATCH 107/177] fix(linstorvhdutil): handle correctly generic
+Subject: [PATCH 107/180] fix(linstorvhdutil): handle correctly generic
  exceptions in _raise_openers_exception
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0108-fix-minidrbdcluster-robustify-to-unmount-correctly-L.patch
+++ b/SOURCES/0108-fix-minidrbdcluster-robustify-to-unmount-correctly-L.patch
@@ -1,7 +1,7 @@
 From 3b63e456318beb1746adab95136d142d1ee93f9e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 16 Feb 2023 14:24:07 +0100
-Subject: [PATCH 108/177] fix(minidrbdcluster): robustify to unmount correctly
+Subject: [PATCH 108/180] fix(minidrbdcluster): robustify to unmount correctly
  LINSTOR DB
 
 There is a small delay during which the database may not be unmounted

--- a/SOURCES/0109-fix-minidrbdcluster-handle-correctly-KeyboardInterru.patch
+++ b/SOURCES/0109-fix-minidrbdcluster-handle-correctly-KeyboardInterru.patch
@@ -1,7 +1,7 @@
 From af8bb2c311fb2dcf54f158b60b62c4b77073bbe8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Feb 2023 19:30:18 +0100
-Subject: [PATCH 109/177] fix(minidrbdcluster): handle correctly
+Subject: [PATCH 109/180] fix(minidrbdcluster): handle correctly
  KeyboardInterrupt with systemd units
 
 It's necessary to always add systemd services in the running list before

--- a/SOURCES/0110-feat-LinstorSR-use-drbd-reactor-instead-of-minidrbdc.patch
+++ b/SOURCES/0110-feat-LinstorSR-use-drbd-reactor-instead-of-minidrbdc.patch
@@ -1,7 +1,7 @@
 From 180f9e933cad1eefb1d9694b4a98d912d70b8697 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 24 Feb 2023 14:28:29 +0100
-Subject: [PATCH 110/177] feat(LinstorSR): use drbd-reactor instead of
+Subject: [PATCH 110/180] feat(LinstorSR): use drbd-reactor instead of
  minidrbdcluster
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0111-fix-LinstorSR-ensure-vhdutil-calls-are-correctly-exe.patch
+++ b/SOURCES/0111-fix-LinstorSR-ensure-vhdutil-calls-are-correctly-exe.patch
@@ -1,7 +1,7 @@
 From b49b91f7a56cc4e673fbc6edcc05bc40a14d1bea Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 1 Mar 2023 10:56:43 +0100
-Subject: [PATCH 111/177] fix(LinstorSR): ensure vhdutil calls are correctly
+Subject: [PATCH 111/180] fix(LinstorSR): ensure vhdutil calls are correctly
  executed on pools with > 3 hosts
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0112-fix-LinstorSR-replace-bad-param-in-detach_thin-impl.patch
+++ b/SOURCES/0112-fix-LinstorSR-replace-bad-param-in-detach_thin-impl.patch
@@ -1,7 +1,7 @@
 From 099f7a633435610b5e09c487ef0d42473d8fd9a9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 9 Mar 2023 17:06:59 +0100
-Subject: [PATCH 112/177] fix(LinstorSR): replace bad param in detach_thin impl
+Subject: [PATCH 112/180] fix(LinstorSR): replace bad param in detach_thin impl
 
 To get the physical size, the volume UUID must be used, not the path.
 

--- a/SOURCES/0113-fix-linstorvolumemanager-remove-usage-of-realpath.patch
+++ b/SOURCES/0113-fix-linstorvolumemanager-remove-usage-of-realpath.patch
@@ -1,7 +1,7 @@
 From 1d84de36cf45bbaba8fa0ea993bba09e1c18616d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 10 Mar 2023 18:11:10 +0100
-Subject: [PATCH 113/177] fix(linstorvolumemanager): remove usage of realpath
+Subject: [PATCH 113/180] fix(linstorvolumemanager): remove usage of realpath
 
 Because a diskless DRBD path not always exist, get_volume_name_from_device_path can fail.
 It's easy to reproduce using > 4 hosts and with a call to linstorvhdutil.get_vhd_info:

--- a/SOURCES/0114-fix-linstorvhdutil-avoid-parent-path-resolution.patch
+++ b/SOURCES/0114-fix-linstorvhdutil-avoid-parent-path-resolution.patch
@@ -1,7 +1,7 @@
 From e7550ad1ca7033adb3bb6dbc3c6a79fa2386d90b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 16 Mar 2023 18:54:46 +0100
-Subject: [PATCH 114/177] fix(linstorvhdutil): avoid parent path resolution
+Subject: [PATCH 114/180] fix(linstorvhdutil): avoid parent path resolution
 
 When many hosts are used (>= 4), we can fail to get
 VHD info (with parent option) because the local parent VDI

--- a/SOURCES/0115-fix-LinstorSR-create-parent-path-during-attach.patch
+++ b/SOURCES/0115-fix-LinstorSR-create-parent-path-during-attach.patch
@@ -1,7 +1,7 @@
 From 03a0c875d8ee453743237f36e9dcd9715f4a07d2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 17 Mar 2023 12:06:08 +0100
-Subject: [PATCH 115/177] fix(LinstorSR): create parent path during attach
+Subject: [PATCH 115/180] fix(LinstorSR): create parent path during attach
 
 It's necessary to force DRBD diskless path creation when
 a VDI is attached. Otherwise the attach can fail on pool with

--- a/SOURCES/0116-fix-LinstorSR-retry-if-we-can-t-build-volume-cache.patch
+++ b/SOURCES/0116-fix-LinstorSR-retry-if-we-can-t-build-volume-cache.patch
@@ -1,7 +1,7 @@
 From 601a07072f2ce0bb275c31a0daa5d803d9cfc885 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 3 Apr 2023 10:03:57 +0200
-Subject: [PATCH 116/177] fix(LinstorSR): retry if we can't build volume cache
+Subject: [PATCH 116/180] fix(LinstorSR): retry if we can't build volume cache
 
 Otherwise after SR creation, the master PBD can be unplugged.
 See: https://xcp-ng.org/forum/post/60726

--- a/SOURCES/0117-fix-linstorvolumemanager-reduce-peer-slots-param-to-.patch
+++ b/SOURCES/0117-fix-linstorvolumemanager-reduce-peer-slots-param-to-.patch
@@ -1,7 +1,7 @@
 From 2d862e93882ff9d63aa75c39d671825aeeefeba7 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 25 Apr 2023 10:46:00 +0200
-Subject: [PATCH 117/177] fix(linstorvolumemanager): reduce peer-slots param to
+Subject: [PATCH 117/180] fix(linstorvolumemanager): reduce peer-slots param to
  3
 
 Because we use 3 backing disks at most, it's useless to increase the default linstor limit (8).

--- a/SOURCES/0118-fix-LinstorSR-attach-a-valid-XAPI-session-is_open-is.patch
+++ b/SOURCES/0118-fix-LinstorSR-attach-a-valid-XAPI-session-is_open-is.patch
@@ -1,7 +1,7 @@
 From e13b45dc17a75702f4a6999e9bc28105ee0e48fb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 25 Apr 2023 11:20:55 +0200
-Subject: [PATCH 118/177] fix(LinstorSR): attach a valid XAPI session is_open
+Subject: [PATCH 118/180] fix(LinstorSR): attach a valid XAPI session is_open
  is called
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0119-fix-LinstorSR-ensure-we-always-have-a-DRBD-path-to-s.patch
+++ b/SOURCES/0119-fix-LinstorSR-ensure-we-always-have-a-DRBD-path-to-s.patch
@@ -1,7 +1,7 @@
 From 05bc50d10da120a065fff476a0a0532058d8192e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 28 Apr 2023 10:43:27 +0200
-Subject: [PATCH 119/177] fix(LinstorSR): ensure we always have a DRBD path to
+Subject: [PATCH 119/180] fix(LinstorSR): ensure we always have a DRBD path to
  snap
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0120-fix-LinstorSR-remove-hosts-ips-param.patch
+++ b/SOURCES/0120-fix-LinstorSR-remove-hosts-ips-param.patch
@@ -1,7 +1,7 @@
 From c7030966d57e33747b6dde463f35e9d7d79e6fb5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 30 May 2023 11:19:13 +0200
-Subject: [PATCH 120/177] fix(LinstorSR): remove hosts/ips param
+Subject: [PATCH 120/180] fix(LinstorSR): remove hosts/ips param
 
 ---
  drivers/LinstorSR.py            | 47 +++++----------------------------

--- a/SOURCES/0121-fix-LinstorSR-compute-correctly-SR-size-using-pool-c.patch
+++ b/SOURCES/0121-fix-LinstorSR-compute-correctly-SR-size-using-pool-c.patch
@@ -1,7 +1,7 @@
 From 54fa0adaf9bd385ca6e3f7b2eab5616f10b458be Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 1 Jun 2023 17:40:37 +0200
-Subject: [PATCH 121/177] fix(LinstorSR): compute correctly SR size using pool
+Subject: [PATCH 121/180] fix(LinstorSR): compute correctly SR size using pool
  count
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0122-fix-blktap2-ensure-we-can-import-this-module-when-LI.patch
+++ b/SOURCES/0122-fix-blktap2-ensure-we-can-import-this-module-when-LI.patch
@@ -1,7 +1,7 @@
 From 3cf1299c59cab4cf4f92a7a98db1757b0c876996 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Jun 2023 11:50:54 +0200
-Subject: [PATCH 122/177] fix(blktap2): ensure we can import this module when
+Subject: [PATCH 122/180] fix(blktap2): ensure we can import this module when
  LINSTOR is not installed
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0123-fix-LinstorSR-ensure-volume-cache-can-be-recreated.patch
+++ b/SOURCES/0123-fix-LinstorSR-ensure-volume-cache-can-be-recreated.patch
@@ -1,7 +1,7 @@
 From b06882d0cdb391ca92cd08146b935648cbb6ef6e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 21 Jun 2023 14:10:18 +0200
-Subject: [PATCH 123/177] fix(LinstorSR): ensure volume cache can be recreated
+Subject: [PATCH 123/180] fix(LinstorSR): ensure volume cache can be recreated
 
 After SR creation we may fail to load volumes with this exception:
 "Failed to get usable size of..." and so we can't plug the master PBD.

--- a/SOURCES/0124-fix-linstor-manager-remove-dead-useless-code-in-add-.patch
+++ b/SOURCES/0124-fix-linstor-manager-remove-dead-useless-code-in-add-.patch
@@ -1,7 +1,7 @@
 From 085905977ebf04aea99cc2301aaea15fd1f8ee4f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 20 Jul 2023 10:46:33 +0200
-Subject: [PATCH 124/177] fix(linstor-manager): remove dead/useless code in
+Subject: [PATCH 124/180] fix(linstor-manager): remove dead/useless code in
  add/remove_host helpers
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0125-fix-LinstorSR-Ensure-we-always-have-a-device-path-du.patch
+++ b/SOURCES/0125-fix-LinstorSR-Ensure-we-always-have-a-device-path-du.patch
@@ -1,7 +1,7 @@
 From 6dc4f983d955ca094c0bfb580cfda4dbb194ca3d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 1 Aug 2023 15:16:17 +0200
-Subject: [PATCH 125/177] fix(LinstorSR): Ensure we always have a device path
+Subject: [PATCH 125/180] fix(LinstorSR): Ensure we always have a device path
  during leaf-coalesce calls
 
 So we must not verify that we have a valid DRBD path in the load step,

--- a/SOURCES/0126-fix-LinstorSR-always-use-lock.acquire-during-attach-.patch
+++ b/SOURCES/0126-fix-LinstorSR-always-use-lock.acquire-during-attach-.patch
@@ -1,7 +1,7 @@
 From a4de2c2acab46a3d45ffea3be0818669ed559320 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 16 Aug 2023 12:04:01 +0200
-Subject: [PATCH 126/177] fix(LinstorSR): always use lock.acquire() during
+Subject: [PATCH 126/180] fix(LinstorSR): always use lock.acquire() during
  attach/detach
 
 We can't use a retry range on the lock because we can trigger a bad situation

--- a/SOURCES/0127-fix-LinstorSR-mare-sure-hostnames-are-unique-at-SR-c.patch
+++ b/SOURCES/0127-fix-LinstorSR-mare-sure-hostnames-are-unique-at-SR-c.patch
@@ -1,7 +1,7 @@
 From a7c3c1602e8210ebd74741d5c8ec2f1ef474918b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 17 Aug 2023 14:52:13 +0200
-Subject: [PATCH 127/177] fix(LinstorSR): mare sure hostnames are unique at SR
+Subject: [PATCH 127/180] fix(LinstorSR): mare sure hostnames are unique at SR
  creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0128-fix-LinstorSR-ensure-we-can-attach-non-special-stati.patch
+++ b/SOURCES/0128-fix-LinstorSR-ensure-we-can-attach-non-special-stati.patch
@@ -1,7 +1,7 @@
 From 54bca8660c18628ec36c1835b9f14aec80c187a8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 18 Aug 2023 11:06:56 +0200
-Subject: [PATCH 128/177] fix(LinstorSR): ensure we can attach non-special
+Subject: [PATCH 128/180] fix(LinstorSR): ensure we can attach non-special
  static VDIs
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0129-fix-LinstorSR-ensure-we-can-detach-when-deflate-call.patch
+++ b/SOURCES/0129-fix-LinstorSR-ensure-we-can-detach-when-deflate-call.patch
@@ -1,7 +1,7 @@
 From 9a295973c226d411ab4276b5bee8a241dc7c555e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 31 Aug 2023 18:00:27 +0200
-Subject: [PATCH 129/177] fix(LinstorSR): ensure we can detach when deflate
+Subject: [PATCH 129/180] fix(LinstorSR): ensure we can detach when deflate
  call is not possible
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0130-fix-LinstorSR-assume-VDI-is-always-a-VHD-when-the-in.patch
+++ b/SOURCES/0130-fix-LinstorSR-assume-VDI-is-always-a-VHD-when-the-in.patch
@@ -1,7 +1,7 @@
 From 0065166fc2de0bb1368eb590d6a12762cabdda04 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 28 Sep 2023 16:00:02 +0200
-Subject: [PATCH 130/177] fix(LinstorSR): assume VDI is always a VHD when the
+Subject: [PATCH 130/180] fix(LinstorSR): assume VDI is always a VHD when the
  info is missing during cleanup
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0131-fix-LinstorSR-remove-SR-lock-during-thin-attach-deta.patch
+++ b/SOURCES/0131-fix-LinstorSR-remove-SR-lock-during-thin-attach-deta.patch
@@ -1,7 +1,7 @@
 From f894c7a0cadbed19314bb93e04bdc4a7a6bcb62b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 2 Oct 2023 16:48:49 +0200
-Subject: [PATCH 131/177] fix(LinstorSR): remove SR lock during thin
+Subject: [PATCH 131/180] fix(LinstorSR): remove SR lock during thin
  attach/detach
 
 This lock is normally useless and can create a dead lock when thin mode is activated:

--- a/SOURCES/0132-fix-LinstorSR-ensure-database-is-mounted-during-scan.patch
+++ b/SOURCES/0132-fix-LinstorSR-ensure-database-is-mounted-during-scan.patch
@@ -1,7 +1,7 @@
 From 30b45e72a11b9e72a9edcdd22d71a15b8d132e63 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 3 Oct 2023 18:42:42 +0200
-Subject: [PATCH 132/177] fix(LinstorSR): ensure database is mounted during
+Subject: [PATCH 132/180] fix(LinstorSR): ensure database is mounted during
  scan
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0133-fix-LinstorSR-restart-drbd-reactor-in-case-of-failur.patch
+++ b/SOURCES/0133-fix-LinstorSR-restart-drbd-reactor-in-case-of-failur.patch
@@ -1,7 +1,7 @@
 From 6603e355de8b19f851669fa3d58a42662ea4e0eb Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 4 Oct 2023 14:30:36 +0200
-Subject: [PATCH 133/177] fix(LinstorSR): restart drbd-reactor in case of
+Subject: [PATCH 133/180] fix(LinstorSR): restart drbd-reactor in case of
  failure
 
 Otherwise we can have all hosts unusable after a massive reboot:

--- a/SOURCES/0134-fix-linstorvolumemanager-retry-in-case-of-failure-du.patch
+++ b/SOURCES/0134-fix-linstorvolumemanager-retry-in-case-of-failure-du.patch
@@ -1,7 +1,7 @@
 From ac881521fa06183435435e47933c6e7f034dfed8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 9 Oct 2023 10:37:32 +0200
-Subject: [PATCH 134/177] fix(linstorvolumemanager): retry in case of failure
+Subject: [PATCH 134/180] fix(linstorvolumemanager): retry in case of failure
  during mkfs call on database
 
 The device is not always ready after creation.

--- a/SOURCES/0135-fix-linstorvolumemanager-avoid-diskless-creation-whe.patch
+++ b/SOURCES/0135-fix-linstorvolumemanager-avoid-diskless-creation-whe.patch
@@ -1,7 +1,7 @@
 From 69ddfe0cf317308e2097ef4cacb081b9c4c60c40 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 26 Sep 2023 11:48:38 +0200
-Subject: [PATCH 135/177] fix(linstorvolumemanager): avoid diskless creation
+Subject: [PATCH 135/180] fix(linstorvolumemanager): avoid diskless creation
  when a new resource is added
 
 Like said in this discussion https://github.com/xcp-ng/sm/pull/34 :

--- a/SOURCES/0136-fix-LinstorSR-remove-diskless-after-VDI.detach-calls.patch
+++ b/SOURCES/0136-fix-LinstorSR-remove-diskless-after-VDI.detach-calls.patch
@@ -1,7 +1,7 @@
 From 7e6f37fb95ad0974b7e4be3e336b348517fa0946 Mon Sep 17 00:00:00 2001
 From: Rene Peinthor <rene.peinthor@linbit.com>
 Date: Tue, 25 Jul 2023 11:19:39 +0200
-Subject: [PATCH 136/177] fix(LinstorSR): remove diskless after VDI.detach
+Subject: [PATCH 136/180] fix(LinstorSR): remove diskless after VDI.detach
  calls
 
 Signed-off-by: Rene Peinthor <rene.peinthor@linbit.com>

--- a/SOURCES/0137-fix-LinstorSR-robustify-_load_vdi_info-in-cleanup.py.patch
+++ b/SOURCES/0137-fix-LinstorSR-robustify-_load_vdi_info-in-cleanup.py.patch
@@ -1,7 +1,7 @@
 From 995c6b7cf9ecb9baee34e05586320ccb4339651b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 11 Oct 2023 12:39:56 +0200
-Subject: [PATCH 137/177] fix(LinstorSR): robustify _load_vdi_info in
+Subject: [PATCH 137/180] fix(LinstorSR): robustify _load_vdi_info in
  cleanup.py
 
 After a failed snapshot like that:

--- a/SOURCES/0138-fix-LinstorSR-ensure-detach-never-fails-on-plugin-fa.patch
+++ b/SOURCES/0138-fix-LinstorSR-ensure-detach-never-fails-on-plugin-fa.patch
@@ -1,7 +1,7 @@
 From 64d36a80ff1e19ee7b4a8816f537b1e90ccda32f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 23 Oct 2023 14:31:27 +0200
-Subject: [PATCH 138/177] fix(LinstorSR): ensure detach never fails on plugin
+Subject: [PATCH 138/180] fix(LinstorSR): ensure detach never fails on plugin
  failure
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0139-fix-LinstorSR-ensure-we-coalesce-only-volumes-with-a.patch
+++ b/SOURCES/0139-fix-LinstorSR-ensure-we-coalesce-only-volumes-with-a.patch
@@ -1,7 +1,7 @@
 From c9ab4bc2198754e8eacc2fe4699eb5e6e5e4728e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 23 Oct 2023 15:52:23 +0200
-Subject: [PATCH 139/177] fix(LinstorSR): ensure we coalesce only volumes with
+Subject: [PATCH 139/180] fix(LinstorSR): ensure we coalesce only volumes with
  a valid size
 
 ---

--- a/SOURCES/0140-fix-LinstorSR-don-t-try-to-repair-persistent-volumes.patch
+++ b/SOURCES/0140-fix-LinstorSR-don-t-try-to-repair-persistent-volumes.patch
@@ -1,7 +1,7 @@
 From e615d0cc2f5dad974bec0de819fa3bf0a4b5d07a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 24 Oct 2023 11:57:40 +0200
-Subject: [PATCH 140/177] fix(LinstorSR): don't try to repair persistent
+Subject: [PATCH 140/180] fix(LinstorSR): don't try to repair persistent
  volumes in GC
 
 Use constants to simplify maintenance.

--- a/SOURCES/0141-fix-linstorvhdutil-format-correctly-message-if-vhd-u.patch
+++ b/SOURCES/0141-fix-linstorvhdutil-format-correctly-message-if-vhd-u.patch
@@ -1,7 +1,7 @@
 From ed396144e6293ac060fe8bbfde48363ed0313468 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 14 Nov 2023 18:21:53 +0100
-Subject: [PATCH 141/177] fix(linstorvhdutil): format correctly message if
+Subject: [PATCH 141/180] fix(linstorvhdutil): format correctly message if
  vhd-util cannot be run
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0142-fix-LinstorSR-wait-during-attach-to-open-DRBD-path.patch
+++ b/SOURCES/0142-fix-LinstorSR-wait-during-attach-to-open-DRBD-path.patch
@@ -1,7 +1,7 @@
 From 7d872f79b8857c2db490cf0c77a5c1c647af59e2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 24 Oct 2023 23:07:23 +0200
-Subject: [PATCH 142/177] fix(LinstorSR): wait during attach to open DRBD path
+Subject: [PATCH 142/180] fix(LinstorSR): wait during attach to open DRBD path
 
 ENODATA and other errors like EROFS can be raised when
 a new DRBD path is created on the fly. So ensure to block before tapdisk starts.

--- a/SOURCES/0143-fix-LinstorSR-support-different-volume-sizes-in-clea.patch
+++ b/SOURCES/0143-fix-LinstorSR-support-different-volume-sizes-in-clea.patch
@@ -1,7 +1,7 @@
 From d1e3ace3c5c16ba428c4151482f4065d09930621 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 14 Nov 2023 18:08:26 +0100
-Subject: [PATCH 143/177] fix(LinstorSR): support different volume sizes in
+Subject: [PATCH 143/180] fix(LinstorSR): support different volume sizes in
  cleanup.py
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0144-fix-LinstorSR-remove-useless-IPS_XHA_CACHE-var.patch
+++ b/SOURCES/0144-fix-LinstorSR-remove-useless-IPS_XHA_CACHE-var.patch
@@ -1,7 +1,7 @@
 From 79d4085610ef1ca85107eccd5a6e79f91d460027 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Nov 2023 10:52:27 +0100
-Subject: [PATCH 144/177] fix(LinstorSR): remove useless IPS_XHA_CACHE var
+Subject: [PATCH 144/180] fix(LinstorSR): remove useless IPS_XHA_CACHE var
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 ---

--- a/SOURCES/0145-fix-LinstorSR-ensure-we-can-deflate-on-any-host-afte.patch
+++ b/SOURCES/0145-fix-LinstorSR-ensure-we-can-deflate-on-any-host-afte.patch
@@ -1,7 +1,7 @@
 From 5cd04079c9bca752f6f78532ad1ae0bf962c3902 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 21 Nov 2023 13:50:24 +0100
-Subject: [PATCH 145/177] fix(LinstorSR): ensure we can deflate on any host
+Subject: [PATCH 145/180] fix(LinstorSR): ensure we can deflate on any host
  after a journal rollback
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0146-fix-LinstorSR-ensure-we-always-use-real-DRBD-VHD-siz.patch
+++ b/SOURCES/0146-fix-LinstorSR-ensure-we-always-use-real-DRBD-VHD-siz.patch
@@ -1,7 +1,7 @@
 From f3726fc7b992ceb2d51e3e1725cc1cb6eff2dc77 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 27 Nov 2023 12:15:43 +0100
-Subject: [PATCH 146/177] fix(LinstorSR): ensure we always use real DRBD/VHD
+Subject: [PATCH 146/180] fix(LinstorSR): ensure we always use real DRBD/VHD
  sizes in inflate/deflate GC calls
 
 ---

--- a/SOURCES/0147-feat-linstor-kv-tool-If-no-controller-uri-option-is-.patch
+++ b/SOURCES/0147-feat-linstor-kv-tool-If-no-controller-uri-option-is-.patch
@@ -1,7 +1,7 @@
 From 95d463f76f5227f4dd4726c50695c739882f92a2 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.tech>
 Date: Mon, 27 Nov 2023 14:23:57 +0100
-Subject: [PATCH 147/177] feat(linstor-kv-tool): If no controller uri option is
+Subject: [PATCH 147/180] feat(linstor-kv-tool): If no controller uri option is
  provided fetch it (#48)
 
 Signed-off-by: BenjiReis <benjamin.reis@vates.fr>

--- a/SOURCES/0148-fix-linstorvolumemanager-robustify-SR-destroy-46.patch
+++ b/SOURCES/0148-fix-linstorvolumemanager-robustify-SR-destroy-46.patch
@@ -1,7 +1,7 @@
 From b8e4a29597f8dc8034e4ea307cd5e347d6a3b631 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.tech>
 Date: Wed, 29 Nov 2023 15:45:32 +0100
-Subject: [PATCH 148/177] fix(linstorvolumemanager): robustify SR destroy (#46)
+Subject: [PATCH 148/180] fix(linstorvolumemanager): robustify SR destroy (#46)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
 Co-authored-by: BenjiReis <benjamin.reis@vates.fr>

--- a/SOURCES/0149-feat-linstor-manager-extend-API-with-createNodeInter.patch
+++ b/SOURCES/0149-feat-linstor-manager-extend-API-with-createNodeInter.patch
@@ -1,7 +1,7 @@
 From 9a3af8ca152d5f94314886acb12f1971892bdf22 Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.tech>
 Date: Wed, 29 Nov 2023 16:54:30 +0100
-Subject: [PATCH 149/177] feat(linstor-manager): extend API with
+Subject: [PATCH 149/180] feat(linstor-manager): extend API with
  createNodeInterface and setNodePreferredInterface (#47)
 
 Signed-off-by: BenjiReis <benjamin.reis@vates.fr>

--- a/SOURCES/0150-fix-LinstorSR-support-VDI.resize-on-thick-volumes.patch
+++ b/SOURCES/0150-fix-LinstorSR-support-VDI.resize-on-thick-volumes.patch
@@ -1,7 +1,7 @@
 From 36459279481994f97bb186e6522c117b9669120a Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 1 Dec 2023 11:55:12 +0100
-Subject: [PATCH 150/177] fix(LinstorSR): support VDI.resize on thick volumes
+Subject: [PATCH 150/180] fix(LinstorSR): support VDI.resize on thick volumes
 
 ---
  drivers/LinstorSR.py | 3 +++

--- a/SOURCES/0151-fix-linstorvolumemanager-format-correctly-exception-.patch
+++ b/SOURCES/0151-fix-linstorvolumemanager-format-correctly-exception-.patch
@@ -1,7 +1,7 @@
 From 4119be3b2769b7c29013cb5f60e68238a439b474 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 4 Dec 2023 16:36:55 +0100
-Subject: [PATCH 151/177] fix(linstorvolumemanager): format correctly exception
+Subject: [PATCH 151/180] fix(linstorvolumemanager): format correctly exception
  during db mount
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0152-fix-LinstorSR-ensure-we-can-skip-coalesces-if-device.patch
+++ b/SOURCES/0152-fix-LinstorSR-ensure-we-can-skip-coalesces-if-device.patch
@@ -1,7 +1,7 @@
 From 9f3c9d85430ad14214b25fc6d529c88e8c217985 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 4 Dec 2023 18:57:08 +0100
-Subject: [PATCH 152/177] fix(LinstorSR): ensure we can skip coalesces if
+Subject: [PATCH 152/180] fix(LinstorSR): ensure we can skip coalesces if
  device path can't be fetched
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0153-feat-linstor-manager-add-methods-to-modify-destroy-l.patch
+++ b/SOURCES/0153-feat-linstor-manager-add-methods-to-modify-destroy-l.patch
@@ -1,7 +1,7 @@
 From d607e5c450a9cbe39ea5826c2a4ec7f63751f805 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 19 Dec 2023 14:49:33 +0100
-Subject: [PATCH 153/177] feat(linstor-manager): add methods to
+Subject: [PATCH 153/180] feat(linstor-manager): add methods to
  modify/destroy/list net interfaces
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0154-fix-LinstorSR-force-a-defined-volume-prefix-if-we-ca.patch
+++ b/SOURCES/0154-fix-LinstorSR-force-a-defined-volume-prefix-if-we-ca.patch
@@ -1,7 +1,7 @@
 From 0fcc4fbd4814578062bf83d7e26f3975cc120cd1 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 12 Jan 2024 10:28:20 +0100
-Subject: [PATCH 154/177] fix(LinstorSR): force a defined volume prefix if we
+Subject: [PATCH 154/180] fix(LinstorSR): force a defined volume prefix if we
  can't import libs
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0155-fix-LinstorSR-explicit-error-message-when-a-group-is.patch
+++ b/SOURCES/0155-fix-LinstorSR-explicit-error-message-when-a-group-is.patch
@@ -1,7 +1,7 @@
 From c83b1aeacc1db0ec6110accaa128eed05eb36294 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 18 Jan 2024 10:24:01 +0100
-Subject: [PATCH 155/177] fix(LinstorSR): explicit error message when a group
+Subject: [PATCH 155/180] fix(LinstorSR): explicit error message when a group
  is not unique during SR creation
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0156-fix-LinstorSR-make-sure-VDI.delete-doesn-t-throw-und.patch
+++ b/SOURCES/0156-fix-LinstorSR-make-sure-VDI.delete-doesn-t-throw-und.patch
@@ -1,7 +1,7 @@
 From a428724082121c6a61de9636efdeb3b0f2aead49 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 18 Jan 2024 11:18:11 +0100
-Subject: [PATCH 156/177] fix(LinstorSR): make sure VDI.delete doesn't throw
+Subject: [PATCH 156/180] fix(LinstorSR): make sure VDI.delete doesn't throw
  under specific conditions
 
 If we can update the volume state in the KV-store, there is no reason to raise

--- a/SOURCES/0157-fix-LinstorSR-add-drbd-in-the-blacklist-of-multipath.patch
+++ b/SOURCES/0157-fix-LinstorSR-add-drbd-in-the-blacklist-of-multipath.patch
@@ -1,7 +1,7 @@
 From db9f69a83b5402daf90fd1d2c44d9e65e37708c5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 19 Jan 2024 14:39:17 +0100
-Subject: [PATCH 157/177] fix(LinstorSR): add drbd in the blacklist of
+Subject: [PATCH 157/180] fix(LinstorSR): add drbd in the blacklist of
  multipath.conf
 
 If DRBD is installed for the first time, and if the multipathd

--- a/SOURCES/0158-fix-linstorvolumemanager-create-cloned-volumes-on-ho.patch
+++ b/SOURCES/0158-fix-linstorvolumemanager-create-cloned-volumes-on-ho.patch
@@ -1,7 +1,7 @@
 From 4dbb05941ce89601e4766452e87e75a8abfbc63c Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 22 Jan 2024 11:25:25 +0100
-Subject: [PATCH 158/177] fix(linstorvolumemanager): create cloned volumes on
+Subject: [PATCH 158/180] fix(linstorvolumemanager): create cloned volumes on
  host selected by LINSTOR
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0159-fix-linstorvolumemanager-don-t-align-volumes-on-LVM-.patch
+++ b/SOURCES/0159-fix-linstorvolumemanager-don-t-align-volumes-on-LVM-.patch
@@ -1,7 +1,7 @@
 From 0e86f2c9c1acdf9a669807d0db783cb58ac29499 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 26 Jan 2024 15:29:21 +0100
-Subject: [PATCH 159/177] fix(linstorvolumemanager): don't align volumes on LVM
+Subject: [PATCH 159/180] fix(linstorvolumemanager): don't align volumes on LVM
  sector size
 
 It's the goal of the LINSTOR stack to align properly on the LVM layer.

--- a/SOURCES/0160-fix-linstorvolumemanager-assert-with-message-after-l.patch
+++ b/SOURCES/0160-fix-linstorvolumemanager-assert-with-message-after-l.patch
@@ -1,7 +1,7 @@
 From 67926a299d10072816286df087cb1fe3a0111717 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Feb 2024 18:01:22 +0100
-Subject: [PATCH 160/177] fix(linstorvolumemanager): assert with message after
+Subject: [PATCH 160/180] fix(linstorvolumemanager): assert with message after
  log in update_volume_uuid
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0161-fix-linstorvolumemanager-retry-resize-if-volume-is-n.patch
+++ b/SOURCES/0161-fix-linstorvolumemanager-retry-resize-if-volume-is-n.patch
@@ -1,7 +1,7 @@
 From 0fc311b8ac8da92ba91f99a1ceb97ee7663c88ed Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 5 Feb 2024 23:13:06 +0100
-Subject: [PATCH 161/177] fix(linstorvolumemanager): retry resize if volume is
+Subject: [PATCH 161/180] fix(linstorvolumemanager): retry resize if volume is
  not up to date
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0162-fix-LinstorSR-create-DRBD-diskless-if-necessary-for-.patch
+++ b/SOURCES/0162-fix-LinstorSR-create-DRBD-diskless-if-necessary-for-.patch
@@ -1,7 +1,7 @@
 From 0d61202439fd59c9d0121d71ce63e41e5a7d7f68 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Feb 2024 00:10:32 +0100
-Subject: [PATCH 162/177] fix(LinstorSR): create DRBD diskless if necessary for
+Subject: [PATCH 162/180] fix(LinstorSR): create DRBD diskless if necessary for
  each VHD parent
 
 It's necessary to have all parents during snapshot to create a new VHD child.

--- a/SOURCES/0163-fix-LinstorSR-fix-bad-call-to-vhdutil.inflate-bad-ex.patch
+++ b/SOURCES/0163-fix-LinstorSR-fix-bad-call-to-vhdutil.inflate-bad-ex.patch
@@ -1,7 +1,7 @@
 From 574d72fc61a205b0a037cfe6a0002f2602f8e99d Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 6 Feb 2024 00:14:11 +0100
-Subject: [PATCH 163/177] fix(LinstorSR): fix bad call to vhdutil.inflate + bad
+Subject: [PATCH 163/180] fix(LinstorSR): fix bad call to vhdutil.inflate + bad
  exception
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0164-fix-LinstorSR-activate-VG-if-attach-from-config-is-a.patch
+++ b/SOURCES/0164-fix-LinstorSR-activate-VG-if-attach-from-config-is-a.patch
@@ -1,7 +1,7 @@
 From fdd9b4d9038c31c1c54d31b5ea135f6cab85ac24 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 12 Feb 2024 20:54:06 +0100
-Subject: [PATCH 164/177] fix(LinstorSR): activate VG if attach from config is
+Subject: [PATCH 164/180] fix(LinstorSR): activate VG if attach from config is
  asked
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0165-feat-LinstorSR-use-a-specific-resource-group-for-DB-.patch
+++ b/SOURCES/0165-feat-LinstorSR-use-a-specific-resource-group-for-DB-.patch
@@ -1,7 +1,7 @@
 From 51699827c68a7674b379b44bcc9fa51c95c9b9a2 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 19 Mar 2024 23:09:54 +0100
-Subject: [PATCH 165/177] feat(LinstorSR): use a specific resource group for DB
+Subject: [PATCH 165/180] feat(LinstorSR): use a specific resource group for DB
  and HA
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0166-feat-linstor-manager-add-getNodePreferredInterface-h.patch
+++ b/SOURCES/0166-feat-linstor-manager-add-getNodePreferredInterface-h.patch
@@ -1,7 +1,7 @@
 From d3d377079f5153fa41220b4df9de176b733cd6a8 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 15 Apr 2024 11:22:18 +0200
-Subject: [PATCH 166/177] feat(linstor-manager): add
+Subject: [PATCH 166/180] feat(linstor-manager): add
  `getNodePreferredInterface` helper
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0167-fix-linstorvolumemanager-blocks-deletion-of-default-.patch
+++ b/SOURCES/0167-fix-linstorvolumemanager-blocks-deletion-of-default-.patch
@@ -1,7 +1,7 @@
 From 297296c0ec9c5df659267e1432e4de0ac6af5618 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 15 Apr 2024 11:26:00 +0200
-Subject: [PATCH 167/177] fix(linstorvolumemanager): blocks deletion of default
+Subject: [PATCH 167/180] fix(linstorvolumemanager): blocks deletion of default
  network interface
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0168-feat-linstorvolumemanager-change-logic-of-get_resour.patch
+++ b/SOURCES/0168-feat-linstorvolumemanager-change-logic-of-get_resour.patch
@@ -1,7 +1,7 @@
 From 1d940461f9f408b93eef80c09156f74745d62570 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 15 Apr 2024 17:56:47 +0200
-Subject: [PATCH 168/177] feat(linstorvolumemanager): change logic of
+Subject: [PATCH 168/180] feat(linstorvolumemanager): change logic of
  `get_resources_info`: - Add a nested level "nodes" for each resource - Add a
  "uuid" attr on resources - Rename LINSTOR "uuid" to "linstor-uuid" - Optimize
  code

--- a/SOURCES/0169-feat-linstor-manager-add-error-codes-to-healthCheck-.patch
+++ b/SOURCES/0169-feat-linstor-manager-add-error-codes-to-healthCheck-.patch
@@ -1,7 +1,7 @@
 From c377cf900ae07d3b6de4004dd3a65df9086c30b3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 18 Apr 2024 13:57:37 +0200
-Subject: [PATCH 169/177] feat(linstor-manager): add error codes to healthCheck
+Subject: [PATCH 169/180] feat(linstor-manager): add error codes to healthCheck
  helper
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0170-fix-LinstorSR-fix-bad-exception-reference-during-sna.patch
+++ b/SOURCES/0170-fix-LinstorSR-fix-bad-exception-reference-during-sna.patch
@@ -1,7 +1,7 @@
 From 84e236ff9a967f5df25535213f89e377d51d4b5f Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 24 Apr 2024 15:10:49 +0200
-Subject: [PATCH 170/177] fix(LinstorSR): fix bad exception reference during
+Subject: [PATCH 170/180] fix(LinstorSR): fix bad exception reference during
  snapshot
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0171-fix-tapdisk-pause-ensure-LINSTOR-VHD-chain-is-availa.patch
+++ b/SOURCES/0171-fix-tapdisk-pause-ensure-LINSTOR-VHD-chain-is-availa.patch
@@ -1,7 +1,7 @@
 From 66ec66a863f3d5c8c95e5310dd2e9c77335faab5 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 24 Apr 2024 17:29:26 +0200
-Subject: [PATCH 171/177] fix(tapdisk-pause): ensure LINSTOR VHD chain is
+Subject: [PATCH 171/180] fix(tapdisk-pause): ensure LINSTOR VHD chain is
  available
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0172-fix-linstorvhdutil-retry-check-on-another-machine-in.patch
+++ b/SOURCES/0172-fix-linstorvhdutil-retry-check-on-another-machine-in.patch
@@ -1,7 +1,7 @@
 From 5a48b3ddc8683c3f6217c1bcce17d4f064efaee9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 6 May 2024 18:15:00 +0200
-Subject: [PATCH 172/177] fix(linstorvhdutil): retry check on another machine
+Subject: [PATCH 172/180] fix(linstorvhdutil): retry check on another machine
  in case of failure (#54)
 
 Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>

--- a/SOURCES/0173-fix-LinstorSR-explicit-errors-when-database-path-is-.patch
+++ b/SOURCES/0173-fix-LinstorSR-explicit-errors-when-database-path-is-.patch
@@ -1,7 +1,7 @@
 From 13ff45ec98437db8d85e3d9c52d6bb353f8f9656 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 6 May 2024 21:35:36 +0200
-Subject: [PATCH 173/177] fix(LinstorSR): explicit errors when database path is
+Subject: [PATCH 173/180] fix(LinstorSR): explicit errors when database path is
  fetched
 
 ---

--- a/SOURCES/0174-fix-LinstorSR-Misc-fixes-on-destroy.patch
+++ b/SOURCES/0174-fix-LinstorSR-Misc-fixes-on-destroy.patch
@@ -1,7 +1,7 @@
 From 34e414b5d11363ebcce4c0f3a98d9e8de6c90432 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Tue, 30 Apr 2024 15:38:34 +0200
-Subject: [PATCH 174/177] fix(LinstorSR): Misc fixes on destroy
+Subject: [PATCH 174/180] fix(LinstorSR): Misc fixes on destroy
 
 linstor-manager:
 - fix on get_drbd_volumes

--- a/SOURCES/0175-fix-LinstorSR-open-non-leaf-volumes-in-RO-mode-creat.patch
+++ b/SOURCES/0175-fix-LinstorSR-open-non-leaf-volumes-in-RO-mode-creat.patch
@@ -1,7 +1,7 @@
 From 383d6484765a0b316402f1899bc9a2ec2cf81521 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 20 Jun 2024 22:37:40 +0200
-Subject: [PATCH 175/177] fix(LinstorSR): open non-leaf volumes in RO mode
+Subject: [PATCH 175/180] fix(LinstorSR): open non-leaf volumes in RO mode
  (create_chain_paths)
 
 We must never open non-leaf volumes with the write option.

--- a/SOURCES/0176-fix-LinstorSR-ensure-_is_master-is-always-set.patch
+++ b/SOURCES/0176-fix-LinstorSR-ensure-_is_master-is-always-set.patch
@@ -1,7 +1,7 @@
 From 0cbabd180b8fc5ecaf2ca8ff066f37bd18706b68 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Fri, 26 Jul 2024 11:32:20 +0200
-Subject: [PATCH 176/177] fix(LinstorSR): ensure `_is_master` is always set
+Subject: [PATCH 176/180] fix(LinstorSR): ensure `_is_master` is always set
 
 `_is_master` is not always initialized, and more precisely
 in the case of detach where LinstorSR.load method is not called.

--- a/SOURCES/0177-fix-linstor-check-if-resource-is-tiebreaker-62.patch
+++ b/SOURCES/0177-fix-linstor-check-if-resource-is-tiebreaker-62.patch
@@ -1,7 +1,7 @@
 From 8d6cfc70d30e13cdf6a8ea2be3a534bace9fb936 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Fri, 26 Jul 2024 14:13:05 +0200
-Subject: [PATCH 177/177] fix(linstor): check if resource is tiebreaker (#62)
+Subject: [PATCH 177/180] fix(linstor): check if resource is tiebreaker (#62)
 
 We check if a resource is already a tiebreaker before trying to delete
 the resource.

--- a/SOURCES/0178-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
+++ b/SOURCES/0178-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
@@ -1,0 +1,50 @@
+From b7e68c234512d9f8cee7c4400ae20d67fba1cc4b Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Thu, 9 Jan 2025 17:40:54 +0100
+Subject: [PATCH 178/180] fix(cleanup.py): protect LinstorSR init against race
+ condition (#78)
+
+During `LinstorSR` init, only create the journaler to make `should_preempt` happy.
+The volume manager MUST always be created in a SR lock context. Otherwise,
+we can trigger major issues.
+
+For example, a volume can be deleted from the KV-store by `cleanup.py` during a
+snapshot rollback. Very rare situation but which allowed this problem to be discovered.
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/cleanup.py | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/cleanup.py b/drivers/cleanup.py
+index 8c16f689..48fac2bf 100755
+--- a/drivers/cleanup.py
++++ b/drivers/cleanup.py
+@@ -3014,7 +3014,7 @@ class LinstorSR(SR):
+ 
+         SR.__init__(self, uuid, xapi, createLock, force)
+         self.path = LinstorVolumeManager.DEV_ROOT_PATH
+-        self._reloadLinstor()
++        self._reloadLinstor(journaler_only=True)
+ 
+     def deleteVDI(self, vdi):
+         self._checkSlaves(vdi)
+@@ -3045,7 +3045,7 @@ class LinstorSR(SR):
+         )
+         return super(LinstorSR, self).pauseVDIs(vdiList)
+ 
+-    def _reloadLinstor(self):
++    def _reloadLinstor(self, journaler_only=False):
+         session = self.xapi.session
+         host_ref = util.get_this_host_ref(session)
+         sr_ref = session.xenapi.SR.get_by_uuid(self.uuid)
+@@ -3062,6 +3062,9 @@ class LinstorSR(SR):
+             controller_uri, group_name, logger=util.SMlog
+         )
+ 
++        if journaler_only:
++            return
++
+         self._linstor = LinstorVolumeManager(
+             controller_uri,
+             group_name,

--- a/SOURCES/0179-fix-LinstorSR-sync-fork-load-daemon-with-http-nbd-tr.patch
+++ b/SOURCES/0179-fix-LinstorSR-sync-fork-load-daemon-with-http-nbd-tr.patch
@@ -1,0 +1,36 @@
+From 2031020847e5f8f69bc5ed855e3bbaee7ea2975a Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Thu, 9 Jan 2025 17:42:46 +0100
+Subject: [PATCH 179/180] fix(LinstorSR): sync fork-load-daemon with
+ http-nbd-transfer (v1.5.0) (#74)
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ scripts/fork-log-daemon | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/fork-log-daemon b/scripts/fork-log-daemon
+index 665a60ba..debbc893 100755
+--- a/scripts/fork-log-daemon
++++ b/scripts/fork-log-daemon
+@@ -1,5 +1,6 @@
+ #!/usr/bin/env python
+ 
++import os
+ import select
+ import signal
+ import subprocess
+@@ -7,7 +8,12 @@ import sys
+ import syslog
+ 
+ def main():
+-    process = subprocess.Popen(sys.argv[1:], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
++    process = subprocess.Popen(
++        sys.argv[1:],
++        stdout=subprocess.PIPE,
++        stderr=subprocess.STDOUT,
++        env=dict(os.environ, PYTHONUNBUFFERED='1')
++    )
+     signal.signal(signal.SIGTERM, signal.SIG_IGN)
+     write_to_stdout = True
+ 

--- a/SOURCES/0180-Fix-filter-to-reject-other-device-types-76.patch
+++ b/SOURCES/0180-Fix-filter-to-reject-other-device-types-76.patch
@@ -1,0 +1,23 @@
+From fbef448eee94b08a7cfd2ba3685766943c08c7a0 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 9 Jan 2025 17:41:22 +0100
+Subject: [PATCH 180/180] Fix filter to reject other device types (#76)
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LargeBlockSR.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/LargeBlockSR.py b/drivers/LargeBlockSR.py
+index 0fd1f345..e90108ed 100644
+--- a/drivers/LargeBlockSR.py
++++ b/drivers/LargeBlockSR.py
+@@ -215,7 +215,7 @@ class LargeBlockSR(EXTSR.EXTSR):
+         util.SMlog("Reconnecting VG {} to use emulated device".format(self.vgname))
+         try:
+             lvutil.setActiveVG(self.vgname, False)
+-            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"r|^/dev/nvme.*|\", \"a|/dev/loop.*|\" ] }")
++            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"a|/dev/loop.*|\", \"r|.*|\" ] }")
+         except util.CommandException as e:
+             xs_errors.XenError("LargeBlockVGReconnectFailed", opterr="Failed to reconnect the VolumeGroup {}, error: {}".format(self.vgname, e))
+ 

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -11,7 +11,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 2.30.8
-Release: %{?xsrel}.1.0.linstor.1%{?dist}
+Release: %{?xsrel}.2.0.linstor.1%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -279,6 +279,9 @@ Patch1174: 0174-fix-LinstorSR-Misc-fixes-on-destroy.patch
 Patch1175: 0175-fix-LinstorSR-open-non-leaf-volumes-in-RO-mode-creat.patch
 Patch1176: 0176-fix-LinstorSR-ensure-_is_master-is-always-set.patch
 Patch1177: 0177-fix-linstor-check-if-resource-is-tiebreaker-62.patch
+Patch1178: 0178-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
+Patch1179: 0179-fix-LinstorSR-sync-fork-load-daemon-with-http-nbd-tr.patch
+Patch1180: 0180-Fix-filter-to-reject-other-device-types-76.patch
 
 %description
 This package contains storage backends used in XCP
@@ -696,6 +699,12 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
+* Fri Jan 17 2025 Ronan Abhamon <ronan.abhamon@vates.tech> - 2.30.8-13.2.0.linstor.1
+- Add 0178-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
+- Sync fork-load-daemon script with http-nbd-transfer (v1.5.0)
+- Add 0179-fix-LinstorSR-sync-fork-load-daemon-with-http-nbd-tr.patch
+- Add 0180-Fix-filter-to-reject-other-device-types-76.patch
+
 * Thu Oct 03 2024 Ronan Abhamon <ronan.abhamon@vates.tech> - 2.30.8-13.1.0.linstor.1
 - Add "Provides": sm-linstor (necessary for the "Requires" of xcp-ng-linstor)
 - Add LINSTOR patches


### PR DESCRIPTION
- Fix race condition in LINSTOR GC
- Fix VG activation in LargeBlockSR for non-NVMe devices
- Sync fork-load-daemon script with http-nbd-transfer (v1.5.0)

Koji build (pre-release, v8.2-v-linstor-testing): http://koji.xcp-ng.org/taskinfo?taskID=72714
Warning: Must be released with http-nbd-transfer.