### PR TITLE
Release 2.30.8-13.2

### DIFF
--- a/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
+++ b/SOURCES/0001-backport-of-ccd121cc248d79b749a63d4ad099e6d5f4b8b588.patch
@@ -1,7 +1,7 @@
 From 705a6d9deed2ba862577681fc54df144060f3816 Mon Sep 17 00:00:00 2001
 From: Mark Syms <mark.syms@citrix.com>
 Date: Thu, 20 May 2021 17:40:06 +0100
-Subject: [PATCH 01/23] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
+Subject: [PATCH 01/24] backport of ccd121cc248d79b749a63d4ad099e6d5f4b8b588:
  CA-354692: check for device parameter in create/probe calls
 
 Signed-off-by: Mark Syms <mark.syms@citrix.com>

--- a/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
+++ b/SOURCES/0002-Update-xs-sm.service-s-description-for-XCP-ng.patch
@@ -1,7 +1,7 @@
 From fd898b82d880619f0acd9d1b8f1d55b3967bc339 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:22:17 +0200
-Subject: [PATCH 02/23] Update xs-sm.service's description for XCP-ng
+Subject: [PATCH 02/24] Update xs-sm.service's description for XCP-ng
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0003-Add-TrueNAS-multipath-config.patch
+++ b/SOURCES/0003-Add-TrueNAS-multipath-config.patch
@@ -1,7 +1,7 @@
 From bd709621897bda8d9f14820fb3d52eecfe51facb Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 15:26:43 +0200
-Subject: [PATCH 03/23] Add TrueNAS multipath config
+Subject: [PATCH 03/24] Add TrueNAS multipath config
 
 This was a patch added to the sm RPM git repo before we had this
 forked git repo for sm in the xcp-ng github organisation.

--- a/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
+++ b/SOURCES/0004-feat-drivers-add-CephFS-GlusterFS-and-XFS-drivers.patch
@@ -1,7 +1,7 @@
 From 574897552a11af6fc92e145df0bacb42a2ac6b53 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 20 Jul 2020 16:26:42 +0200
-Subject: [PATCH 04/23] feat(drivers): add CephFS, GlusterFS and XFS drivers
+Subject: [PATCH 04/24] feat(drivers): add CephFS, GlusterFS and XFS drivers
 
 ---
  Makefile               |   3 +

--- a/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
+++ b/SOURCES/0005-feat-drivers-add-ZFS-driver-to-avoid-losing-VDI-meta.patch
@@ -1,7 +1,7 @@
 From 3a948fe3ff75146c3a9c960768ca4791c109a6b6 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 12 Aug 2020 11:14:33 +0200
