### PR TITLE
Release 3.2.12-17.7

### DIFF
--- a/SOURCES/0129-feat-qcow2-Add-QCOW2-support.patch
+++ b/SOURCES/0129-feat-qcow2-Add-QCOW2-support.patch
@@ -1,4 +1,4 @@
-From 5ea4ce5876b58d60ab3f8b8f208fc4d0b616ee12 Mon Sep 17 00:00:00 2001
+From c772e4bc6d25f5f054b567e32506a72bda9536f6 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Sun, 15 Mar 2026 17:08:51 +0100
 Subject: [PATCH] feat(qcow2): Add QCOW2 support
@@ -158,7 +158,7 @@ index f8e8a8b0..d68d9c77 100755
      assert False, f"Unsupported image format: {image_format}"
  
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index 80b9e1a9..9f485908 100755
+index 80b9e1a9..a9bcd925 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -14,24 +14,431 @@
@@ -990,7 +990,7 @@ index 80b9e1a9..9f485908 100755
 +        if size < 0 or size > MAX_QCOW_SIZE:
 +            raise xs_errors.XenError(
 +                "VDISize",
-+                opterr="VDI size must be between {} MB and {} MB".format(MIN_QCOW_SIZE // (1024*1024), MAX_QCOW_SIZE // (1024 * 1024))
++                opterr="VDI size must be between 1 MB and {} MB".format(MAX_QCOW_SIZE // (1024 * 1024))
 +            )
 +
 +        return util.roundup(QCOW_CLUSTER_SIZE, size)

--- a/SOURCES/0130-feat-qcow2-Add-coalesce-with-call-to-tapdisk.patch
+++ b/SOURCES/0130-feat-qcow2-Add-coalesce-with-call-to-tapdisk.patch
@@ -1,4 +1,4 @@
-From 030a57632a2a29557e659d80f9da745992836f3f Mon Sep 17 00:00:00 2001
+From bc6bc610ccf812f8730ec45aaa2099462e7e73e8 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Fri, 14 Feb 2025 17:01:16 +0100
 Subject: [PATCH] feat(qcow2): Add coalesce with call to tapdisk
@@ -811,7 +811,7 @@ index f84034bc..0fc4f499 100755
 +        "cancel_coalesce_master": cancel_coalesce_master,
 +        })
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index 9f485908..a2bbe68f 100755
+index a9bcd925..54878aa9 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -14,20 +14,23 @@

--- a/SOURCES/0131-feat-qcow2-Add-qcow2helper.patch
+++ b/SOURCES/0131-feat-qcow2-Add-qcow2helper.patch
@@ -1,4 +1,4 @@
-From cc37e22698bf40487668566cf9bab74c3790f949 Mon Sep 17 00:00:00 2001
+From ba8dd4c95474fb0dd535dfa4ab7ed9d13fdeb043 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Wed, 25 Jun 2025 17:00:22 +0200
 Subject: [PATCH] feat(qcow2): Add qcow2helper
@@ -43,7 +43,7 @@ index 4669979f..afa87a03 100755
  	$(MAKE) -C sm_typing install DESTDIR=$(SM_STAGING)
  	ln -sf $(SM_DEST)blktap2.py $(SM_STAGING)$(BIN_DEST)/blktap2
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index a2bbe68f..49da9917 100755
+index 54878aa9..8cf2a7f9 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -43,6 +43,7 @@ MIN_QCOW_SIZE: Final = QCOW_CLUSTER_SIZE

--- a/SOURCES/0132-fix-MooseFSSR-type-hint-fix.patch
+++ b/SOURCES/0132-fix-MooseFSSR-type-hint-fix.patch
@@ -1,4 +1,4 @@
-From 9ae18d97c6b62400c6dde090962e8fa5e389a87a Mon Sep 17 00:00:00 2001
+From 8e5e4537e3a55efe277afedd203db7c5cf390de2 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Wed, 2 Jul 2025 14:58:46 +0200
 Subject: [PATCH] fix(MooseFSSR): type hint fix

