### PR TITLE
RPM Release 3.2.3-1.16

### DIFF
--- a/SOURCES/0061-Fix-LVHDSR.load-set-other_conf-in-cond-branch-to-pre.patch
+++ b/SOURCES/0061-Fix-LVHDSR.load-set-other_conf-in-cond-branch-to-pre.patch
@@ -1,0 +1,34 @@
+From a91b15c95f80fb1a67c7ad6ce061b00caf26d493 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Wed, 8 Jan 2025 11:12:13 +0100
+Subject: [PATCH 61/64] Fix LVHDSR.load: set other_conf in cond-branch to
+ prevent mypy error
+
+Avoid:
+```
+drivers/LVHDSR.py:195: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
+drivers/LVHDSR.py:196: error: Value of type "Any | None" is not indexable  [index]
+```
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/LVHDSR.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/LVHDSR.py b/drivers/LVHDSR.py
+index 3e9afcd..66f9aac 100755
+--- a/drivers/LVHDSR.py
++++ b/drivers/LVHDSR.py
+@@ -166,10 +166,11 @@ class LVHDSR(SR.SR):
+         self.mdpath = os.path.join(self.path, self.MDVOLUME_NAME)
+         self.provision = self.PROVISIONING_DEFAULT
+
+-        self.other_conf = None
+         has_sr_ref = self.srcmd.params.get("sr_ref")
+         if has_sr_ref:
+             self.other_conf = self.session.xenapi.SR.get_other_config(self.sr_ref)
++        else:
++            self.other_conf = None
+
+         self.lvm_conf = None
+         if self.other_conf:

--- a/SOURCES/0062-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
+++ b/SOURCES/0062-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
@@ -1,0 +1,50 @@
+From 23df6a7fe591ba0a96f5f18a632168a2b3566344 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Thu, 9 Jan 2025 17:41:02 +0100
+Subject: [PATCH 62/64] fix(cleanup.py): protect LinstorSR init against race
+ condition (#79)
+
+During `LinstorSR` init, only create the journaler to make `should_preempt` happy.
+The volume manager MUST always be created in a SR lock context. Otherwise,
+we can trigger major issues.
+
+For example, a volume can be deleted from the KV-store by `cleanup.py` during a
+snapshot rollback. Very rare situation but which allowed this problem to be discovered.
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>
+---
+ drivers/cleanup.py | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/cleanup.py b/drivers/cleanup.py
+index f1341dc..01d44df 100755
+--- a/drivers/cleanup.py
++++ b/drivers/cleanup.py
+@@ -3221,7 +3221,7 @@ class LinstorSR(SR):
+
+         SR.__init__(self, uuid, xapi, createLock, force)
+         self.path = LinstorVolumeManager.DEV_ROOT_PATH
+-        self._reloadLinstor()
++        self._reloadLinstor(journaler_only=True)
+
+     @override
+     def deleteVDI(self, vdi) -> None:
+@@ -3256,7 +3256,7 @@ class LinstorSR(SR):
+         )
+         return super(LinstorSR, self).pauseVDIs(vdiList)
+
+-    def _reloadLinstor(self):
++    def _reloadLinstor(self, journaler_only=False):
+         session = self.xapi.session
+         host_ref = util.get_this_host_ref(session)
+         sr_ref = session.xenapi.SR.get_by_uuid(self.uuid)
+@@ -3273,6 +3273,9 @@ class LinstorSR(SR):
+             controller_uri, group_name, logger=util.SMlog
+         )
+
++        if journaler_only:
++            return
++
+         self._linstor = LinstorVolumeManager(
+             controller_uri,
+             group_name,

--- a/SOURCES/0063-Fix-filter-to-reject-other-device-types-77.patch
+++ b/SOURCES/0063-Fix-filter-to-reject-other-device-types-77.patch
@@ -1,0 +1,22 @@
+From ba46ff91ed0bc9d4002bd7fb06e46f08ca4a4c8a Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 9 Jan 2025 17:41:32 +0100
+Subject: [PATCH 63/64] Fix filter to reject other device types (#77)
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LargeBlockSR.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/LargeBlockSR.py b/drivers/LargeBlockSR.py
+index fa66cfc..449b2cf 100644
+--- a/drivers/LargeBlockSR.py
++++ b/drivers/LargeBlockSR.py
+@@ -224,7 +224,7 @@ class LargeBlockSR(EXTSR.EXTSR):
+         util.SMlog("Reconnecting VG {} to use emulated device".format(self.vgname))
+         try:
+             lvutil.setActiveVG(self.vgname, False)
+-            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"r|^/dev/nvme.*|\", \"a|/dev/loop.*|\" ] }")
++            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"a|/dev/loop.*|\", \"r|.*|\" ] }")
+         except util.CommandException as e:
+             xs_errors.XenError("LargeBlockVGReconnectFailed", opterr="Failed to reconnect the VolumeGroup {}, error: {}".format(self.vgname, e))