-Subject: [PATCH 05/23] feat(drivers): add ZFS driver to avoid losing VDI
+Subject: [PATCH 05/24] feat(drivers): add ZFS driver to avoid losing VDI
  metadata (xcp-ng/xcp#401)
 
 ---

--- a/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
+++ b/SOURCES/0006-Re-add-the-ext4-driver-for-users-who-need-to-transit.patch
@@ -1,7 +1,7 @@
 From 8b1962f5d6d8b092525e94241df033e4a78872b1 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi@laposte.net>
 Date: Thu, 13 Aug 2020 17:10:12 +0200
-Subject: [PATCH 06/23] Re-add the ext4 driver for users who need to transition
+Subject: [PATCH 06/24] Re-add the ext4 driver for users who need to transition
 
 The driver is needed to transition to the ext driver.
 Users who upgrade from XCP-ng <= 8.0 need a working driver so that they

--- a/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
+++ b/SOURCES/0007-feat-drivers-add-LinstorSR-driver.patch
@@ -1,7 +1,7 @@
 From 9b836e9e503354796a7f975bb44f10a0920f33e3 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Mon, 16 Mar 2020 15:39:44 +0100
-Subject: [PATCH 07/23] feat(drivers): add LinstorSR driver
+Subject: [PATCH 07/24] feat(drivers): add LinstorSR driver
 
 Some important points:
 

--- a/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
+++ b/SOURCES/0008-feat-tests-add-unit-tests-concerning-ZFS-close-xcp-n.patch
@@ -1,7 +1,7 @@
 From c756b29ce80da0cd38f88bbaaddf4e1130962af9 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 27 Oct 2020 15:04:36 +0100
-Subject: [PATCH 08/23] feat(tests): add unit tests concerning ZFS (close
+Subject: [PATCH 08/24] feat(tests): add unit tests concerning ZFS (close
  xcp-ng/xcp#425)
 
 - Check if "create" doesn't succeed without zfs packages

--- a/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
+++ b/SOURCES/0009-If-no-NFS-ACLs-provided-assume-everyone.patch
@@ -1,7 +1,7 @@
 From c4402ded6d0dd748435c621c7d7840cb7886bc3f Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Thu, 25 Feb 2021 09:54:52 +0100
-Subject: [PATCH 09/23] If no NFS ACLs provided, assume everyone:
+Subject: [PATCH 09/24] If no NFS ACLs provided, assume everyone:
 
 Some QNAP devices do not provide ACL when fetching NFS mounts.
 In this case the assumed ACL should be: "*".

--- a/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
+++ b/SOURCES/0010-Added-SM-Driver-for-MooseFS.patch
@@ -1,7 +1,7 @@
 From ba6e2bace64965d7d9f89e6dd9a94bf22ae075a2 Mon Sep 17 00:00:00 2001
 From: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>
 Date: Fri, 29 Jan 2021 15:21:23 +0100
-Subject: [PATCH 10/23] Added SM Driver for MooseFS
+Subject: [PATCH 10/24] Added SM Driver for MooseFS
 
 Co-authored-by: Piotr Robert Konopelko <piotr.konopelko@moosefs.pro>
 Signed-off-by: Aleksander Wieliczko <aleksander.wieliczko@moosefs.pro>

--- a/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
+++ b/SOURCES/0011-Avoid-usage-of-umount-in-ISOSR-when-legacy_mode-is-u.patch
@@ -1,7 +1,7 @@
 From dc7619735961b1fc0b7075cdc02ba375b76aa011 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Thu, 2 Dec 2021 09:28:37 +0100
-Subject: [PATCH 11/23] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
+Subject: [PATCH 11/24] Avoid usage of `umount` in `ISOSR` when `legacy_mode`
  is used
 
 `umount` should not be called when `legacy_mode` is enabled, otherwise a mounted dir

--- a/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
+++ b/SOURCES/0012-MooseFS-SR-uses-now-UUID-subdirs-for-each-SR.patch
@@ -1,7 +1,7 @@
 From a1341e33251ec40a12e0971ffeda8b935af0be93 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Wed, 18 May 2022 17:28:09 +0200
-Subject: [PATCH 12/23] MooseFS SR uses now UUID subdirs for each SR
+Subject: [PATCH 12/24] MooseFS SR uses now UUID subdirs for each SR
 
 A sm-config boolean param `subdir` is available to configure where to store the VHDs:
 - In a subdir with the SR UUID, the new behavior

--- a/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
+++ b/SOURCES/0013-Fix-is_open-call-for-many-drivers-25.patch
@@ -1,7 +1,7 @@
 From 58c1e5a82d1b943a94a1524e52fd8bf43e916e3e Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:36:36 +0200
-Subject: [PATCH 13/23] Fix is_open call for many drivers (#25)
+Subject: [PATCH 13/24] Fix is_open call for many drivers (#25)
 
 Ensure all shared drivers are imported in `_is_open` definition to register
 them in the driver list. Otherwise this function always fails with a SRUnknownType exception.

--- a/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
+++ b/SOURCES/0014-Remove-SR_CACHING-capability-for-many-SR-types-24.patch
@@ -1,7 +1,7 @@
 From 9d45a0e68acbcaec82a36c74f91dfa176b4fc7bf Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@gmail.com>
 Date: Thu, 23 Jun 2022 10:37:07 +0200
-Subject: [PATCH 14/23] Remove SR_CACHING capability for many SR types (#24)
+Subject: [PATCH 14/24] Remove SR_CACHING capability for many SR types (#24)
 
 SR_CACHING offers the capacity to use IntelliCache, but this
 feature is only available using NFS SR.

--- a/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
+++ b/SOURCES/0015-Remove-SR_PROBE-from-ZFS-capabilities-37.patch
@@ -1,7 +1,7 @@
 From ee2433b00bea733c8ec0d294ffb476e04e7e5bdb Mon Sep 17 00:00:00 2001
 From: BenjiReis <benjamin.reis@vates.fr>
 Date: Fri, 4 Aug 2023 12:10:08 +0200
-Subject: [PATCH 15/23] Remove `SR_PROBE` from ZFS capabilities (#37)
+Subject: [PATCH 15/24] Remove `SR_PROBE` from ZFS capabilities (#37)
 
 The probe method is not implemented so we
 shouldn't advertise it.

--- a/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
+++ b/SOURCES/0016-Fix-vdi-ref-when-static-vdis-are-used.patch
@@ -1,7 +1,7 @@
 From a14e7dbb656f0c722e85cacf4ad658695e086502 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Wed, 16 Aug 2023 13:42:21 +0200
-Subject: [PATCH 16/23] Fix vdi-ref when static vdis are used
+Subject: [PATCH 16/24] Fix vdi-ref when static vdis are used
 
 When static vdis are used there is no snapshots and we don't want to
 call method from XAPI.

--- a/SOURCES/0017-Tell-users-not-to-edit-multipath.conf-directly.patch
+++ b/SOURCES/0017-Tell-users-not-to-edit-multipath.conf-directly.patch
@@ -1,7 +1,7 @@
 From 1cf0c93a4e8c1de3688115954a8d4a8d4c25830d Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 27 Jan 2023 12:03:15 +0100
-Subject: [PATCH 17/23] Tell users not to edit multipath.conf directly
+Subject: [PATCH 17/24] Tell users not to edit multipath.conf directly
 
 This file is meant to remain unchanged and regularly updated along with
 the SM component. Users can create a custom configuration file in

--- a/SOURCES/0018-Add-custom.conf-multipath-configuration-file.patch
+++ b/SOURCES/0018-Add-custom.conf-multipath-configuration-file.patch
@@ -1,7 +1,7 @@
 From c8e7d59b6c9b68f9e5ef89d0ad87c157bb35c736 Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 27 Jan 2023 12:23:13 +0100
-Subject: [PATCH 18/23] Add custom.conf multipath configuration file
+Subject: [PATCH 18/24] Add custom.conf multipath configuration file
 
 Meant to be installed as /etc/multipath/conf.d/custom.conf for users
 to have an easy entry point for editing, as well as information on what

--- a/SOURCES/0019-Install-etc-multipath-conf.d-custom.conf.patch
+++ b/SOURCES/0019-Install-etc-multipath-conf.d-custom.conf.patch
@@ -1,7 +1,7 @@
 From 81b847dca6a48d73936592820a1a7b88ae1ff5cc Mon Sep 17 00:00:00 2001
 From: Samuel Verschelde <stormi-xcp@ylix.fr>
 Date: Fri, 25 Aug 2023 17:47:34 +0200
-Subject: [PATCH 19/23] Install /etc/multipath/conf.d/custom.conf
+Subject: [PATCH 19/24] Install /etc/multipath/conf.d/custom.conf
 
 Update Makefile so that the file is installed along with sm.
 

--- a/SOURCES/0020-Backport-NFS4-only-support.patch
+++ b/SOURCES/0020-Backport-NFS4-only-support.patch
@@ -1,7 +1,7 @@
 From fe5a7b355ea6820036cfeef3847b2bec28567632 Mon Sep 17 00:00:00 2001
 From: Benjamin Reis <benjamin.reis@vates.tech>
 Date: Mon, 18 Dec 2023 10:22:26 +0100
-Subject: [PATCH 20/23] Backport NFS4 only support
+Subject: [PATCH 20/24] Backport NFS4 only support
 
 See: https://github.com/xapi-project/sm/pull/617
 

--- a/SOURCES/0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
+++ b/SOURCES/0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
@@ -1,7 +1,7 @@
 From eea13526d4e202e395d1a4289f837b0171a73b8e Mon Sep 17 00:00:00 2001
 From: Benjamin Reis <benjamin.reis@vates.tech>
 Date: Mon, 18 Dec 2023 10:35:46 +0100
-Subject: [PATCH 21/23] Backport probe for NFS4 when rpcinfo does not include
+Subject: [PATCH 21/24] Backport probe for NFS4 when rpcinfo does not include
  it
 
 See: https://github.com/xapi-project/sm/pull/655

--- a/SOURCES/0022-feat-LargeBlock-backport-of-largeblocksr-51-55.patch
+++ b/SOURCES/0022-feat-LargeBlock-backport-of-largeblocksr-51-55.patch
@@ -1,7 +1,7 @@
 From 05e5ce03d6fd4523a942345cf49cc41eebaa78f7 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Tue, 7 May 2024 15:20:22 +0200
-Subject: [PATCH 22/23] feat(LargeBlock): backport of largeblocksr (#51) (#55)
+Subject: [PATCH 22/24] feat(LargeBlock): backport of largeblocksr (#51) (#55)
 
 A SR inheriting from a EXTSR allowing to use a 4KiB blocksize device as
 SR.

--- a/SOURCES/0023-feat-LVHDSR-add-a-way-to-modify-config-of-LVMs-56.patch
+++ b/SOURCES/0023-feat-LVHDSR-add-a-way-to-modify-config-of-LVMs-56.patch
@@ -1,7 +1,7 @@
 From bc8ee2e18aa6ba1a8923c09ff0d765f931ddc348 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.fr>
 Date: Tue, 28 May 2024 15:17:21 +0200
-Subject: [PATCH 23/23] feat(LVHDSR): add a way to modify config of LVMs (#56)
+Subject: [PATCH 23/24] feat(LVHDSR): add a way to modify config of LVMs (#56)
 
 With this change the driver supports a "lvm-conf" param on "other-config".
 For now The configuration is only used by "remove" calls from LVMCache.

--- a/SOURCES/0024-Fix-filter-to-reject-other-device-types-76.patch
+++ b/SOURCES/0024-Fix-filter-to-reject-other-device-types-76.patch
@@ -1,0 +1,23 @@
+From 3d71d7ea2b6df0f248d213c2c3bed28032f25abe Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 9 Jan 2025 17:41:22 +0100
+Subject: [PATCH 24/24] Fix filter to reject other device types (#76)
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LargeBlockSR.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/LargeBlockSR.py b/drivers/LargeBlockSR.py
+index 0fd1f345..e90108ed 100644
+--- a/drivers/LargeBlockSR.py
++++ b/drivers/LargeBlockSR.py
+@@ -215,7 +215,7 @@ class LargeBlockSR(EXTSR.EXTSR):
+         util.SMlog("Reconnecting VG {} to use emulated device".format(self.vgname))
+         try:
+             lvutil.setActiveVG(self.vgname, False)
+-            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"r|^/dev/nvme.*|\", \"a|/dev/loop.*|\" ] }")
++            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"a|/dev/loop.*|\", \"r|.*|\" ] }")
+         except util.CommandException as e:
+             xs_errors.XenError("LargeBlockVGReconnectFailed", opterr="Failed to reconnect the VolumeGroup {}, error: {}".format(self.vgname, e))
+ 

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -11,7 +11,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 2.30.8
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -121,6 +121,7 @@ Patch1020: 0020-Backport-NFS4-only-support.patch
 Patch1021: 0021-Backport-probe-for-NFS4-when-rpcinfo-does-not-includ.patch
 Patch1022: 0022-feat-LargeBlock-backport-of-largeblocksr-51-55.patch
 Patch1023: 0023-feat-LVHDSR-add-a-way-to-modify-config-of-LVMs-56.patch
+Patch1024: 0024-Fix-filter-to-reject-other-device-types-76.patch
 
 %description
 This package contains storage backends used in XCP
@@ -524,6 +525,9 @@ cp -r htmlcov %{buildroot}/htmlcov
 %{_unitdir}/linstor-monitor.service
 
 %changelog
+* Fri Jan 17 2025 Ronan Abhamon <ronan.abhamon@vates.tech> - 2.30.8-13.2
+- Add 0024-Fix-filter-to-reject-other-device-types-76.patch
+
 * Thu Oct 03 2024 Ronan Abhamon <ronan.abhamon@vates.tech> - 2.30.8-13.1
 - Sync with hotfix XS82ECU1075
 - Sync patches with our latest 2.30.8-8.2 branch


### PR DESCRIPTION
- Fix VG activation in LargeBlockSR for non-NVMe devices

Koji build (pre-release, v8.2-incoming): http://koji.xcp-ng.org/taskinfo?taskID=72741