--- a/SOURCES/0133-feat-qcow2-Remove-limitation-on-blocksize.patch
+++ b/SOURCES/0133-feat-qcow2-Remove-limitation-on-blocksize.patch
@@ -1,4 +1,4 @@
-From dac09eacf4e2c9b6b91651c1a881483f06e28af7 Mon Sep 17 00:00:00 2001
+From 6f69a459c4399336d6697ef2d68a391601b24658 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Tue, 19 Aug 2025 15:21:43 +0200
 Subject: [PATCH] feat(qcow2): Remove limitation on blocksize
@@ -30,7 +30,7 @@ index e2b44935..a1d59c01 100755
  
      @abstractmethod
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index 49da9917..037bb51b 100755
+index 8cf2a7f9..b74ba8b6 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -36,9 +36,9 @@ from constants import NS_PREFIX_LVM, VG_PREFIX
@@ -134,7 +134,7 @@ index 49da9917..037bb51b 100755
          self.setHidden(path, False) #We add hidden header at creation
  
 @@ -863,7 +866,7 @@ class QCowUtil(CowUtil):
-                 opterr="VDI size must be between {} MB and {} MB".format(MIN_QCOW_SIZE // (1024*1024), MAX_QCOW_SIZE // (1024 * 1024))
+                 opterr="VDI size must be between 1 MB and {} MB".format(MAX_QCOW_SIZE // (1024 * 1024))
              )
  
 -        return util.roundup(QCOW_CLUSTER_SIZE, size)

--- a/SOURCES/0134-fix-coalesce-Big-vhd-blocks-cause-exception.patch
+++ b/SOURCES/0134-fix-coalesce-Big-vhd-blocks-cause-exception.patch
@@ -1,4 +1,4 @@
-From df4054477b8c01c926d314405bfe8dd167357948 Mon Sep 17 00:00:00 2001
+From 6a5772249cc3b84429153a02ecdf84522cb27b24 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Mon, 25 Aug 2025 17:07:34 +0200
 Subject: [PATCH] fix(coalesce): Big vhd-blocks cause exception

--- a/SOURCES/0135-feat-qcow2_helper-support-extended_l2-feature.patch
+++ b/SOURCES/0135-feat-qcow2_helper-support-extended_l2-feature.patch
@@ -1,4 +1,4 @@
-From 6c0a5161ce1251b575c8fa5a66a49d3d78b92425 Mon Sep 17 00:00:00 2001
+From 63fbc5a4732dd76b7db88956cca0c88ba0e11365 Mon Sep 17 00:00:00 2001
 From: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
 Date: Sat, 27 Sep 2025 00:08:29 +0200
 Subject: [PATCH] feat(qcow2_helper): support extended_l2 feature

--- a/SOURCES/0136-fix-qcow2-fix-mirror-for-migration.patch
+++ b/SOURCES/0136-fix-qcow2-fix-mirror-for-migration.patch
@@ -1,4 +1,4 @@
-From 9699fe3984bf923c0a53a02fa2752b22330d936f Mon Sep 17 00:00:00 2001
+From 73335c6ba992f1da72032b8e9745cb1e640ed6c1 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Tue, 30 Sep 2025 10:45:17 +0200
 Subject: [PATCH] fix(qcow2): fix mirror for migration
@@ -201,7 +201,7 @@ index a1d59c01..daf8842e 100755
          pass
  
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index 037bb51b..4892d608 100755
+index b74ba8b6..a7d4adc3 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -812,16 +812,38 @@ class QCowUtil(CowUtil):

--- a/SOURCES/0137-fix-qcow2-Use-measure-to-compute-overhead-in-qcow2.patch
+++ b/SOURCES/0137-fix-qcow2-Use-measure-to-compute-overhead-in-qcow2.patch
@@ -1,4 +1,4 @@
-From cd50bcdedde62391a9a1f9880570baa4e39ba45f Mon Sep 17 00:00:00 2001
+From debafc6b707900e66c59966e35adbd94c6baf935 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Mon, 6 Oct 2025 14:37:32 +0200
 Subject: [PATCH] fix(qcow2): Use measure to compute overhead in qcow2
@@ -30,7 +30,7 @@ index daf8842e..84874df8 100755
  
      @abstractmethod
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index 4892d608..2178527c 100755
+index a7d4adc3..7d08edde 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -23,6 +23,7 @@ import re

--- a/SOURCES/0138-fix-qcow2-Make-getDefaultPreallocationSizeVirt-retur.patch
+++ b/SOURCES/0138-fix-qcow2-Make-getDefaultPreallocationSizeVirt-retur.patch
@@ -1,4 +1,4 @@
-From 24d76a1058a04d4869a49b3d0ade588e8c5fe33a Mon Sep 17 00:00:00 2001
+From 8af3c01b9e96b86c0fd03e11e06cbc83e02a7b20 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Mon, 6 Oct 2025 17:07:11 +0200
 Subject: [PATCH] fix(qcow2): Make getDefaultPreallocationSizeVirt return
@@ -10,7 +10,7 @@ Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index 2178527c..c696041e 100755
+index 7d08edde..0e254f27 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -450,7 +450,8 @@ class QCowUtil(CowUtil):

--- a/SOURCES/0139-Add-missing-image-format-attr-on-snap-VDIs-113.patch
+++ b/SOURCES/0139-Add-missing-image-format-attr-on-snap-VDIs-113.patch
@@ -1,4 +1,4 @@
-From ba9c87f67dc9c6106db907e585dc646b34a4a2b8 Mon Sep 17 00:00:00 2001
+From 59b499f7a0d6ee1066e08a47d3806181b375985c Mon Sep 17 00:00:00 2001
 From: Goulven Riou <goulven.riou@vates.tech>
 Date: Tue, 16 Dec 2025 15:05:24 +0100
 Subject: [PATCH] Add missing image-format attr on snap VDIs (#113)

--- a/SOURCES/0140-Fix-vdi_type-and-image_format-for-udevSR.patch
+++ b/SOURCES/0140-Fix-vdi_type-and-image_format-for-udevSR.patch
@@ -1,4 +1,4 @@
-From d710f2b6ccc3bd43d704b5dd6bb2e3ec083f6b7b Mon Sep 17 00:00:00 2001
+From b4afc437c6c5e710b768763cf467a0adf2ebc965 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Fri, 16 Jan 2026 15:47:27 +0100
 Subject: [PATCH] Fix vdi_type and image_format for udevSR

--- a/SOURCES/0141-Fix-cbtlog-on-FileSR.patch
+++ b/SOURCES/0141-Fix-cbtlog-on-FileSR.patch
@@ -1,4 +1,4 @@
-From 043a9eb99ebe993c7a236d37ed1ae42887a27304 Mon Sep 17 00:00:00 2001
+From 3a91e13deef5dc03b00a29e20336c97f600e61c8 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Fri, 17 Apr 2026 17:58:19 +0200
 Subject: [PATCH] Fix cbtlog on FileSR

--- a/SOURCES/0142-fix-qcow2-Set-the-max-size-to-be-under-16TiB.patch
+++ b/SOURCES/0142-fix-qcow2-Set-the-max-size-to-be-under-16TiB.patch
@@ -1,4 +1,4 @@
-From 2e7a0602dd75e9a030389f2fc8ee1f5e09e5650d Mon Sep 17 00:00:00 2001
+From 68945266259040ce15444e84c63a67400901c9ae Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Thu, 23 Apr 2026 17:55:17 +0200
 Subject: [PATCH] fix(qcow2): Set the max size to be under 16TiB
@@ -17,7 +17,7 @@ Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
-index c696041e..e8280563 100755
+index 0e254f27..2f27ea93 100755
 --- a/drivers/qcow2util.py
 +++ b/drivers/qcow2util.py
 @@ -41,7 +41,7 @@ QCOW2_DEFAULT_CLUSTER_SIZE: Final = 64 * 1024 # 64 KiB

--- a/SOURCES/0143-fix-LVMSR-activate-chain-for-QCOW2-resize.patch
+++ b/SOURCES/0143-fix-LVMSR-activate-chain-for-QCOW2-resize.patch
@@ -1,0 +1,41 @@
+From d7caeef812c24936565a474a77ef476cca9e5862 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 23 Apr 2026 17:36:55 +0200
+Subject: [PATCH] fix(LVMSR): activate chain for QCOW2 resize
+
+In QCOW2, the resize need to read the backing chain.
+It meant that resizing a VDI with snapshot would fail on LVMSR.
+With these changes, we activate the chain while we do the resize to avoid
+failing on the resize.
+```
+Apr 22 16:47:15 r620-x1 SM: [384495][MainThread] Raising exception [110, VDI resize failed [opterr=Command ['/usr/bin/qemu-img', 'resize', '/dev/VG_XenStorage-454b5ad1-f870-deb1-7521-c8612edcc565/QCOW2-04d972bd-8bd1-4bdf-9047-8099d837024f', '3221225472'] failed (): Operation not permitted]]
+```
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LVMSR.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/LVMSR.py b/drivers/LVMSR.py
+index e545ff6f..16d6d36e 100755
+--- a/drivers/LVMSR.py
++++ b/drivers/LVMSR.py
+@@ -1597,6 +1597,9 @@ class LVMVDI(VDI.VDI):
+         else:
+             if lvSizeNew != lvSizeOld:
+                 self.lvmcowutil.inflate(self.sr.journaler, self.sr.uuid, self.uuid, self.vdi_type, lvSizeNew)
++            if self.vdi_type == VdiType.QCOW2:
++                # We only do this for QCOW2 since qemu-img need to read the chain to resize
++                self._chainSetActive(True, True)
+             self.cowutil.setSizeVirtFast(self.path, size)
+             self.size = self.cowutil.getSizeVirt(self.path)
+             self.utilisation = self.sr.lvmCache.getSize(self.lvname)
+@@ -1607,6 +1610,8 @@ class LVMVDI(VDI.VDI):
+                 str(self.utilisation))
+         self.sr._updateStats(self.sr.uuid, self.size - oldSize)
+         super(LVMVDI, self).resize_cbt(self.sr.uuid, self.uuid, self.size)
++        if self.vdi_type == VdiType.QCOW2:
++            self._chainSetActive(False, True)
+         return VDI.VDI.get_params(self)
+ 
+     @override

--- a/SOURCES/0144-Fix-qcow2util-fix-exception-handling-in-coalesceOnli.patch
+++ b/SOURCES/0144-Fix-qcow2util-fix-exception-handling-in-coalesceOnli.patch
@@ -1,0 +1,38 @@
+From 81b687f431e07dec8c42ffe30347fd0e537f4ab6 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Tue, 28 Apr 2026 18:08:39 +0200
+Subject: [PATCH] Fix(qcow2util): fix exception handling in coalesceOnline
+
+The previous exception handling didn't make a difference between commit failing
+or query failing. This change the log to mark the difference.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/qcow2util.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
+index 2f27ea93..5ffe64c5 100755
+--- a/drivers/qcow2util.py
++++ b/drivers/qcow2util.py
+@@ -755,7 +755,11 @@ class QCowUtil(CowUtil):
+             # We need to wait for query to return concluded
+             # We are technically ininterruptible since being interrupted will only stop checking if the job is done.
+             # We need to call `tap-ctl cancel` if we are interrupted, it is done in cleanup.py code.
++        except TapCtl.CommandFailure:
++            util.SMlog(f"Commit command failed on tapdisk instance {pid} (m: {minor}). Raising...")
++            raise
+ 
++        try:
+             status, nb, _ = TapCtl.query(pid, minor)
+             if status == "undefined":
+                 util.SMlog("Tapdisk {} (m: {}) coalesce status undefined for {}".format(pid, minor, path))
+@@ -767,7 +771,7 @@ class QCowUtil(CowUtil):
+                 logger.log("Got status {} for tapdisk {} (m: {})".format(status, pid, minor))
+             return nb
+         except TapCtl.CommandFailure:
+-            util.SMlog("Query command failed on tapdisk instance {}. Raising...".format(pid))
++            util.SMlog(f"Query command failed on tapdisk instance {pid} (m: {minor}). Raising...")
+             raise
+ 
+     @override

--- a/SOURCES/0145-feat-use-preferred-image-formats-as-a-list.patch
+++ b/SOURCES/0145-feat-use-preferred-image-formats-as-a-list.patch
@@ -1,0 +1,68 @@
+From 797a4ed906f122e9287b0425b9439382edf80b2b Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Wed, 29 Apr 2026 11:55:48 +0200
+Subject: [PATCH] feat: use preferred-image-formats as a list
+
+The preferred image formats input is a list but wasn't used as such.
+This commit add the check for the first image format in the list that will
+accept the size when no image format is manually chosen.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/FileSR.py | 19 +++++++++++++++++--
+ drivers/LVMSR.py  | 12 +++++++++++-
+ 2 files changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/FileSR.py b/drivers/FileSR.py
+index 0a8f6a74..942b0425 100755
+--- a/drivers/FileSR.py
++++ b/drivers/FileSR.py
+@@ -511,8 +511,23 @@ class FileVDI(VDI.VDI):
+                     self.vdi_type = vdi_type
+ 
+             if not self.vdi_type:
+-                self.vdi_type = getVdiTypeFromImageFormat(self.sr.preferred_image_formats[0])
+-            self.cowutil = getCowUtil(self.vdi_type)
++                size = int(self.sr.srcmd.params['args'][0])
++                # In the case of vdi_create, the first parameter is size.
++                # We need it to validate the vdi_type choice
++                for image_format in self.sr.preferred_image_formats:
++                    vdi_type = getVdiTypeFromImageFormat(image_format)
++                    cowutil = getCowUtil(vdi_type)
++                    try:
++                        cowutil.validateAndRoundImageSize(size)
++                        break
++                    except xs_errors.SROSError:
++                        util.SMlog(f"We won't be able to create the VDI with format {vdi_type}.")
++                        # If the last one also fail we still give the vdi_type and cowutil,
++                        # it will fail in the `create` function instead when re-running `validateAndRoundImageSize`
++                self.vdi_type = vdi_type
++                self.cowutil = cowutil
++            else:
++                self.cowutil = getCowUtil(self.vdi_type)
+             self.path = os.path.join(self.sr.path, "%s%s" %
+                 (vdi_uuid, VDI_TYPE_TO_EXTENSION[self.vdi_type]))
+         else:
+diff --git a/drivers/LVMSR.py b/drivers/LVMSR.py
+index 16d6d36e..5d48528b 100755
+--- a/drivers/LVMSR.py
++++ b/drivers/LVMSR.py
+@@ -1372,7 +1372,17 @@ class LVMVDI(VDI.VDI):
+                     raise xs_errors.XenError('VDICreate', opterr='Cannot create COW type disk in legacy mode')
+ 
+         if not self.vdi_type:
+-            self._setType(getVdiTypeFromImageFormat(self.sr.preferred_image_formats[0]))
++            size = int(self.sr.srcmd.params['args'][0])
++            # In the case of vdi_create, the first parameter is size.
++            # We need it to validate the vdi_type choice
++            for image_format in self.sr.preferred_image_formats:
++                vdi_type = getVdiTypeFromImageFormat(image_format)
++                self._setType(vdi_type)
++                try:
++                    self.cowutil.validateAndRoundImageSize(size)
++                    break
++                except xs_errors.SROSError:
++                    util.SMlog(f"We won't be able to create the VDI with format {vdi_type}.")
+ 
+         self.lvname = "%s%s" % (LV_PREFIX[self.vdi_type], vdi_uuid)
+         self.path = os.path.join(self.sr.path, self.lvname)

--- a/SOURCES/0146-fix-cleanup-online-coalesce-would-crash.patch
+++ b/SOURCES/0146-fix-cleanup-online-coalesce-would-crash.patch
@@ -1,0 +1,51 @@
+From dadb99c4d6c08deaf5a20c869e4e37ae6acdfc89 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Wed, 29 Apr 2026 19:16:36 +0200
+Subject: [PATCH] fix(cleanup): online coalesce would crash
+
+On a LVMSR, the online coalesce would try to get the parent from children to
+know if they needed offline relink but these child LVs weren't enabled.
+We add a override for getParent where we activate the LV.
+We also remove some validate from _doCoalesceOnHost since we shouldn't do a
+validate on a QCOW2 being used, it can lead to wrongly assume a VDI corrupted.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/cleanup.py | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/cleanup.py b/drivers/cleanup.py
+index 04ea2c98..a8271ee2 100755
+--- a/drivers/cleanup.py
++++ b/drivers/cleanup.py
+@@ -859,8 +859,6 @@ class VDI(object):
+             raise
+ 
+     def _doCoalesceOnHost(self, hostRef):
+-        self.validate()
+-        self.parent.validate(True)
+         self.parent._increaseSizeVirt(self.sizeVirt)
+         self.sr._updateSlavesOnResize(self.parent)
+         #TODO: We might need to make the LV RW on the slave directly for coalesce?
+@@ -884,7 +882,6 @@ class VDI(object):
+         Util.runAbortable(lambda: self._call_plugin_coalesce(hostRef), \
+                           None, self.sr.uuid, abortTest, VDI.POLL_INTERVAL, 0, prefSig=signal.SIGTERM)
+ 
+-        self.parent.validate(True)
+         #self._verifyContents(0)
+         self.parent.updateBlockInfo()
+ 
+@@ -1654,6 +1651,13 @@ class LVMVDI(VDI):
+         self._activate()
+         return VDI._queryCowBlocks(self)
+ 
++    @override
++    def getParent(self) -> str:
++        self._activate()
++        parent = VDI.getParent(self)
++        self._deactivate()
++        return parent
++
+     @override
+     def _calcExtraSpaceForCoalescing(self) -> int:
+         if not VdiType.isCowImage(self.parent.vdi_type):

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.6%{?dist}
+Release: %{?xsrel}.7%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -227,6 +227,10 @@ Patch1139: 0139-Add-missing-image-format-attr-on-snap-VDIs-113.patch
 Patch1140: 0140-Fix-vdi_type-and-image_format-for-udevSR.patch
 Patch1141: 0141-Fix-cbtlog-on-FileSR.patch
 Patch1142: 0142-fix-qcow2-Set-the-max-size-to-be-under-16TiB.patch
+Patch1143: 0143-fix-LVMSR-activate-chain-for-QCOW2-resize.patch
+Patch1144: 0144-Fix-qcow2util-fix-exception-handling-in-coalesceOnli.patch
+Patch1145: 0145-feat-use-preferred-image-formats-as-a-list.patch
+Patch1146: 0146-fix-cleanup-online-coalesce-would-crash.patch
 
 
 %description
@@ -551,6 +555,12 @@ then
 fi
 
 %changelog
+* Thu Apr 30 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-17.7
+- Add 0143-fix-LVMSR-activate-chain-for-QCOW2-resize.patch
+- Add 0144-Fix-qcow2util-fix-exception-handling-in-coalesceOnli.patch
+- Add 0145-feat-use-preferred-image-formats-as-a-list.patch
+- Add 0146-fix-cleanup-online-coalesce-would-crash.patch
+
 * Fri Apr 24 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-17.6
 - Limit the max size of QCOW2 VDI to be under 16TiB for compatibility with EXTSR
 


### PR DESCRIPTION
Add a few patches for QCOW2:
- a fix for resizing a VDI with snapshots on LVMSR
- a fix for online coalesce on LVMSR
- a fix for online coalesce that could fail thinking a QCOW2 was corrupted
- a new feature to handle `device-config:preferred-image-formats` as a list of authorized formats on a SR

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3208
XCPNG-2862

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

This add a few fixes and feature aimed at QCOW2:
a few fixes for online coalesce (one related to LVMSR)
a change on error message during online coalesce to be clearer
a fix for VDI resize on LVMSR when VDI has snapshots
a change to handle `device-config:preferred-image-formats` as a list of authorized image formats on a SR

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

A few fixes for QCOW2 coalesce 
A VDI with snapshot on LVMSR would fail to resize because the parent was inaccessible
`device-config:preferred-image-formats` is now treated as a list of authorized image formats on a SR.
If it's `vhd,qcow2` then the storage layer will see if the size of the image is possible for VHD otherwise it will create a QCOW2. This only happen if `sm-config:image-format` isn't given to the `VDI.create` command.



#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

No change needed

#### Documentation update needed

- [X] Yes
- [ ] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

The handling of `device-config:preferred-image-formats` should be made clear for user that wants to use it.

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: LINKS, TODO, or N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Manually resizing a LVMVDI QCOW2 with snapshots
Manipulating `device-config:preferred-image-formats` while observing the result of a VDI creation

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

QCOW2 tests

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Coalesce tests and resize tests

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->

Koji build(v8.3-incoming, scratch): https://koji.xcp-ng.org/taskinfo?taskID=104497