--- a/SOURCES/0064-feat-add-HPE-Nimble-multipath-configuration.patch
+++ b/SOURCES/0064-feat-add-HPE-Nimble-multipath-configuration.patch
@@ -1,0 +1,37 @@
+From 26be9451ec4989f4bde8d4a9b1bd5e6b6cd53e56 Mon Sep 17 00:00:00 2001
+From: Vincent Schwalbach <mail@vincent-schwalbach.de>
+Date: Tue, 16 Jul 2024 13:42:59 +0200
+Subject: [PATCH 65/65] feat: add HPE Nimble multipath configuration Added HPE
+ Nimble Configuration from the HPE Storage Toolkit for Linux
+
+Signed-off-by: Vincent Schwalbach <mail@vincent-schwalbach.de>
+(cherry picked from commit be6922f1626f2a3583872a4c51fef6dff07cdea3)
+---
+ multipath/multipath.conf | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/multipath/multipath.conf b/multipath/multipath.conf
+index 00a8f48..5800e36 100644
+--- a/multipath/multipath.conf
++++ b/multipath/multipath.conf
+@@ -156,4 +156,19 @@ devices {
+         prio                        alua
+         failback                    immediate
+     }
+-}
++    device {
++        vendor                      "Nimble"
++        product                     "Server"
++        path_grouping_policy        group_by_prio
++        prio                        "alua"
++        hardware_handler            "1 alua"
++        path_selector               "service-time 0"
++        path_checker                tur
++        no_path_retry               30
++        failback                    immediate
++        fast_io_fail_tmo            5
++        dev_loss_tmo                infinity
++        rr_min_io_rq                1
++        rr_weight                   uniform
++    }
++}

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -6,7 +6,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.3
-Release: 1.15%{?xsrel}%{?dist}
+Release: 1.16%{?xsrel}%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.3.tar.gz
@@ -106,6 +106,10 @@ Patch1057: 0057-Use-static-analysis-tool-mypy.patch
 Patch1058: 0058-Add-mypy-stubs.patch
 Patch1059: 0059-Use-override-everywhere.patch
 Patch1060: 0060-Makefile-fix-don-t-execute-precheck-during-installat.patch
+Patch0161: 0061-Fix-LVHDSR.load-set-other_conf-in-cond-branch-to-pre.patch
+Patch0162: 0062-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
+Patch0163: 0063-Fix-filter-to-reject-other-device-types-77.patch
+Patch1064: 0064-feat-add-HPE-Nimble-multipath-configuration.patch
 
 %description
 This package contains storage backends used in XCP
@@ -419,6 +423,12 @@ Manager and some other packages
 
 
 %changelog
+* Mon Jan 20 2025 Yann LE BRIS <yann.lebris@vates.tech> - 3.2.3-1.16
+- Add 0061-Fix-LVHDSR.load-set-other_conf-in-cond-branch-to-pre.patch
+- Add 0062-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
+- Add 0063-Fix-filter-to-reject-other-device-types-77.patch
+- Add 0064-feat-add-HPE-Nimble-multipath-configuration.patch
+
 * Thu Dec 19 2024 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.3-1.15
 - Fix missing mypy "@override" import in nfs-on-slave script
 


### PR DESCRIPTION
Adding patchs who can be release for 8.3:
- 0061-Fix-LVHDSR.load-set-other_conf-in-cond-branch-to-pre.patch
- 0062-fix-cleanup.py-protect-LinstorSR-init-against-race-c.patch
- 0063-Fix-filter-to-reject-other-device-types-77.patch
- 0064-feat-add-HPE-Nimble-multipath-configuration.patch (cherry-pick be6922f from xapi-project/sm)