### PR TITLE
Release 3.2.12-17.9

### DIFF
--- a/SOURCES/0149-fix-LVMSR-scan-with-cbt_metadata.patch
+++ b/SOURCES/0149-fix-LVMSR-scan-with-cbt_metadata.patch
@@ -1,0 +1,52 @@
+From 7a084c9dbe5ddac23e59d8a7c7185afea35d52a9 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Sun, 10 May 2026 19:15:56 +0200
+Subject: [PATCH] fix(LVMSR): scan with cbt_metadata
+
+Scan with cbt_metadata VDIs find itself in the vdi_create part of `LVMVDI.load`
+without the size parameter expected.
+We added a special case for this.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LVMSR.py | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/LVMSR.py b/drivers/LVMSR.py
+index 5d48528b..3b05acac 100755
+--- a/drivers/LVMSR.py
++++ b/drivers/LVMSR.py
+@@ -1372,17 +1372,22 @@ class LVMVDI(VDI.VDI):
+                     raise xs_errors.XenError('VDICreate', opterr='Cannot create COW type disk in legacy mode')
+ 
+         if not self.vdi_type:
+-            size = int(self.sr.srcmd.params['args'][0])
+-            # In the case of vdi_create, the first parameter is size.
+-            # We need it to validate the vdi_type choice
+-            for image_format in self.sr.preferred_image_formats:
+-                vdi_type = getVdiTypeFromImageFormat(image_format)
+-                self._setType(vdi_type)
+-                try:
+-                    self.cowutil.validateAndRoundImageSize(size)
+-                    break
+-                except xs_errors.SROSError:
+-                    util.SMlog(f"We won't be able to create the VDI with format {vdi_type}.")
++            if self.sr.srcmd.cmd == "vdi_create":
++                size = int(self.sr.srcmd.params['args'][0])
++                # In the case of vdi_create, the first parameter is size.
++                # We need it to validate the vdi_type choice
++                for image_format in self.sr.preferred_image_formats:
++                    vdi_type = getVdiTypeFromImageFormat(image_format)
++                    self._setType(vdi_type)
++                    try:
++                        self.cowutil.validateAndRoundImageSize(size)
++                        break
++                    except xs_errors.SROSError:
++                        util.SMlog(f"We won't be able to create the VDI with format {vdi_type}.")
++            else:
++                # For cbt_metadata, we found ourselves here without being a vdi_create, we don't have size
++                util.SMlog("Not a vdi_create, must be cbtlog")
++                self._setType(getVdiTypeFromImageFormat(self.sr.preferred_image_formats[0]))
+ 
+         self.lvname = "%s%s" % (LV_PREFIX[self.vdi_type], vdi_uuid)
+         self.path = os.path.join(self.sr.path, self.lvname)

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.8%{?dist}
+Release: %{?xsrel}.9%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -233,6 +233,7 @@ Patch1145: 0145-feat-use-preferred-image-formats-as-a-list.patch
 Patch1146: 0146-fix-cleanup-online-coalesce-would-crash.patch
 Patch1147: 0147-fix-linstor-add-backward-compatibility-for-getInfo.patch
 Patch1148: 0148-fix-linstor-add-backward-compatibility-for-manager-p.patch
+Patch1149: 0149-fix-LVMSR-scan-with-cbt_metadata.patch
 
 
 %description
@@ -557,6 +558,9 @@ then
 fi
 
 %changelog
+* Wed May 13 2026 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 3.2.12-17.9
+- Fix VDIs scan with CBT that trigger 'list index out of range' exception on SMAPI code
+
 * Wed May 06 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-17.8
 - Add 0147-fix-linstor-add-backward-compatibility-for-getInfo.patch
 - Add 0148-fix-linstor-add-backward-compatibility-for-manager-p.patch


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3267

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Scan with cbt_metadata VDIs find itself in the vdi_create part of `LVMVDI.load`
without the size parameter expected.

This issue shows up in the log as a `list index out of range` exception.

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Fix VDIs scan with CBT that trigger `list index out of range` exception on SMAPI code.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Manual SR scan tests with and without CBT.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Scan with CBT is the most important test. I can do it.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

There is no CBT test in xcp-ng-tests yet.

#### What tests have been or will be added to CI for this change? If none, explain why.

There is a WIP branch to add CBT tests in xcp-ng-tests test suite.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->

Koji build (scratch, v8.3-incoming): https://koji.xcp-ng.org/taskinfo?taskID=105218