### PR TITLE
Release 3.2.12-17.4

### DIFF
--- a/SOURCES/0139-Fix-vdi_type-and-image_format-for-udevSR.patch
+++ b/SOURCES/0139-Fix-vdi_type-and-image_format-for-udevSR.patch
@@ -1,0 +1,28 @@
+From a23c3f4e2e897f5c7b3e0d8f06f689b3dd1bc054 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Fri, 16 Jan 2026 15:47:27 +0100
+Subject: [PATCH] Fix vdi_type and image_format for udevSR
+
+Add `vdi_type` on udevVDI
+Add `image_format` for udevVDI
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/udevSR.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/udevSR.py b/drivers/udevSR.py
+index a8442764..e38260bd 100755
+--- a/drivers/udevSR.py
++++ b/drivers/udevSR.py
+@@ -153,6 +153,10 @@ class udevVDI(VDI.VDI):
+         self.utilisation = 0
+         self.label = self.path
+         self.sm_config = {}
++        self.vdi_type = "raw" # We give raw but there is a special case in blktap2.py:VDI.tap_wanted() for udevSR
++        self.image_format = "raw"
++        self.sm_config["image-format"] = self.image_format
++
+         try:
+             s = os.stat(self.path)
+             self.deleted = False

--- a/SOURCES/0140-Fix-cbtlog-on-FileSR.patch
+++ b/SOURCES/0140-Fix-cbtlog-on-FileSR.patch
@@ -1,0 +1,33 @@
+From d0a40774580e50d3f7b6aa829d92544045a120b2 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Fri, 17 Apr 2026 17:58:19 +0200
+Subject: [PATCH] Fix cbtlog on FileSR
+
+The `_get_blocktracking_status` function would return false if the `vdi_type`
+was something not referenced as being a COWImage. But in the case of
+`vdi-data-destroy` on FileSR, the `vdi_type` become `cbtlog` which would return
+False.
+As such, the call to `VDI.list_changed_blocks` would error saying the CBT are
+not related (the default error).
+The LVM-based SR appear to maintain the VDI type instead of using cbtlog here.
+
+This commit return the behaviour to the one before cowutil but with current interface.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/VDI.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/VDI.py b/drivers/VDI.py
+index b2a12d1b..4c2ef3c3 100755
+--- a/drivers/VDI.py
++++ b/drivers/VDI.py
+@@ -802,7 +802,7 @@ class VDI(object):
+         """ Get blocktracking status """
+         if not uuid:
+             uuid = self.uuid
+-        if not VdiType.isCowImage(self.vdi_type):
++        if self.vdi_type == VdiType.RAW:
+             return False
+         elif 'VDI_CONFIG_CBT' not in util.sr_get_capability(
+                 self.sr.uuid, session=self.sr.session):

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.4%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -223,6 +223,8 @@ Patch1135: 0135-fix-qcow2-fix-mirror-for-migration.patch
 Patch1136: 0136-fix-qcow2-Use-measure-to-compute-overhead-in-qcow2.patch
 Patch1137: 0137-fix-qcow2-Make-getDefaultPreallocationSizeVirt-retur.patch
 Patch1138: 0138-Add-missing-image-format-attr-on-snap-VDIs-113.patch
+Patch1139: 0139-Fix-vdi_type-and-image_format-for-udevSR.patch
+Patch1140: 0140-Fix-cbtlog-on-FileSR.patch
 
 %description
 This package contains storage backends used in XCP
@@ -546,6 +548,10 @@ then
 fi
 
 %changelog
+* Mon Apr 20 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-17.4
+- Add patch for cbtlog on FileSR
+- Add patch for udevSR not having a vdi_type
+
 * Wed Apr 15 2026 Philippe Coval <philippe.coval@vates.tech> - 3.2.12-17.3
 - fairlock: Fix upgrade warning by reloading service files
 


### PR DESCRIPTION
Add patches for cbtlog on FileSR and to add udevSR vdi_type

### Main information

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

This add patches:
- fixing a cbtlog regression making `list_changed_blocks` fail after using `VDI.data_destroy`  on FileSR
- fixing udevSR vdi_type missing and causing an error in `blktap2.py` when activating a udevSR VDI

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

Important fix for 8.3-next

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

---

### Release Notes and Documentation

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Tests reproducing the regression passed.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

User that tested backups with purged data being enable should see the situation fix itself, it might be needed to reset the CBT chain.


#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

At the moment, no tests for CBT exists

#### What tests have been or will be added to CI for this change? If none, explain why.

Tests are being added.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
