### PR TITLE
Release 3.2.12-17.8

### DIFF
--- a/SOURCES/0147-fix-linstor-add-backward-compatibility-for-getInfo.patch
+++ b/SOURCES/0147-fix-linstor-add-backward-compatibility-for-getInfo.patch
@@ -1,0 +1,57 @@
+From a44decc471e41e7b6a0f619fcf57fb30f75837e8 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.tech>
+Date: Wed, 6 May 2026 11:47:37 +0200
+Subject: [PATCH] fix(linstor): add backward compatibility for `getInfo`
+
+`getInfo` is not available on versions without QCOW2 support, we must use `getVHDInfo` instead.
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.tech>
+---
+ drivers/linstor-manager   |  2 ++
+ drivers/linstorcowutil.py | 17 ++++++++++++++++-
+ 2 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/linstor-manager b/drivers/linstor-manager
+index 8369d311..d6b9cd13 100755
+--- a/drivers/linstor-manager
++++ b/drivers/linstor-manager
+@@ -1257,6 +1257,8 @@ if __name__ == '__main__':
+         # DRBDs, otherwise we still have EROFS errors...
+         'check': check,
+         'getInfo': get_info,
++        # Backward compatibility with non-QCOW2 versions.
++        'getVHDInfo': get_info,
+         'hasParent': has_parent,
+         'getParent': get_parent,
+         'getSizeVirt': get_size_virt,
+diff --git a/drivers/linstorcowutil.py b/drivers/linstorcowutil.py
+index 1aa35d8c..941d6de5 100644
+--- a/drivers/linstorcowutil.py
++++ b/drivers/linstorcowutil.py
+@@ -231,10 +231,25 @@ class LinstorCowUtil(object):
+             'includeParent': include_parent,
+             'resolveParent': False
+         }
+-        return self._get_info(vdi_uuid, self._extract_uuid, **kwargs)
++
++        try:
++            return self._get_info(vdi_uuid, self._extract_uuid, **kwargs)
++        except Exception as e:
++            # Backward compatibility with non-QCOW2 versions.
++            if str(e).startswith("['UNKNOWN_XENAPI_PLUGIN_FUNCTION', 'getInfo']"):
++                return self._get_vhd_info(vdi_uuid, self._extract_uuid, **kwargs)
++            raise
+ 
+     @linstorhostcall('getInfo')
+     def _get_info(self, vdi_uuid, response):
++        return self._get_info_impl(vdi_uuid, response)
++
++    # Backward compatibility with non-QCOW2 versions.
++    @linstorhostcall('getVHDInfo')
++    def _get_vhd_info(self, vdi_uuid, response):
++        return self._get_info_impl(vdi_uuid, response)
++
++    def _get_info_impl(self, vdi_uuid, response):
+         obj = json.loads(response)
+ 
+         image_info = CowImageInfo(vdi_uuid)

