### PR TITLE
Release 3.2.12-17.6

### DIFF
--- a/SOURCES/0142-fix-qcow2-Set-the-max-size-to-be-under-16TiB.patch
+++ b/SOURCES/0142-fix-qcow2-Set-the-max-size-to-be-under-16TiB.patch
@@ -1,0 +1,31 @@
+From 2e7a0602dd75e9a030389f2fc8ee1f5e09e5650d Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 23 Apr 2026 17:55:17 +0200
+Subject: [PATCH] fix(qcow2): Set the max size to be under 16TiB
+
+The previous max size would mean that the fully allocated VDI would be over 16TiB.
+A EXTSR max file size is 16TiB (with default configuration) and the VDI would
+not be able to grow to max size.
+It's temporary waiting for an implementation that would define the max size to
+be SR type specific.
+This max virtual size mean the fully allocated VDI size will be under 16TiB
+including metadata.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/qcow2util.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
+index c696041e..e8280563 100755
+--- a/drivers/qcow2util.py
++++ b/drivers/qcow2util.py
+@@ -41,7 +41,7 @@ QCOW2_DEFAULT_CLUSTER_SIZE: Final = 64 * 1024 # 64 KiB
+ 
+ MIN_QCOW_SIZE: Final = QCOW2_DEFAULT_CLUSTER_SIZE
+ 
+-MAX_QCOW_SIZE: Final = 16 * 1024 * 1024 * 1024 * 1024
++MAX_QCOW_SIZE: Final = 17589500641280 # Max size so that the fully allocated size with metadata is under the max size of EXT4 (17592185061376 bytes fully allocated)
+ 
+ QEMU_IMG: Final = "/usr/bin/qemu-img"
+ QCOW2_HELPER = "/opt/xensource/libexec/qcow2_helper"

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.5%{?dist}
+Release: %{?xsrel}.6%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -226,6 +226,8 @@ Patch1138: 0138-fix-qcow2-Make-getDefaultPreallocationSizeVirt-retur.patch
 Patch1139: 0139-Add-missing-image-format-attr-on-snap-VDIs-113.patch
 Patch1140: 0140-Fix-vdi_type-and-image_format-for-udevSR.patch
 Patch1141: 0141-Fix-cbtlog-on-FileSR.patch
+Patch1142: 0142-fix-qcow2-Set-the-max-size-to-be-under-16TiB.patch
+
 
 %description
 This package contains storage backends used in XCP
@@ -549,6 +551,9 @@ then
 fi
 
 %changelog
+* Fri Apr 24 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-17.6
+- Limit the max size of QCOW2 VDI to be under 16TiB for compatibility with EXTSR
+
 * Tue Apr 21 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-17.5
 - Add 0101-fix-LVMSR-deactivate-unused-LVM-snap-base-before-del.patch
 


### PR DESCRIPTION
This build is to limit QCOW2 VDI max size to be 16TiB with metadata to allow compatibility with EXTSR (EXTSR is limited to 16TiB unique file size)

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3215

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

ANSWER, or N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

If we have a full QCOW2 VDI, we would not be able to migrate it to an EXTSR without this limitation.

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

If we have a full QCOW2 VDI, we would not be able to migrate it to an EXTSR without this limitation.
It's a temporary limitation until we can find a better solution.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

#### Documentation update needed

- [X] Yes
- [ ] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

QCOW2 FAQ and documentation should speak about this limitation and why.

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: LINKS, TODO, or N/A.

---

### Testing and regression avoidance

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Test with max size in xcp-ng-tests

#### What tests have been or will be added to CI for this change? If none, explain why.

Limitation for max size in the test is being changed.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->

---

Koji build(v8.3-incoming, scratch): https://koji.xcp-ng.org/taskinfo?taskID=104151