--- a/SOURCES/0148-fix-linstor-add-backward-compatibility-for-manager-p.patch
+++ b/SOURCES/0148-fix-linstor-add-backward-compatibility-for-manager-p.patch
@@ -1,0 +1,186 @@
+From 5c7fc1cd8972973befac6962c1a4d45219752401 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.tech>
+Date: Wed, 6 May 2026 12:05:08 +0200
+Subject: [PATCH] fix(linstor): add backward compatibility for manager plugin
+
+`vdiType` is not defined on versions without QCOW2 support.
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.tech>
+---
+ drivers/linstor-manager | 44 +++++++++++++++++++++++++----------------
+ 1 file changed, 27 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/linstor-manager b/drivers/linstor-manager
+index d6b9cd13..52711ff0 100755
+--- a/drivers/linstor-manager
++++ b/drivers/linstor-manager
+@@ -296,6 +296,16 @@ def extract_uuid(linstor, device_path):
+ 
+ # ------------------------------------------------------------------------------
+ 
++def get_args_vdi_type(args):
++    # Backward compatibility with non-QCOW2 versions.
++    # `vdiType` is not defined on previous versions.
++    return args.get('vdiType') or 'vhd'
++
++def get_cow_util_from_args(args):
++    return getCowUtil(get_args_vdi_type(args))
++
++# ------------------------------------------------------------------------------
++
+ 
+ def prepare_sr(session, args):
+     try:
+@@ -400,7 +410,7 @@ def destroy(session, args):
+ 
+ def check(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         ignore_missing_footer = util.strtobool(
+             args['ignoreMissingFooter']
+@@ -414,7 +424,7 @@ def check(session, args):
+ 
+ def get_info(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         group_name = args['groupName']
+         include_parent = util.strtobool(args['includeParent'])
+@@ -436,7 +446,7 @@ def get_info(session, args):
+ 
+ def has_parent(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.hasParent(device_path))
+     except Exception as e:
+@@ -446,7 +456,7 @@ def has_parent(session, args):
+ 
+ def get_parent(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         group_name = args['groupName']
+ 
+@@ -464,7 +474,7 @@ def get_parent(session, args):
+ 
+ def get_size_virt(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.getSizeVirt(device_path))
+     except Exception as e:
+@@ -474,7 +484,7 @@ def get_size_virt(session, args):
+ 
+ def get_size_phys(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.getSizePhys(device_path))
+     except Exception as e:
+@@ -484,7 +494,7 @@ def get_size_phys(session, args):
+ 
+ def get_allocated_size(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.getAllocatedSize(device_path))
+     except Exception as e:
+@@ -494,7 +504,7 @@ def get_allocated_size(session, args):
+ 
+ def get_max_resize_size(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.getMaxResizeSize(device_path))
+     except Exception as e:
+@@ -504,7 +514,7 @@ def get_max_resize_size(session, args):
+ 
+ def get_depth(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.getDepth(device_path))
+     except Exception as e:
+@@ -514,7 +524,7 @@ def get_depth(session, args):
+ 
+ def get_key_hash(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return cowutil.getKeyHash(device_path) or ''
+     except Exception as e:
+@@ -524,7 +534,7 @@ def get_key_hash(session, args):
+ 
+ def get_block_bitmap(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return base64.b64encode(cowutil.getBlockBitmap(device_path)).decode('ascii')
+     except Exception as e:
+@@ -546,7 +556,7 @@ def get_drbd_size(session, args):
+ 
+ def set_size_virt(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         size = int(args['size'])
+         jFile = args['jFile']
+@@ -559,7 +569,7 @@ def set_size_virt(session, args):
+ 
+ def set_size_virt_fast(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         size = int(args['size'])
+         cowutil.setSizeVirtFast(device_path, size)
+@@ -571,7 +581,7 @@ def set_size_virt_fast(session, args):
+ 
+ def set_parent(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         parent_path = args['parentPath']
+         cowutil.setParent(device_path, parent_path, False)
+@@ -583,7 +593,7 @@ def set_parent(session, args):
+ 
+ def coalesce(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         return str(cowutil.coalesce(device_path))
+     except Exception as e:
+@@ -593,7 +603,7 @@ def coalesce(session, args):
+ 
+ def repair(session, args):
+     try:
+-        cowutil = getCowUtil(args['vdiType'])
++        cowutil = get_cow_util_from_args(args)
+         device_path = args['devicePath']
+         cowutil.repair(device_path)
+         return ''
+@@ -604,7 +614,7 @@ def repair(session, args):
+ 
+ def deflate(session, args):
+     try:
+-        vdi_type = args['vdiType']
++        vdi_type = get_args_vdi_type(args)
+         device_path = args['devicePath']
+         new_size = int(args['newSize'])
+         old_size = int(args['oldSize'])

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.7%{?dist}
+Release: %{?xsrel}.8%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -231,6 +231,8 @@ Patch1143: 0143-fix-LVMSR-activate-chain-for-QCOW2-resize.patch
 Patch1144: 0144-Fix-qcow2util-fix-exception-handling-in-coalesceOnli.patch
 Patch1145: 0145-feat-use-preferred-image-formats-as-a-list.patch
 Patch1146: 0146-fix-cleanup-online-coalesce-would-crash.patch
+Patch1147: 0147-fix-linstor-add-backward-compatibility-for-getInfo.patch
+Patch1148: 0148-fix-linstor-add-backward-compatibility-for-manager-p.patch
 
 
 %description
@@ -555,6 +557,10 @@ then
 fi
 
 %changelog
+* Wed May 06 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-17.8
+- Add 0147-fix-linstor-add-backward-compatibility-for-getInfo.patch
+- Add 0148-fix-linstor-add-backward-compatibility-for-manager-p.patch
+
 * Thu Apr 30 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-17.7
 - Add 0143-fix-LVMSR-activate-chain-for-QCOW2-resize.patch
 - Add 0144-Fix-qcow2util-fix-exception-handling-in-coalesceOnli.patch


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3249

#### Context & Motivation

We renamed in QCOW2 release some helpers and changed a few LINSTOR sm attributes, which caused communication between slaves and the master to break during an update process. However, it is possible to restore a stable state by manually updating all hosts.

This PR add backward compatibility to deal with master host updated and non-QCOW2 slaves.

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

fasttrack

---

### Release Notes and Documentation

#### Explain the change to users

Add fixes regarding LINSTOR backward compatibility to handle remote calls on slaves with non-QCOW2 versions.

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

#### What tests have you performed?

Manual LINSTOR tests: snapshots, VM boot, ...
Automatic LINSTOR tests must be launched after build.

#### What manual tests should be performed after the build, and by whom?

LINSTOR tests (all xe actions on SR) by storage team. 

#### What's covered by the xcp-ng-tests test suite?

Not covered. We don't have RPU/update tests.

#### What tests have been or will be added to CI for this change? If none, explain why.

None. We must refactor xcp-ng-tests to execute tests with a master up to date and with outdated slaves. We can't add this change before this release. To plan.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No