### PR TITLE
Release 3.2.12-21.2

### DIFF
--- a/SOURCES/0152-feat-qcow2-live-leaf-coalesce.patch
+++ b/SOURCES/0152-feat-qcow2-live-leaf-coalesce.patch
@@ -1,0 +1,209 @@
+From 1877d017a998a7ee2f38085bcf237f513af14e38 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Fri, 20 Mar 2026 14:26:13 +0100
+Subject: [PATCH] feat(qcow2): live leaf coalesce
+
+Instead of doing a snapshot to coalesce before doing the leaf.
+Live leaf coalesce directly call the online coalesce on a host that has the VDI
+opened.
+
+In case of live leaf coalesce, we don't do the pause of VDI because we are
+gonna have tapdisk doing the coalesce.
+In this case, calling validate on the VDIs can cause the check to fail since
+the VDI is being used.
+We have the validate only being done for non-coalesce-on-remote path.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/cleanup.py    | 90 +++++++++++++++++++++++++------------------
+ tests/test_cleanup.py |  4 +-
+ 2 files changed, 55 insertions(+), 39 deletions(-)
+
+diff --git a/drivers/cleanup.py b/drivers/cleanup.py
+index a8271ee2..51726be2 100755
+--- a/drivers/cleanup.py
++++ b/drivers/cleanup.py
+@@ -864,23 +864,7 @@ class VDI(object):
+         #TODO: We might need to make the LV RW on the slave directly for coalesce?
+         # Children and parent need to be RW for QCOW2 coalesce, otherwise tapdisk(libqcow) will crash trying to access them
+ 
+-        def abortTest():
+-            file = self.sr._gc_running_file(self)
+-            try:
+-                with open(file, "r") as f:
+-                    if not f.read():
+-                        Util.log("abortTest: Cancelling coalesce")
+-                        return True
+-            except OSError as e:
+-                if e.errno == errno.ENOENT:
+-                    Util.log("File {} does not exist".format(file))
+-                else:
+-                    Util.log("IOError: {}".format(e))
+-                return True
+-            return False
+-
+-        Util.runAbortable(lambda: self._call_plugin_coalesce(hostRef), \
+-                          None, self.sr.uuid, abortTest, VDI.POLL_INTERVAL, 0, prefSig=signal.SIGTERM)
++        self._coalesceCowImageOnHost(hostRef)
+ 
+         #self._verifyContents(0)
+         self.parent.updateBlockInfo()
+@@ -1051,6 +1035,26 @@ class VDI(object):
+ 
+         util.fistpoint.activate("LVHDRT_coalescing_VHD_data", self.sr.uuid)
+ 
++    def _coalesceCowImageOnHost(self, hostRef):
++        Util.log("  Running COW coalesce on {} via remote host {}".format(self, hostRef))
++        def abortTest():
++            file = self.sr._gc_running_file(self)
++            try:
++                with open(file, "r") as f:
++                    if not f.read():
++                        Util.log("abortTest: Cancelling coalesce")
++                        return True
++            except OSError as e:
++                if e.errno == errno.ENOENT:
++                    Util.log("File {} does not exist".format(file))
++                else:
++                    Util.log("IOError: {}".format(e))
++                return True
++            return False
++
++        Util.runAbortable(lambda: self._call_plugin_coalesce(hostRef),
++                          None, self.sr.uuid, abortTest, VDI.POLL_INTERVAL, 0, prefSig=signal.SIGTERM)
++
+     def _relinkSkip(self) -> None:
+         """Relink children of this VDI to point to the parent of this VDI"""
+         abortFlag = IPCFlag(self.sr.uuid)
+@@ -2356,7 +2360,12 @@ class SR(object):
+             uuid = vdi.uuid
+             try:
+                 # "vdi" object will no longer be valid after this call
+-                self._coalesceLeaf(vdi)
++                if vdi.cowutil.isCoalesceableOnRemote():
++                    Util.log("We will live coalesce leaf: {uuid}".format(uuid=vdi.uuid))
++                    self._liveLeafCoalesce(vdi, coalesce_on_remote=True)
++                else:
++                    Util.log("We can't live coalesce leaf: {uuid}".format(uuid=vdi.uuid))
++                    self._coalesceLeaf(vdi)
+             finally:
+                 vdi = self.getVDI(uuid)
+                 if vdi:
+@@ -2841,7 +2850,7 @@ class SR(object):
+             return False
+         return True
+ 
+-    def _liveLeafCoalesce(self, vdi: VDI) -> bool:
++    def _liveLeafCoalesce(self, vdi: VDI, coalesce_on_remote: bool = False) -> bool:
+         util.fistpoint.activate("LVHDRT_coaleaf_delay_3", self.uuid)
+         self.lock()
+         try:
+@@ -2854,12 +2863,13 @@ class SR(object):
+                 return False
+ 
+             uuid = vdi.uuid
+-            vdi.pause(failfast=True)
++            if not coalesce_on_remote:
++                vdi.pause(failfast=True)
+             try:
+                 try:
+-                    # "vdi" object will no longer be valid after this call
+                     self._create_running_file(vdi)
+-                    self._doCoalesceLeaf(vdi)
++                    # "vdi" object will no longer be valid after this call
++                    self._doCoalesceLeaf(vdi, coalesce_on_remote)
+                 except:
+                     Util.logException("_doCoalesceLeaf")
+                     self._handleInterruptedCoalesceLeaf()
+@@ -2880,24 +2890,30 @@ class SR(object):
+             self.logFilter.logState()
+         return True
+ 
+-    def _doCoalesceLeaf(self, vdi: VDI):
++    def _doCoalesceLeaf(self, vdi: VDI, coalesce_on_remote: bool):
+         """Actual coalescing of a leaf VDI onto parent. Must be called in an
+         offline/atomic context"""
+         self.journaler.create(VDI.JRN_LEAF, vdi.uuid, vdi.parent.uuid)
+         self._prepareCoalesceLeaf(vdi)
+         vdi.parent._setHidden(False)
+         vdi.parent._increaseSizeVirt(vdi.sizeVirt, False)
+-        vdi.validate(True)
+-        vdi.parent.validate(True)
+-        util.fistpoint.activate("LVHDRT_coaleaf_before_coalesce", self.uuid)
+-        timeout = vdi.LIVE_LEAF_COALESCE_TIMEOUT
+-        if vdi.getConfig(vdi.DB_LEAFCLSC) == vdi.LEAFCLSC_FORCE:
+-            Util.log("Leaf-coalesce forced, will not use timeout")
+-            timeout = 0
+-        vdi._coalesceCowImage(timeout)
+-        util.fistpoint.activate("LVHDRT_coaleaf_after_coalesce", self.uuid)
+-        vdi.parent.validate(True)
+-        #vdi._verifyContents(timeout / 2)
++        host_refs = self._hasLeavesAttachedOn(vdi) if coalesce_on_remote else None
++        if host_refs:
++            util.fistpoint.activate("LVHDRT_coaleaf_before_coalesce", self.uuid)
++            vdi._coalesceCowImageOnHost(list(host_refs)[0])
++            util.fistpoint.activate("LVHDRT_coaleaf_after_coalesce", self.uuid)
++        else:
++            vdi.validate(True)
++            vdi.parent.validate(True)
++            util.fistpoint.activate("LVHDRT_coaleaf_before_coalesce", self.uuid)
++            timeout = vdi.LIVE_LEAF_COALESCE_TIMEOUT
++            if vdi.getConfig(vdi.DB_LEAFCLSC) == vdi.LEAFCLSC_FORCE:
++                Util.log("Leaf-coalesce forced, will not use timeout")
++                timeout = 0
++            vdi._coalesceCowImage(timeout)
++            util.fistpoint.activate("LVHDRT_coaleaf_after_coalesce", self.uuid)
++            vdi.parent.validate(True)
++            #vdi._verifyContents(timeout / 2)
+ 
+         # rename
+         vdiUuid = vdi.uuid
+@@ -3361,7 +3377,7 @@ class LVMSR(SR):
+                     self.lvActivator.remove(uuid, False)
+ 
+     @override
+-    def _liveLeafCoalesce(self, vdi) -> bool:
++    def _liveLeafCoalesce(self, vdi: VDI, coalesce_on_remote: bool = False) -> bool:
+         """If the parent is raw and the child was resized (virt. size), then
+         we'll need to resize the parent, which can take a while due to zeroing
+         out of the extended portion of the LV. Do it before pausing the child
+@@ -3370,7 +3386,7 @@ class LVMSR(SR):
+             self.lvmCache.setReadonly(vdi.parent.fileName, False)
+             vdi.parent._increaseSizeVirt(vdi.sizeVirt)
+ 
+-        return SR._liveLeafCoalesce(self, vdi)
++        return SR._liveLeafCoalesce(self, vdi, coalesce_on_remote)
+ 
+     @override
+     def _prepareCoalesceLeaf(self, vdi) -> None:
+@@ -3783,7 +3799,7 @@ class LinstorSR(SR):
+         return True
+ 
+     @override
+-    def _liveLeafCoalesce(self, vdi) -> bool:
++    def _liveLeafCoalesce(self, vdi: VDI, coalesce_on_remote: bool = False) -> bool:
+         self.lock()
+         try:
+             self._linstor.ensure_volume_is_not_locked(
+diff --git a/tests/test_cleanup.py b/tests/test_cleanup.py
+index 8d3e84ff..10ebbf83 100644
+--- a/tests/test_cleanup.py
++++ b/tests/test_cleanup.py
+@@ -1908,7 +1908,7 @@ class TestSR(unittest.TestCase):
+         mock_vdi.getSizePhys.return_value = 10 * MEGA
+         mock_vdi.parent = mock_parent
+ 
+-        sr._doCoalesceLeaf(mock_vdi)
++        sr._doCoalesceLeaf(mock_vdi, False)
+ 
+         mock_parent.delConfig.assert_called_with("vhd-parent")
+ 
+@@ -1930,7 +1930,7 @@ class TestSR(unittest.TestCase):
+         mock_vdi.getSizePhys.return_value = 10 * MEGA
+         mock_vdi.parent = mock_parent
+ 
+-        sr._doCoalesceLeaf(mock_vdi)
++        sr._doCoalesceLeaf(mock_vdi, False)
+ 
+         self.assertNotIn('vhd-parent', mock_parent.delConfig.call_args)
+ 

--- a/SOURCES/0153-fix-qcow2-online-coalesce-on-LVMSR.patch
+++ b/SOURCES/0153-fix-qcow2-online-coalesce-on-LVMSR.patch
@@ -1,0 +1,151 @@
+From 9cbdfaca8999b66acdaa8d1ff67c4174f735bc58 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 7 May 2026 16:56:01 +0200
+Subject: [PATCH] fix(qcow2): online coalesce on LVMSR
+
+The online coalesce done by tapdisk need to be able to write the child of the
+VDI we are coalescing to be able to change its parent.
+Previously, if the child was RO, it would cause a tapdisk crash with the error:
+```
+tapdisk[2765226]: libqcow2: error in raw_reconfigure_getfd() at block/file-posix.c:1111:
+tapdisk[2765226]:
+tapdisk[2765226]: The device is not writable: Permission denied
+```
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/cleanup.py  | 25 ++++++++++++++-----------
+ drivers/on_slave.py | 29 ++++++++++++++++++-----------
+ 2 files changed, 32 insertions(+), 22 deletions(-)
+
+diff --git a/drivers/cleanup.py b/drivers/cleanup.py
+index 51726be2..bc2ba837 100755
+--- a/drivers/cleanup.py
++++ b/drivers/cleanup.py
+@@ -842,9 +842,9 @@ class VDI(object):
+     def _cancel_exception(sig, frame):
+         raise CancelException()
+ 
+-    def _call_plugin_coalesce(self, hostRef):
++    def _call_plugin_coalesce(self, hostRef, leaf):
+         signal.signal(signal.SIGTERM, self._cancel_exception)
+-        args = {"path": self.path, "vdi_type": self.vdi_type}
++        args = {"path": self.path, "vdi_type": self.vdi_type, "leaf_path": leaf.path}
+         Util.log("Calling remote coalesce plugin with: {}".format(args))
+         try:
+             ret = self.sr.xapi.session.xenapi.host.call_plugin( \
+@@ -858,13 +858,11 @@ class VDI(object):
+         except Exception:
+             raise
+ 
+-    def _doCoalesceOnHost(self, hostRef):
++    def _doCoalesceOnHost(self, hostRef, leaf):
+         self.parent._increaseSizeVirt(self.sizeVirt)
+         self.sr._updateSlavesOnResize(self.parent)
+-        #TODO: We might need to make the LV RW on the slave directly for coalesce?
+-        # Children and parent need to be RW for QCOW2 coalesce, otherwise tapdisk(libqcow) will crash trying to access them
+ 
+-        self._coalesceCowImageOnHost(hostRef)
++        self._coalesceCowImageOnHost(hostRef, leaf)
+ 
+         #self._verifyContents(0)
+         self.parent.updateBlockInfo()
+@@ -1035,7 +1033,7 @@ class VDI(object):
+ 
+         util.fistpoint.activate("LVHDRT_coalescing_VHD_data", self.sr.uuid)
+ 
+-    def _coalesceCowImageOnHost(self, hostRef):
++    def _coalesceCowImageOnHost(self, hostRef, leaf):
+         Util.log("  Running COW coalesce on {} via remote host {}".format(self, hostRef))
+         def abortTest():
+             file = self.sr._gc_running_file(self)
+@@ -1052,7 +1050,7 @@ class VDI(object):
+                 return True
+             return False
+ 
+-        Util.runAbortable(lambda: self._call_plugin_coalesce(hostRef),
++        Util.runAbortable(lambda: self._call_plugin_coalesce(hostRef, leaf),
+                           None, self.sr.uuid, abortTest, VDI.POLL_INTERVAL, 0, prefSig=signal.SIGTERM)
+ 
+     def _relinkSkip(self) -> None:
+@@ -2526,7 +2524,7 @@ class SR(object):
+     def _hasLeavesAttachedOn(self, vdi: VDI):
+         leaves = vdi.getAllLeaves()
+         leaves_vdi = [leaf.uuid for leaf in leaves]
+-        return util.get_hosts_attached_on(self.xapi.session, leaves_vdi)
++        return util.get_hosts_attached_on_with_vdi_uuid(self.xapi.session, leaves_vdi)
+ 
+     def _gc_running_file(self, vdi: VDI):
+         run_file = "gc_running_{}".format(vdi.uuid)
+@@ -2571,7 +2569,11 @@ class SR(object):
+                 if host_refs and vdi.cowutil.isCoalesceableOnRemote():
+                     #Leaf opened on another host, we need to call online coalesce
+                     Util.log("Remote coalesce for {}".format(vdi.path))
+-                    vdi._doCoalesceOnHost(list(host_refs)[0])
++
++                    leaf_for_coalesce_uuid, host_ref = next(iter(host_refs.items())) # First host_ref since we should only have one
++                    leaf_for_coalesce = [leaf for leaf in vdi.getAllLeaves() if leaf.uuid == leaf_for_coalesce_uuid][0]
++
++                    vdi._doCoalesceOnHost(host_ref, leaf_for_coalesce)
+                     # If we use a host OpaqueRef to do a online coalesce, this vdi will not need to be relinked since it was done by tapdisk
+                     # If we coalesce up the chain, we shouldn't need to do the relink at all, we only need to do the relink on the children if their direct parent was the one we were coalescing
+                     for child in vdi.children:
+@@ -2900,7 +2902,8 @@ class SR(object):
+         host_refs = self._hasLeavesAttachedOn(vdi) if coalesce_on_remote else None
+         if host_refs:
+             util.fistpoint.activate("LVHDRT_coaleaf_before_coalesce", self.uuid)
+-            vdi._coalesceCowImageOnHost(list(host_refs)[0])
++            _, host_ref = next(iter(host_refs.items()))
++            vdi._coalesceCowImageOnHost(host_ref, vdi) # vdi is the leaf for the online coalesce
+             util.fistpoint.activate("LVHDRT_coaleaf_after_coalesce", self.uuid)
+         else:
+             vdi.validate(True)
+diff --git a/drivers/on_slave.py b/drivers/on_slave.py
+index 0fc4f499..3844684d 100755
+--- a/drivers/on_slave.py
++++ b/drivers/on_slave.py
+@@ -162,26 +162,33 @@ def refresh_lun_size_by_SCSIid(session, args):
+         util.SMlog("on-slave.refresh_lun_size_by_SCSIid with %s failed" % args)
+         return "False"
+ 
+-def commit_tapdisk(session, args):
+-    path: str = args["path"]
+-    vdi_type = args["vdi_type"]
+-    #TODO: naming should reflect that it does more than coalesceing, like setting volume RW
+-
++def _make_chain_RW(cowutil, leaf_path, write: bool):
+     def set_RW(path):
+         try:
+             util.pread2(["lvchange", "-p", "rw", path])
+         except:
+             pass
+-    #TODO: need to make children RW. Or we let the relink happen with a refresh on master and hope it doesn't corrupt the disk
+-    if path.startswith("/dev/"):
+-        set_RW(path)
++
++    # if path.startswith("/dev/"):
++    #     set_RW(leaf_path) # Not needed since it's a leaf
++
++    parent = cowutil.getParentNoCheck(leaf_path)
++    while parent:
++        if parent.startswith("/dev/"):
++            set_RW(parent)
++        parent = cowutil.getParentNoCheck(parent)
++
++def commit_tapdisk(session, args):
++    path: str = args["path"]
++    vdi_type = args["vdi_type"]
++    leaf_path: str = args["leaf_path"] # The path of the leaf used by the tapdisk
+ 
+     from cowutil import getCowUtil
+     cowutil = getCowUtil(vdi_type)
+     try:
+-        parent = cowutil.getParentNoCheck(path)
+-        if parent.startswith("/dev/"):
+-            set_RW(parent)
++        if path.startswith("/dev/"):
++            # We need to make children RW or tapdisk will crash trying to do it
++            _make_chain_RW(cowutil, leaf_path, True)
+         return str(cowutil.coalesceOnline(path))
+     except:
+         util.logException("Couldn't coalesce online")

--- a/SOURCES/0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
+++ b/SOURCES/0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
@@ -1,0 +1,1305 @@
+From dbd1f2ad344f9963979bafe67af2e5eee6cd2b96 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Tue, 26 May 2026 09:56:48 +0200
+Subject: [PATCH] feat(qcow2_helper): Added a scan command to qcow2_helper
+
+It's implemented only for LVMSR version of qcow2.
+The current python implementation for FileSR isn't problem.
+
+It emulates the behaviour of `vhd-util`.
+We use the `lvm-util` library imported from blktap to read info about LVs and
+be able to read the header from the real device without having to
+activate/desactivate LVs each time. It's a problem with performance of LVMSR.
+It's not used in qcow2util in this commit.
+
+We want to only enable the LV only to get allocated size and bitmap in GC.
+
+We added a parameter `-a` to `qcow2_helper scan` to scan parents.
+scan parents mean that even if the match pattern does not include the parent,
+they will be included in the scan.  It's used to scan a QCOW2 LV specifically
+by the sm by using "QCOW2-<VDI UUID>" as the match pattern and obtain the full chain quickly.
+We used this new option to also re-implement getInfoFromLVM using the scan to
+obtain information about a LVM QCOW2.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/qcow2util.py | 149 ++++++++------
+ qcow2/Makefile       |   2 +-
+ qcow2/lvm-util.c     | 337 ++++++++++++++++++++++++++++++++
+ qcow2/lvm-util.h     |  74 +++++++
+ qcow2/qcow2_helper.c | 451 ++++++++++++++++++++++++++++++++++++-------
+ qcow2/qcow_helper.h  |  41 +++-
+ qcow2/util.h         |  52 +++++
+ 7 files changed, 967 insertions(+), 139 deletions(-)
+ create mode 100644 qcow2/lvm-util.c
+ create mode 100644 qcow2/lvm-util.h
+ create mode 100644 qcow2/util.h
+
+diff --git a/drivers/qcow2util.py b/drivers/qcow2util.py
+index 5ffe64c5..6c33f3cf 100755
+--- a/drivers/qcow2util.py
++++ b/drivers/qcow2util.py
+@@ -30,8 +30,6 @@ import util
+ import xs_errors
+ from blktap2 import TapCtl
+ from cowutil import CowUtil, CowImageInfo
+-from lvmcache import LVMCache
+-from constants import NS_PREFIX_LVM, VG_PREFIX
+ 
+ # ------------------------------------------------------------------------------
+ 
+@@ -501,28 +499,8 @@ class QCowUtil(CowUtil):
+     def getInfoFromLVM(
+         self, lvName: str, extractUuidFunction: Callable[[str], str], vgName: str
+     ) -> Optional[CowImageInfo]:
+-        lvcache = LVMCache(vgName)
+-        return self._getInfoLV(lvcache, extractUuidFunction, vgName, lvName)
+-
+-    def _getInfoLV(
+-        self, lvcache: LVMCache, extractUuidFunction: Callable[[str], str], vgName: str, lvName: str
+-    ) -> Optional[CowImageInfo]:
+-        lvPath = "/dev/{}/{}".format(vgName, lvName)
+-        lvcache.refresh()
+-        if lvName not in lvcache.lvs:
+-            util.SMlog("{} does not exist anymore".format(lvName))
+-            return None
+-
+-        vdiUuid = extractUuidFunction(lvPath)
+-        srUuid = vgName.replace(VG_PREFIX, "")
+-
+-        ns = NS_PREFIX_LVM + srUuid
+-        lvcache.activate(ns, vdiUuid, lvName, False)
+-        try:
+-            cowinfo = self.getInfo(lvPath, extractUuidFunction)
+-        finally:
+-            lvcache.deactivate(ns, vdiUuid, lvName, False)
+-        return cowinfo
++        ret = cast(str, self._ioretry([QCOW2_HELPER, "scan", "-l", vgName, "-m", lvName]))
++        return self._parseQCOW2Info(ret, extractUuidFunction)
+ 
+     @override
+     def getAllInfoFromVG(
+@@ -533,45 +511,53 @@ class QCowUtil(CowUtil):
+         parents: bool = False,
+         exitOnError: bool = False
+     ) -> Dict[str, CowImageInfo]:
+-        result: Dict[str, CowImageInfo] = dict()
+-        #TODO: handle exitOnError
+         if vgName:
+-            reg = re.compile(pattern)
+-            lvcache = LVMCache(vgName)
+-            lvcache.refresh()
+-            # We get size in lvcache.lvs[lvName].size (in bytes)
+-            # We could read the header from the PV directly
+-            lvList = list(lvcache.lvs.keys())
+-            for lvName in lvList:
+-                # lvinfo = lvcache.lvs[lvName]
+-                if reg.match(lvName):
+-                    cowinfo = self._getInfoLV(lvcache, extractUuidFunction, vgName, lvName)
+-                    if cowinfo is None: #We get None if the LV stopped existing in the meanwhile
+-                        continue
+-                    cowinfo.path = lvName # Function CowUtil.getParentChain expect lvName here, otherwise blktap.{_activate,_deactivate} crashes
+-                    result[cowinfo.uuid] = cowinfo
+-                    if parents:
+-                        parentUuid = cowinfo.parentUuid
+-                        parentPath = cowinfo.parentPath
+-                        while parentUuid != "":
+-                            parentLvName = parentPath.split("/")[-1]
+-                            parent_cowinfo = self._getInfoLV(lvcache, extractUuidFunction, vgName, parentLvName)
+-                            if parent_cowinfo is None: #Parent disappeared while scanning
+-                                raise util.SMException("Parent of {} wasn't found during scan".format(lvName))
+-                            parentUuid = parent_cowinfo.parentUuid
+-                            parentPath = parent_cowinfo.parentPath
+-                            parent_cowinfo.path = parentLvName #Same reason as above, some users expect LvName here instead of path
+-                            result[parent_cowinfo.uuid] = parent_cowinfo
+-
+-            return result
++            return self._getAllInfoFromLVM(pattern, extractUuidFunction, vgName, parents, exitOnError)
+         else:
+-            pattern_p: Path = Path(pattern)
+-            list_qcow = list(pattern_p.parent.glob(pattern_p.name))
+-            for qcow in list_qcow:
+-                qcow_str = str(qcow)
+-                info = self.getInfo(qcow_str, extractUuidFunction)
++            return self._getAllInfoFromPath(pattern, extractUuidFunction, exitOnError)
++
++    def _getAllInfoFromLVM(
++        self,
++        pattern: str,
++        extractUuidFunction: Callable[[str], str],
++        vgName: str,
++        parents: bool = False,
++        exitOnError: bool = False
++    ) -> Dict[str, CowImageInfo]:
++        result: Dict[str, CowImageInfo] = dict()
++        cmd = [QCOW2_HELPER, "scan", "-l", vgName, "-m", pattern]
++        if parents:
++            cmd.append("-a")
++        ret = cast(str, self._ioretry(cmd))
++        
++        for line in ret.split("\n"):
++            if not line.strip():
++                continue
++            info = self._parseQCOW2Info(line, extractUuidFunction)
++            if info:
++                if info.error != 0 and exitOnError:
++                    #TODO: this is a workaround in vhdutil, don't know why
++                    return dict()
+                 result[info.uuid] = info
+-            return result
++            else:
++                util.SMlog(f"WARN: QCOW2 info line doesn't parse correctly: {line}")
++        return result
++
++    def _getAllInfoFromPath(
++        self,
++        pattern: str,
++        extractUuidFunction: Callable[[str], str],
++        exitOnError: bool = False
++    ) -> Dict[str, CowImageInfo]:
++        result: Dict[str, CowImageInfo] = dict()
++        #TODO: handle exitOnError
++        pattern_p: Path = Path(pattern)
++        list_qcow = list(pattern_p.parent.glob(pattern_p.name))
++        for qcow in list_qcow:
++            qcow_str = str(qcow)
++            info = self.getInfo(qcow_str, extractUuidFunction)
++            result[info.uuid] = info
++        return result
+ 
+     @override
+     def getParent(self, path: str, extractUuidFunction: Callable[[str], str]) -> Optional[str]:
+@@ -685,7 +671,7 @@ class QCowUtil(CowUtil):
+ 
+     @override
+     def getAllocatedSize(self, path: str) -> int:
+-        cmd = [QCOW2_HELPER, "allocated", path]
++        cmd = [QCOW2_HELPER, "allocated", "-f", path]
+         return int(self._ioretry(cmd))
+ 
+     @override
+@@ -725,7 +711,7 @@ class QCowUtil(CowUtil):
+ 
+     @override
+     def getBlockBitmap(self, path: str) -> bytes:
+-        cmd = [QCOW2_HELPER, "bitmap", path]
++        cmd = [QCOW2_HELPER, "bitmap", "-f", path]
+         text = cast(bytes, self._ioretry(cmd, text=False))
+         return zlib.compress(text)
+ 
+@@ -906,4 +892,41 @@ class QCowUtil(CowUtil):
+ 
+     @override
+     def isCoalesceableOnRemote(self) -> bool:
+-        return True
+\ No newline at end of file
++        return True
++
++    @staticmethod
++    def _parseQCOW2Info(line: str, extractUuidFunction: Callable[[str], str]) -> Optional[CowImageInfo]:
++        vhdInfo = None
++        valueMap = line.split()
++
++        try:
++            (key, val) = valueMap[0].split("=")
++        except:
++            return None
++
++        if key != "qcow2":
++            return None
++
++        uuid = extractUuidFunction(val)
++        if not uuid:
++            util.SMlog(f"***** malformed output, no UUID: {valueMap}")
++            return None
++        vhdInfo = CowImageInfo(uuid)
++        vhdInfo.path = val
++
++        for keyval in valueMap:
++            (key, val) = keyval.split("=")
++            if key == "scan-error": #TODO: need to add this to scan from qcow2_helper
++                vhdInfo.error = line
++                util.SMlog(f"***** QCOW2 scan error: {line}")
++                break
++            elif key == "capacity":
++                vhdInfo.sizeVirt = int(val)
++            elif key == "size":
++                vhdInfo.sizePhys = int(val)
++            elif key == "hidden":
++                vhdInfo.hidden = bool(int(val))
++            elif key == "parent" and val != "none":
++                vhdInfo.parentPath = val #TODO: Do I expect the full path for parent in the code?
++                vhdInfo.parentUuid = extractUuidFunction(val)
++        return vhdInfo
+\ No newline at end of file
+diff --git a/qcow2/Makefile b/qcow2/Makefile
+index 14e93c66..64f3ff7c 100644
+--- a/qcow2/Makefile
++++ b/qcow2/Makefile
+@@ -5,7 +5,7 @@ DEBUGDIR ?= /opt/xensource/debug
+ 
+ OPTS := -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -fopenmp -Ofast
+ 
+-SRC := qcow2_helper.c
++SRC := qcow2_helper.c lvm-util.c
+ 
+ BIN := qcow2_helper
+ 
+diff --git a/qcow2/lvm-util.c b/qcow2/lvm-util.c
+new file mode 100644
+index 00000000..ab22c38c
+--- /dev/null
++++ b/qcow2/lvm-util.c
+@@ -0,0 +1,337 @@
++/*
++ * Copyright (c) 2016, Citrix Systems, Inc.
++ *
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ * 
++ *  1. Redistributions of source code must retain the above copyright
++ *     notice, this list of conditions and the following disclaimer.
++ *  2. Redistributions in binary form must reproduce the above copyright
++ *     notice, this list of conditions and the following disclaimer in the
++ *     documentation and/or other materials provided with the distribution.
++ *  3. Neither the name of the copyright holder nor the names of its 
++ *     contributors may be used to endorse or promote products derived from 
++ *     this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
++ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
++ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
++ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include <stdio.h>
++#include <errno.h>
++#include <stdlib.h>
++#include <string.h>
++#include <syslog.h>
++
++#include "lvm-util.h"
++#include "util.h"
++
++#define EPRINTF(_f, _a...)					\
++	do {							\
++		syslog(LOG_INFO, "%s: " _f, __func__, ##_a);	\
++	} while (0)
++
++#define _NAME "%255s"
++static char line[1024];
++
++static inline int
++lvm_read_line(FILE *scan)
++{
++	memset(line, 0, sizeof(line));
++	return (fscanf(scan, "%1023[^\n]", line) != 1);
++}
++
++static inline int
++lvm_next_line(FILE *scan)
++{
++	return (fscanf(scan, "%1023[\n]", line) != 1);
++}
++
++static int
++lvm_copy_name(char *dst, const char *src, size_t size)
++{
++	if (strnlen(src, size) == size)
++		return -ENAMETOOLONG;
++
++	safe_strncpy(dst, src, size);
++	return 0;
++}
++
++static int
++lvm_parse_pv(struct vg *vg, const char *name, int pvs, uint64_t start)
++{
++	int i, err;
++	struct pv *pv;
++
++	pv = NULL;
++
++	if (!vg->pvs) {
++		vg->pvs = calloc(pvs, sizeof(struct pv));
++		if (!vg->pvs)
++			return -ENOMEM;
++	}
++
++	for (i = 0; i < pvs; i++) {
++		pv = vg->pvs + i;
++
++		if (!pv->name[0])
++			break;
++
++		if (!strcmp(pv->name, name))
++			return -EEXIST;
++	}
++
++	if (!pv)
++		return -ENOENT;
++
++	if (i == pvs)
++		return -ENOMEM;
++
++	err = lvm_copy_name(pv->name, name, sizeof(pv->name) - 1);
++	if (err)
++		return err;
++
++	pv->start = start;
++	return 0;
++}
++
++static int
++lvm_open_vg(const char *vgname, struct vg *vg)
++{
++	FILE *scan;
++	int i, err, pvs, lvs;
++	char *cmd, pvname[256];
++	uint64_t size, pv_start;
++
++	memset(vg, 0, sizeof(*vg));
++
++	err = asprintf(&cmd, "vgs %s --noheadings --nosuffix --units=b "
++		       "--options=vg_name,vg_extent_size,lv_count,pv_count,"
++		       "pv_name,pe_start --unbuffered 2> /dev/null", vgname);
++	if (err == -1)
++		return -ENOMEM;
++
++	errno = 0;
++	scan  = popen(cmd, "r");
++	if (!scan) {
++		err = (errno ? -errno : ENOMEM);
++		goto out;
++	}
++
++	for (i = 0; !lvm_read_line(scan); ++i) {
++		err = -EINVAL;
++		if (sscanf(line, _NAME" %"PRIu64" %d %d "_NAME" %"PRIu64, vg->name,
++			   &size, &lvs, &pvs, pvname, &pv_start) != 6) {
++			EPRINTF("sscanf failed on '%s'\n", line);
++			goto out;
++		}
++
++		if (strcmp(vg->name, vgname)) {
++			EPRINTF("VG name '%s' != '%s'\n", vg->name, vgname);
++			goto out;
++		}
++		err = lvm_parse_pv(vg, pvname, pvs, pv_start);
++		if (err)
++			goto out;
++
++		/* If there is a new line char, consume it */
++		lvm_next_line(scan);
++	}
++
++	err = -EINVAL;
++	if (!i) {
++		EPRINTF("No VGS data read for %s\n", vgname);
++		goto out;
++	}
++
++	if (strcmp(vg->name, vgname)) {
++		EPRINTF("VG name '%s' != '%s'\n", vg->name, vgname);
++		goto out;
++	}
++
++	for (i = 0; i < pvs; i++)
++		if (!vg->pvs[i].name[0]) {
++			EPRINTF("pvs %d name empty\n", i);
++			goto out;
++		}
++
++	err = -ENOMEM;
++	vg->lvs = calloc(lvs, sizeof(struct lv));
++	if (!vg->lvs)
++		goto out;
++
++	err             = 0;
++	vg->lv_cnt      = lvs;
++	vg->pv_cnt      = pvs;
++	vg->extent_size = size;
++
++out:
++	if (scan)
++		pclose(scan);
++	if (err)
++		lvm_free_vg(vg);
++	free(cmd);
++	return err;
++}
++
++static int
++lvm_parse_lv_devices(struct vg *vg, struct lv_segment *seg, char *devices)
++{
++	int i;
++	uint64_t start, pe_start;
++
++	for (i = 0; i < strlen(devices); i++)
++		if (strchr(",()", devices[i]))
++			devices[i] = ' ';
++
++	if (sscanf(devices, _NAME" %"PRIu64, seg->device, &start) != 2) {
++		EPRINTF("sscanf failed on '%s'\n", devices);
++		return -EINVAL;
++	}
++
++	pe_start = -1;
++	for (i = 0; i < vg->pv_cnt; i++)
++		if (!strcmp(vg->pvs[i].name, seg->device)) {
++			pe_start = vg->pvs[i].start;
++			break;
++		}
++
++	if (pe_start == -1) {
++		EPRINTF("invalid pe_start value, device %s not found?\n",
++			seg->device);
++		EPRINTF("PVs known to VG %s, count %d -\n", vg->name, vg->pv_cnt);
++		for (i = 0; i < vg->pv_cnt; i++) {
++			EPRINTF("%s\n", vg->pvs[i].name);
++		}
++		return -EINVAL;
++	}
++
++	seg->pe_start = (start * vg->extent_size) + pe_start;
++	return 0;
++}
++
++static int
++lvm_scan_lvs(struct vg *vg)
++{
++	char *cmd;
++	FILE *scan;
++	int i, err;
++
++	err = asprintf(&cmd, "lvs %s --noheadings --nosuffix --units=b "
++		       "--options=lv_name,lv_size,segtype,seg_count,seg_start,"
++		       "seg_size,devices --unbuffered 2> /dev/null", vg->name);
++	if (err == -1)
++		return -ENOMEM;
++
++	errno = 0;
++	scan  = popen(cmd, "r");
++	if (!scan) {
++		err = (errno ? -errno : -ENOMEM);
++		goto out;
++	}
++
++	for (i = 0;;) {
++		int segs;
++		struct lv *lv;
++		struct lv_segment seg;
++		unsigned long long size, seg_start;
++		char type[32], name[256], devices[1024];
++
++		if (i >= vg->lv_cnt)
++			break;
++
++		if (lvm_read_line(scan)) {
++			vg->lv_cnt = i;
++			break;
++		}
++
++		err = -EINVAL;
++		lv  = vg->lvs + i;
++
++		if (sscanf(line, _NAME" %llu %31s %u %llu %"PRIu64" %1023s",
++			   name, &size, type, &segs, &seg_start,
++			   &seg.pe_size, devices) != 7) {
++			EPRINTF("sscanf failed on '%s'\n", line);
++			goto out;
++		}
++
++		if (seg_start)
++			goto next;
++
++		if (!strcmp(type, "linear"))
++			seg.type = LVM_SEG_TYPE_LINEAR;
++		else
++			seg.type = LVM_SEG_TYPE_UNKNOWN;
++
++		if (lvm_parse_lv_devices(vg, &seg, devices))
++			goto out;
++
++		i++;
++		lv->size          = size;
++		lv->segments      = segs;
++		lv->first_segment = seg;
++
++		err = lvm_copy_name(lv->name, name, sizeof(lv->name) - 1);
++		if (err)
++			goto out;
++		err = -EINVAL;
++
++	next:
++		if (lvm_next_line(scan)) {
++			if (err)
++				EPRINTF("fscanf failed\n");
++			goto out;
++		}
++	}
++
++	err = 0;
++
++out:
++	if (scan)
++		pclose(scan);
++	free(cmd);
++	return err;
++}
++
++void
++lvm_free_vg(struct vg *vg)
++{
++	free(vg->lvs);
++	free(vg->pvs);
++	memset(vg, 0, sizeof(*vg));
++}
++
++int
++lvm_scan_vg(const char *vg_name, struct vg *vg)
++{
++	int err;
++
++	memset(vg, 0, sizeof(*vg));
++
++	err = lvm_open_vg(vg_name, vg);
++	if (err)
++		return err;
++
++	err = lvm_scan_lvs(vg);
++	if (err) {
++		lvm_free_vg(vg);
++		return err;
++	}
++
++	return 0;
++}
+diff --git a/qcow2/lvm-util.h b/qcow2/lvm-util.h
+new file mode 100644
+index 00000000..c15797fa
+--- /dev/null
++++ b/qcow2/lvm-util.h
+@@ -0,0 +1,74 @@
++/*
++ * Copyright (c) 2016, Citrix Systems, Inc.
++ *
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ * 
++ *  1. Redistributions of source code must retain the above copyright
++ *     notice, this list of conditions and the following disclaimer.
++ *  2. Redistributions in binary form must reproduce the above copyright
++ *     notice, this list of conditions and the following disclaimer in the
++ *     documentation and/or other materials provided with the distribution.
++ *  3. Neither the name of the copyright holder nor the names of its 
++ *     contributors may be used to endorse or promote products derived from 
++ *     this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
++ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
++ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
++ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#ifndef _LVM_UTIL_H_
++#define _LVM_UTIL_H_
++
++#include <inttypes.h>
++
++#define MAX_NAME_SIZE            256
++
++#define LVM_SEG_TYPE_LINEAR      1
++#define LVM_SEG_TYPE_UNKNOWN     2
++
++struct lv_segment {
++	uint8_t                  type;
++	char                     device[MAX_NAME_SIZE];
++	uint64_t                 pe_start;
++	uint64_t                 pe_size;
++};
++
++struct lv {
++	char                     name[MAX_NAME_SIZE];
++	uint64_t                 size;
++	uint32_t                 segments;
++	struct lv_segment        first_segment;
++};
++
++struct pv {
++	char                     name[MAX_NAME_SIZE];
++	uint64_t                 start;
++};
++
++struct vg {
++	char                     name[MAX_NAME_SIZE];
++	uint64_t                 extent_size;
++
++	int                      pv_cnt;
++	struct pv               *pvs;
++
++	int                      lv_cnt;
++	struct lv               *lvs;
++};
++
++int lvm_scan_vg(const char *vg_name, struct vg *vg);
++void lvm_free_vg(struct vg *vg);
++
++#endif
+diff --git a/qcow2/qcow2_helper.c b/qcow2/qcow2_helper.c
+index d409d818..5bd71ae8 100644
+--- a/qcow2/qcow2_helper.c
++++ b/qcow2/qcow2_helper.c
+@@ -1,4 +1,5 @@
+ #include "qcow_helper.h"
++#include "lvm-util.h"
+ 
+ static void transform_header_be_to_le(struct qcow2_header* header){
+     SWAP_BE_TO_LE(32, magic);
+@@ -21,9 +22,7 @@ static void transform_header_be_to_le(struct qcow2_header* header){
+     SWAP_BE_TO_LE(32, header_length);
+ }
+ 
+-//#define DEBUG
+-#ifdef DEBUG
+-char* qcow2_get_backing_file(struct qcow2_header* header, int fd){
++char* qcow2_get_backing_file(struct qcow2_header* header, int fd, uint64_t device_offset){
+     int err, backing_file_name_size;
+     char* backing_file_name;
+ 
+@@ -34,8 +33,7 @@ char* qcow2_get_backing_file(struct qcow2_header* header, int fd){
+             fprintf(stderr, "Failed to allocate for backing file name");
+             exit(EXIT_FAILURE);
+         }
+-        lseek(fd, header->backing_file_offset, SEEK_SET);
+-        err = read(fd, backing_file_name, header->backing_file_size);
++        err = pread(fd, backing_file_name, header->backing_file_size, header->backing_file_offset+device_offset);
+         if(err < 0){
+             fprintf(stderr, "Couldn't read backing file: %s (%d)\n", strerror(errno), errno);
+             exit(EXIT_FAILURE);
+@@ -45,7 +43,6 @@ char* qcow2_get_backing_file(struct qcow2_header* header, int fd){
+     }
+     return NULL;
+ }
+-#endif
+ 
+ uint64_t* get_l1_offset(struct qcow2_header* header, int fd){
+     int i, err = 0;
+@@ -255,97 +252,407 @@ int get_allocated_blocks(struct qcow2_header* header, int fd, uint64_t *l1_table
+     return allocated_clusters;
+ }
+ 
+-int main(int argc, char* argv[]){
+-    struct qcow2_header* header = NULL;
+-    char * command, * filename = NULL, * backing_file_name = NULL;
+-    int fd, err = 0, ret = EXIT_SUCCESS;
+-    int extended_l2;
+-    uint64_t *l1_table = NULL, cluster_size = 0, allocated_clusters = 0, allocated_byte = 0;
+-    uint64_t nb_l2_entries;
+-
+-    if(argc != 3){
+-        fprintf(stderr, "Need an argument\n");
+-        exit(EXIT_FAILURE);
+-    }
+-    command = argv[1];
+-    filename = argv[2];
++static int qcow2_open(const char *filename, struct qcow2_header *header, int *fd_out) {
++    int err;
++    int fd;
++
+     fd = open(filename, O_RDONLY);
+-    if(fd < 0){
+-        fprintf(stderr, "Opening file %s failed with error %s (%d)\n", filename, strerror(errno), errno);
+-        ret = EXIT_FAILURE;
+-        goto exit_filename;
++    if (fd < 0) {
++        fprintf(stderr, "Opening file %s failed: %s (%d)\n", filename, strerror(errno), errno);
++        return -1;
++    }
++    err = pread(fd, header, QCOW2_HEADER_SIZE, 0);
++    if (err < 0) {
++        fprintf(stderr, "Failed reading file\n");
++        close(fd);
++        return -1;
++    }
++    transform_header_be_to_le(header);
++    if (header->magic != QCOW2_MAGIC) {
++        fprintf(stderr, "MAGIC is wrong\n");
++        close(fd);
++        return -1;
+     }
+ 
+-    // printf("Reading header from %s\n", filename);
++    *fd_out = fd;
++    return 0;
++}
+ 
+-    header = malloc(QCOW2_HEADER_SIZE);
+-    if(header == NULL){
+-        fprintf(stderr, "Couldn't allocate header\n");
+-        ret = EXIT_FAILURE;
+-        goto close_and_exit;
++static void usage_bitmap(void) { fprintf(stderr, "Usage: bitmap -f <file>\n"); }
++
++static void cmd_bitmap(int argc, char **argv) {
++    char *filename = NULL;
++    int opt, fd;
++    struct qcow2_header header;
++    uint64_t *l1_table;
++
++    while ((opt = getopt(argc, argv, "f:")) != -1) {
++        switch (opt) {
++        case 'f': filename = optarg; break;
++        default:
++            usage_bitmap();
++            exit(EXIT_FAILURE);
++        }
+     }
+ 
+-    err = pread(fd, header, QCOW2_HEADER_SIZE, 0);
+-    if(err < 0){
+-        fprintf(stderr, "Failed reading file\n");
+-        ret = EXIT_FAILURE;
+-        goto close;
++    if (filename == NULL) {
++        usage_bitmap();
++        exit(EXIT_FAILURE);
+     }
+ 
+-    transform_header_be_to_le(header);
++    if (qcow2_open(filename, &header, &fd) < 0)
++        exit(EXIT_FAILURE);
+ 
+-    if(header->magic != QCOW2_MAGIC){
+-        fprintf(stderr, "MAGIC is wrong\n");
+-        goto close;
++    l1_table = get_l1_offset(&header, fd);
++    if (l1_table == NULL) {
++        fprintf(stderr, "Couldn't read L1 Table\n");
++        close(fd);
++        exit(EXIT_FAILURE);
+     }
+ 
+-    cluster_size = (1 << header->cluster_bits);
+-    extended_l2 = (header->version == 3) && (header->incompatible_features & INCOMPATIBLE_FEATURE_EXTENDED_L2);
++    uint64_t cluster_size = qcow2_cluster_size(&header);
++    int extended_l2 = qcow2_extended_l2(&header);
++    dump_bitmap(&header, fd, l1_table, qcow2_nb_l2_entries(cluster_size, extended_l2), extended_l2);
++
++    free(l1_table);
++    close(fd);
++}
++
++static void usage_allocated(void) { fprintf(stderr, "Usage: allocated -f <file>\n"); }
+ 
+-#ifdef DEBUG
+-    printf("Version: %d\n", header->version);
+-    backing_file_name = qcow2_get_backing_file(header, fd);
+-    printf("Backing file: %s\n", backing_file_name);
+-    printf("Extended L2: %d\n", extended_l2);
+-#endif
++static void cmd_allocated(int argc, char **argv) {
++    char *filename = NULL;
++    int opt, fd;
++    struct qcow2_header header;
++    uint64_t *l1_table;
+ 
+-    if (extended_l2) {
+-        nb_l2_entries = cluster_size / (sizeof(uint64_t) * 2);
+-    } else {
+-        nb_l2_entries = cluster_size / (sizeof(uint64_t));
++    while ((opt = getopt(argc, argv, "f:")) != -1) {
++        switch (opt) {
++        case 'f': filename = optarg; break;
++        default:
++            usage_allocated();
++            exit(EXIT_FAILURE);
++        }
+     }
+ 
+-    l1_table = get_l1_offset(header, fd);
+-    if(l1_table == NULL){
++    if (filename == NULL) {
++        usage_allocated();
++        exit(EXIT_FAILURE);
++    }
++
++    if (qcow2_open(filename, &header, &fd) < 0)
++        exit(EXIT_FAILURE);
++
++    l1_table = get_l1_offset(&header, fd);
++    if (l1_table == NULL) {
+         fprintf(stderr, "Couldn't read L1 Table\n");
+-        ret = EXIT_FAILURE;
+-        goto free_backing;
++        close(fd);
++        exit(EXIT_FAILURE);
+     }
++    uint64_t cluster_size = qcow2_cluster_size(&header);
++    int extended_l2 = qcow2_extended_l2(&header);
++    uint64_t clusters = get_allocated_blocks(&header, fd, l1_table, qcow2_nb_l2_entries(cluster_size, extended_l2), extended_l2);
++    uint64_t bytes = get_cluster_to_byte(clusters, cluster_size, extended_l2);
++    printf("%lu\n", bytes);
++    free(l1_table);
++    close(fd);
++}
++
++struct scan_info {
++    char name[NAME_MAX_SIZE]; //SIZE decided democratically
++    uint64_t capacity;
++    uint64_t size;
++    bool hidden;
++    char parent[NAME_MAX_SIZE];
++};
++
++static struct lv* lv_find_by_name(const struct lv *lvs, int lv_count, const char *name) {
++    int i;
++    for (i = 0; i < lv_count; i++)
++        if (strcmp(lvs[i].name, name) == 0)
++            return (struct lv *)&lvs[i];
++    return NULL;
++}
++
++struct lv* lv_filter_by_pattern(const struct vg *vg, const char *pattern, int *lv_count) {
++    int i, j = 0;
++    struct lv *result;
+ 
+-    if(!strcmp("bitmap", command)){
+-        dump_bitmap(header, fd, l1_table, nb_l2_entries, extended_l2);
++    result = malloc(sizeof(struct lv) * vg->lv_cnt);
++    if (result == NULL) {
++        *lv_count = 0;
++        return NULL;
+     }
+-    else if(!strcmp("allocated", command)){
+-        allocated_clusters = get_allocated_blocks(header, fd, l1_table, nb_l2_entries, extended_l2);
+-        allocated_byte = get_cluster_to_byte(allocated_clusters, cluster_size, extended_l2);
+-        printf("%lu\n", allocated_byte);
++
++    for (i = 0; i < vg->lv_cnt; i++) {
++        if (fnmatch(pattern, vg->lvs[i].name, FNM_PATHNAME | FNM_EXTMATCH) == 0)
++            result[j++] = vg->lvs[i];
+     }
+-    else{
+-        fprintf(stderr, "Command %s is unknown.\n", command);
+-        ret = EXIT_FAILURE;
++
++    *lv_count = j;
++    return result;
++}
++
++struct qcow2_header* get_header_from_device(struct lv* lv, int fd){
++    struct qcow2_header* header = NULL;
++    int err;
++
++    header = malloc(QCOW2_HEADER_SIZE);
++    if (header == NULL) {
++        fprintf(stderr, "Couldn't allocate header\n");
++        return NULL;
++    }
++    err = pread(fd, header, QCOW2_HEADER_SIZE, lv->first_segment.pe_start); //OFFSET need to be offset of LV in device
++    if (err < 0) {
++        fprintf(stderr, "Failed reading file %s\n", lv->name);
++        goto err_free_header;
++    }
++    transform_header_be_to_le(header);
++    if (header->magic != QCOW2_MAGIC) {
++        fprintf(stderr, "MAGIC is wrong for %s\n", lv->name);
++        goto err_free_header;
++    }
++
++    return header;
++
++err_free_header:
++    free(header);
++    return NULL;
++}
++
++char* get_backing_file_from_device(struct qcow2_header* header, struct lv* lv, int fd){
++        if(header->backing_file_offset >= lv->first_segment.pe_size){
++            fprintf(stderr, "Backing file is not in first segment for LV %s\n", lv->name);
++            exit(EXIT_FAILURE);
++            // return NULL; //TODO: We need to diff not having a backing file and it erroring here.
++        }
++        return qcow2_get_backing_file(header, fd, lv->first_segment.pe_start);
++}
++
++static uint32_t read_data_from_qcow2_header(int fd, size_t offset){
++    uint32_t data;
++    if(pread(fd, &data, 4, offset) < 1){
++        exit(EXIT_FAILURE); //TODO: Handle error correctly
++    }
++    data = __builtin_bswap32(data);
++    return data;
++}
++
++void transform_custom_header_bswap(struct custom_header* custom_header){
++    custom_header->type = __builtin_bswap32(custom_header->type);
++    custom_header->length = __builtin_bswap32(custom_header->length);
++    // custom_header->custom_header_data = __builtin_bswap64(custom_header->custom_header_data);
++    /**
++     The data in the custom header is little endian when it should be big endian in qcow2
++     It's because the python code writing the hidden status wrote directly at the offset of the data
++     like if it was 1 octet.
++    */
++}
++
++size_t find_custom_header(struct qcow2_header* header, int fd, uint64_t device_offset){
++    size_t current_offset;
++    uint32_t header_length = 72, ext_type, ext_len;
++
++    if(header->version == 3){
++        header_length = header->header_length;
+     }
+ 
+-    if(l1_table != NULL){
+-        free(l1_table);
++    current_offset = header_length;
++    current_offset += device_offset;
++    
++    do{
++        ext_type = read_data_from_qcow2_header(fd, current_offset);
++        ext_len = read_data_from_qcow2_header(fd, current_offset+4);
++        if(ext_type == CUSTOM_HEADER_TYPE){
++            // A custom header is already there
++            return current_offset;
++        }
++        current_offset += 8 + ((ext_len + 7) & ~(uint32_t)7);
++    } while(ext_type != 0);
++
++    return 0;
++}
++
++static int fill_scan_info_from_lv(struct lv *lv, struct scan_info *info) {
++    int fd;
++
++    strncpy(info->name, lv->name, NAME_MAX_SIZE);
++    info->size = lv->size;
++
++    /* Getting header from the underlying device*/
++    fd = open(lv->first_segment.device, O_RDONLY);
++    if (fd < 0) {
++        fprintf(stderr, "Opening device %s failed: %s (%d)\n", lv->first_segment.device, strerror(errno), errno);
++        return -1;
+     }
++    struct qcow2_header* header = get_header_from_device(lv, fd);
+ 
+-free_backing:
+-    if(backing_file_name != NULL)
++    info->capacity = header->size;
++
++    /* Getting parent if it exist */
++    char* backing_file_name = get_backing_file_from_device(header, lv, fd);
++    if(backing_file_name){
++        char* parent_lv_name = basename(backing_file_name); //Transform the backing name from full path of the LV to just the LV name
++        strncpy(info->parent, parent_lv_name, NAME_MAX_SIZE);
++        // strncpy(info->parent, backing_file_name, strlen(backing_file_name));
++        //The existing code in qcow2util.py might need the full path though
+         free(backing_file_name);
+-close:
++    }
++    else{
++        strncpy(info->parent, "none", 5);
++    }
++
++    /* Getting hidden from custom header */
++    size_t custom_header_offset = find_custom_header(header, fd, lv->first_segment.pe_start);
++    if(custom_header_offset){
++        struct custom_header custom_header;
++        pread(fd, &custom_header, sizeof(struct custom_header), custom_header_offset);
++        transform_custom_header_bswap(&custom_header);
++        info->hidden = custom_header.data;
++    }
++    else{
++        info->hidden = 0;
++    }
++
+     free(header);
+-close_and_exit:
+     close(fd);
+-exit_filename:
+-    exit(ret);
++    return 0;
++}
++
++struct scan_info* get_infos(char* vg_name, int* lv_count, const char* pattern, int include_parents) {
++    int i, matched_count, err;
++    struct vg vg;
++    struct lv *matched_lvs;
++    struct scan_info *infos, *info;
++
++    err = lvm_scan_vg(vg_name, &vg);
++    if(err < 0){
++        fprintf(stderr, "lvm_scan_vg failed %d\n", err);
++        return NULL;
++    }
++    matched_lvs = lv_filter_by_pattern(&vg, pattern, &matched_count);
++
++    infos = calloc(vg.lv_cnt, sizeof(struct scan_info));
++    if(infos == NULL){
++        fprintf(stderr, "Failed to allocate scan_info array\n");
++        goto alloc_info_err;
++    }
++
++    for(i = 0; i < matched_count; i++){
++        if(fill_scan_info_from_lv(&matched_lvs[i], &infos[i]) < 0){
++            goto scan_info_err;
++        }
++    }
++
++    if(include_parents){
++        for (i = 0; i < matched_count; i++){
++            struct lv* parent_lv;
++            info = &infos[i];
++
++            if(strcmp(info->parent, "none") == 0)
++                continue;
++
++            if(lv_find_by_name(matched_lvs, matched_count, info->parent) != NULL)
++                continue;
++
++            parent_lv = lv_find_by_name(vg.lvs, vg.lv_cnt, info->parent);
++            if(parent_lv != NULL){
++                matched_lvs[matched_count] = *parent_lv;
++                if(fill_scan_info_from_lv(&matched_lvs[matched_count], &infos[matched_count]) < 0){
++                    goto scan_info_err;
++                }
++                matched_count++;
++            }
++            else{
++                fprintf(stderr, "scan-error: %s not found\n", info->parent);
++                goto scan_info_err;
++            }
++        }
++    }
++
++    free(matched_lvs);
++    lvm_free_vg(&vg);
++
++    *lv_count = matched_count;
++    return infos;
++
++scan_info_err:
++    free(infos);
++alloc_info_err:
++    free(matched_lvs);
++    lvm_free_vg(&vg);
++    return NULL;
++}
++
++static void usage_scan(void) { fprintf(stderr, "Usage: scan -l <vg> -m <match filter> [-a scan parents]\n"); }
++
++static void cmd_scan(int argc, char **argv) {
++    char *vg_name = NULL, *pattern = NULL;
++    int i, opt, lv_count, include_parents = 0;
++
++    while ((opt = getopt(argc, argv, "l:m:a")) != -1) {
++        switch (opt) {
++        case 'l': vg_name = optarg; break;
++        case 'm': pattern = optarg; break;
++        case 'a': include_parents = 1; break;
++        default:
++            usage_scan();
++            exit(EXIT_FAILURE);
++        }
++    }
++    if(vg_name == NULL || pattern == NULL){
++        usage_scan();
++        exit(EXIT_FAILURE);
++    }
++
++    struct scan_info *infos = get_infos(vg_name, &lv_count, pattern, include_parents);
++    if(infos == NULL){
++        exit(EXIT_FAILURE);
++    }
++
++    for(i = 0; i < lv_count; i++){
++        struct scan_info info = infos[i];
++        printf("qcow2=%s capacity=%lu size=%lu hidden=%d parent=%s\n",
++               info.name, info.capacity, info.size, info.hidden, info.parent);
++    }
++    free(infos);
++}
++
++/* Defined here because they are co-dependent on commands */
++static void usage_help(void);
++static void cmd_help(int argc, char **argv);
++
++static const command_t commands[] = {
++    {"bitmap",    cmd_bitmap,    usage_bitmap},
++    {"allocated", cmd_allocated, usage_allocated},
++    {"scan",      cmd_scan,      usage_scan},
++    {"help",      cmd_help,      usage_help},
++};
++
++static void usage_help(void) { fprintf(stderr, "Usage: help\n"); }
++
++static void cmd_help(int argc, char **argv) {
++    int i;
++    fprintf(stderr, "Usage: qcow2_helper <command> [options]\n\nCommands:\n");
++    for (i = 0; i < ARRAY_SIZE(commands); i++)
++        commands[i].usage();
++}
++
++int main(int argc, char *argv[]) {
++    int i;
++
++    if (argc < 2) {
++        fprintf(stderr, "Usage: %s <command> [options]\nRun '%s help' for a list of commands.\n", argv[0], argv[0]);
++        exit(EXIT_FAILURE);
++    }
++
++    for (i = 0; i < ARRAY_SIZE(commands); i++) {
++        if (!strcmp(commands[i].name, argv[1])) {
++            commands[i].fn(argc - 1, argv + 1);
++            return EXIT_SUCCESS;
++        }
++    }
++
++    fprintf(stderr, "Command %s is unknown.\nRun '%s help' for a list of commands.\n", argv[1], argv[0]);
++    return EXIT_FAILURE;
+ }
+diff --git a/qcow2/qcow_helper.h b/qcow2/qcow_helper.h
+index 0271dddb..e157decd 100644
+--- a/qcow2/qcow_helper.h
++++ b/qcow2/qcow_helper.h
+@@ -1,10 +1,14 @@
++#include <errno.h>
++#include <fcntl.h>
++#include <fnmatch.h>
++#include <getopt.h>
++#include <libgen.h>
++#include <stdbool.h>
++#include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <stdint.h>
+ #include <string.h>
+-#include <fcntl.h>
+ #include <unistd.h>
+-#include <errno.h>
+ 
+ #define QCOW2_HEADER_SIZE 104
+ #define QCOW2_MAGIC 0x514649FB
+@@ -17,6 +21,25 @@
+ /* Incompatible features */
+ #define INCOMPATIBLE_FEATURE_EXTENDED_L2 0x0010
+ 
++#define NAME_MAX_SIZE 512
++
++/* Custom header */
++#define CUSTOM_HEADER_TYPE 0x76617465  //vate: it is easy to recognize with hexdump -C
++
++#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
++
++typedef struct {
++    const char *name;
++    void (*fn)(int argc, char **argv);
++    void (*usage)(void);
++} command_t;
++
++struct custom_header{
++    uint32_t type;
++    uint32_t length;
++    uint64_t data;
++};
++
+ struct qcow2_header {
+     uint32_t magic;
+     uint32_t version;
+@@ -43,3 +66,15 @@ struct qcow2_header {
+ 
+ #define SWAP_BE_TO_LE(size, x) \
+     header->x = __builtin_bswap ##size(header->x)
++
++static inline uint64_t qcow2_cluster_size(const struct qcow2_header *header) {
++    return (uint64_t)1 << header->cluster_bits;
++}
++
++static inline int qcow2_extended_l2(const struct qcow2_header *header) {
++    return (header->version == 3) && (header->incompatible_features & INCOMPATIBLE_FEATURE_EXTENDED_L2);
++}
++
++static inline uint64_t qcow2_nb_l2_entries(uint64_t cluster_size, int extended_l2) {
++    return extended_l2 ? cluster_size / (sizeof(uint64_t) * 2) : cluster_size / sizeof(uint64_t);
++}
+diff --git a/qcow2/util.h b/qcow2/util.h
+new file mode 100644
+index 00000000..06cce42d
+--- /dev/null
++++ b/qcow2/util.h
+@@ -0,0 +1,52 @@
++/*
++ * Copyright (c) 2016, Citrix Systems, Inc.
++ *
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ * 
++ *  1. Redistributions of source code must retain the above copyright
++ *     notice, this list of conditions and the following disclaimer.
++ *  2. Redistributions in binary form must reproduce the above copyright
++ *     notice, this list of conditions and the following disclaimer in the
++ *     documentation and/or other materials provided with the distribution.
++ *  3. Neither the name of the copyright holder nor the names of its 
++ *     contributors may be used to endorse or promote products derived from 
++ *     this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
++ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
++ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
++ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#ifndef __TAPDISK_UTIL_H__
++#define __TAPDISK_UTIL_H__
++
++#include <stddef.h>
++#include <string.h>
++
++#define ARRAY_SIZE(_a) (sizeof(_a)/sizeof((_a)[0]))
++
++/*
++ * Strncpy variant that guarantees to terminate the string
++ */
++static inline char *
++safe_strncpy(char *dest, const char *src, size_t n)
++{
++	char *pdest;
++	pdest = strncpy(dest, src, n - 1);
++	if (n > 0)
++		dest[n - 1] = '\0';
++	return pdest;
++}
++
++#endif /* __TAPDISK_UTIL_H__ */

--- a/SOURCES/0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
+++ b/SOURCES/0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
@@ -1,0 +1,56 @@
+From 8d2876ee9f486e9f8ea33ecc94af5a312c55c297 Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Thu, 28 May 2026 16:15:22 +0200
+Subject: [PATCH] fix(cleanup): fix for live leaf coalesce
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In case of two leaf coalesce following each other, tapdisk would crash.
+```
+*b43ce641[qcow2](1.000G///1.004G|ao)
+    *e735e552[qcow2](1.000G///1.004G|ao)
+        340334d1[qcow2](1.000G///1.004G|ao)
+```
+340334d1 would be merged in e735e552 following a commit.
+Then e735e552 would be renamed in 340334d1 to maintain the same UUID for the leaf.
+tapdisk would automatically be using e735e552 as leaf after the commit but
+would not know about the rename. The next leaf coalesce would refer to the leaf
+with the same name but tapdisk would not know to refer to e735e552 instead. We
+introduced a refresh of the VDI so tapdisk read updated information from the
+chain after each leaf coalesce.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/cleanup.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/cleanup.py b/drivers/cleanup.py
+index bc2ba837..dfc9a09c 100755
+--- a/drivers/cleanup.py
++++ b/drivers/cleanup.py
+@@ -2854,6 +2854,7 @@ class SR(object):
+ 
+     def _liveLeafCoalesce(self, vdi: VDI, coalesce_on_remote: bool = False) -> bool:
+         util.fistpoint.activate("LVHDRT_coaleaf_delay_3", self.uuid)
++        need_refresh = False
+         self.lock()
+         try:
+             self.scan()
+@@ -2872,6 +2873,7 @@ class SR(object):
+                     self._create_running_file(vdi)
+                     # "vdi" object will no longer be valid after this call
+                     self._doCoalesceLeaf(vdi, coalesce_on_remote)
++                    need_refresh = True
+                 except:
+                     Util.logException("_doCoalesceLeaf")
+                     self._handleInterruptedCoalesceLeaf()
+@@ -2880,6 +2882,8 @@ class SR(object):
+                 vdi = self.getVDI(uuid)
+                 if vdi:
+                     vdi.ensureUnpaused()
++                    if need_refresh:
++                        vdi.refresh()
+                 self._delete_running_file(vdi)
+                 vdiOld = self.getVDI(self.TMP_RENAME_PREFIX + uuid)
+                 if vdiOld:

--- a/SOURCES/0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
+++ b/SOURCES/0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
@@ -1,0 +1,39 @@
+From c7a470cee22a209c97124f52fba727fa26c6162b Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Fri, 29 May 2026 16:02:29 +0200
+Subject: [PATCH] fix(LVMSR): added a missing call to _setType
+
+The _setType wasn't called if image_format was obtained before.
+An error introduced in rebasing for
+`feat(SR): add a supported image format list defined by drivers` (32ca93209a9e62e7c31a1688d36d2c3c4dc18e5d)
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LVMSR.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/LVMSR.py b/drivers/LVMSR.py
+index 11ceeef8..d3d5008c 100755
+--- a/drivers/LVMSR.py
++++ b/drivers/LVMSR.py
+@@ -1375,9 +1375,9 @@ class LVMVDI(VDI.VDI):
+                 # We need it to validate the vdi_type choice
+                 for image_format in self.sr.preferred_image_formats:
+                     vdi_type = self.sr._resolve_vdi_type_from_image_format(image_format)
+-                    self._setType(vdi_type)
++                    cowutil = getCowUtil(vdi_type)
+                     try:
+-                        self.cowutil.validateAndRoundImageSize(size)
++                        cowutil.validateAndRoundImageSize(size)
+                         break
+                     except xs_errors.SROSError:
+                         util.SMlog(f"We won't be able to create the VDI with format {vdi_type}.")
+@@ -1385,7 +1385,7 @@ class LVMVDI(VDI.VDI):
+                 # For cbt_metadata, we found ourselves here without being a vdi_create, we don't have size
+                 util.SMlog("Not a vdi_create, must be cbtlog")
+                 image_format = self.sr.preferred_image_formats[0]
+-                self._setType(self.sr._resolve_vdi_type_from_image_format(image_format))
++        self._setType(self.sr._resolve_vdi_type_from_image_format(image_format))
+ 
+         if self.sr.legacyMode and self.sr.cmd == 'vdi_create' and VdiType.isCowImage(self.vdi_type):
+             raise xs_errors.XenError('VDICreate', opterr='Cannot create COW type disk in legacy mode')

--- a/SOURCES/0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
+++ b/SOURCES/0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
@@ -1,0 +1,34 @@
+From bcbba772de3c0563a1746d8b4f19ffaaf8b5988a Mon Sep 17 00:00:00 2001
+From: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+Date: Thu, 13 Nov 2025 10:38:14 +0100
+Subject: [PATCH] LVHDSR: convert refvdi retured by get_snapshot_of to vdi_uuid
+
+Signed-off-by: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+---
+ drivers/LVMSR.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/LVMSR.py b/drivers/LVMSR.py
+index d3d5008c..89976cb7 100755
+--- a/drivers/LVMSR.py
++++ b/drivers/LVMSR.py
+@@ -258,6 +258,7 @@ class LVMSR(SR.SR):
+             vdi_info = {}
+             for vdi in self.session.xenapi.SR.get_VDIs(self.sr_ref):
+                 vdi_uuid = self.session.xenapi.VDI.get_uuid(vdi)
++                is_a_snapshot = int(self.session.xenapi.VDI.get_is_a_snapshot(vdi))
+ 
+                 vdi_type = self.session.xenapi.VDI.get_sm_config(vdi).get('vdi_type')
+                 if not vdi_type:
+@@ -270,9 +271,9 @@ class LVMSR(SR.SR):
+                     NAME_LABEL_TAG: util.to_plain_string(self.session.xenapi.VDI.get_name_label(vdi)),
+                     NAME_DESCRIPTION_TAG: util.to_plain_string(self.session.xenapi.VDI.get_name_description(vdi)),
+                     IS_A_SNAPSHOT_TAG: \
+-                        int(self.session.xenapi.VDI.get_is_a_snapshot(vdi)),
++                        is_a_snapshot,
+                     SNAPSHOT_OF_TAG: \
+-                        self.session.xenapi.VDI.get_snapshot_of(vdi),
++                        self.session.xenapi.VDI.get_uuid(self.session.xenapi.VDI.get_snapshot_of(vdi)) if bool(is_a_snapshot) else '',
+                    SNAPSHOT_TIME_TAG: \
+                         self.session.xenapi.VDI.get_snapshot_time(vdi),
+                     TYPE_TAG: \

--- a/SOURCES/0158-test_LVMSR.py-check-that-the-snapshot_of-field-is-no.patch
+++ b/SOURCES/0158-test_LVMSR.py-check-that-the-snapshot_of-field-is-no.patch
@@ -1,0 +1,252 @@
+From bfd54d4afd6b99440265829417384e8371ab3a31 Mon Sep 17 00:00:00 2001
+From: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+Date: Tue, 9 Dec 2025 13:50:22 +0100
+Subject: [PATCH] test_LVMSR.py: check that the snapshot_of field is not
+ 'OpaqueRef:' format
+
+Signed-off-by: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+---
+ tests/test_LVMSR.py | 209 +++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 206 insertions(+), 3 deletions(-)
+
+diff --git a/tests/test_LVMSR.py b/tests/test_LVMSR.py
+index 0151e2f2..b9fee97f 100644
+--- a/tests/test_LVMSR.py
++++ b/tests/test_LVMSR.py
+@@ -49,7 +49,7 @@ class TestLVMSR(unittest.TestCase, Stubs):
+     def tearDown(self) -> None:
+         self.remove_stubs()
+ 
+-    def create_LVMSR(self, master=False, command='foo', sr_uuid=None):
++    def create_LVMSR(self, master=False, command='foo', sr_uuid=None, extra_params={}):
+         srcmd = mock.Mock()
+         srcmd.dconf = {'device': '/dev/bar'}
+         if master:
+@@ -58,6 +58,7 @@ class TestLVMSR(unittest.TestCase, Stubs):
+             'command': command,
+             'session_ref': 'some session ref',
+             'sr_ref': 'test_sr_ref'}
++        srcmd.params.update(extra_params)
+         if sr_uuid is None:
+             sr_uuid = str(uuid.uuid4())
+         return LVMSR.LVMSR(srcmd, sr_uuid)
+@@ -184,8 +185,6 @@ class TestLVMSR(unittest.TestCase, Stubs):
+             lambda x: get_vdi_data('name_description', x))
+         mock_session.xenapi.VDI.get_is_a_snapshot.side_effect = (
+             lambda x: get_vdi_data('is_a_snapshot', x))
+-        mock_session.xenapi.VDI.get_snapshot_of.side_effect = (
+-            lambda x: get_vdi_data('snapshot_of', x))
+         mock_session.xenapi.VDI.get_snapshot_time.side_effect = (
+             lambda x: get_vdi_data('snapshot_time', x))
+         mock_session.xenapi.VDI.get_type.side_effect = (
+@@ -457,6 +456,210 @@ class TestLVMSR(unittest.TestCase, Stubs):
+             call_args = mock_session.xenapi.VDI.db_introduce.call_args
+             self.assertEqual(call_args[0][0], new_vdi_uuid)
+ 
++    @mock.patch('LVMSR.cleanup', autospec=True)
++    @mock.patch('LVMSR.IPCFlag', autospec=True)
++    @mock.patch('LVMSR.lock.Lock', autospec=True)
++    @mock.patch('lvmcowutil.LvmCowUtil.getVolumeInfo')
++    @mock.patch('lvmcowutil.LvmCowUtil.getVDIInfo')
++    @mock.patch('LVMSR.SR.XenAPI')
++    @testlib.with_context
++    def test_snapshotof_success(self,
++                            context,
++                            mock_xenapi,
++                            mock_getVDIInfo,
++                            mock_getVolumeInfo,
++                            mock_lock,
++                            mock_ipc,
++                            mock_cleanup):
++        sr_uuid = str(uuid.uuid4())
++        self.stubout('LVMSR.lvutil._checkVG', autospec=True)
++        mock_lvm_cache = self.stubout('LVMSR.lvmcache.LVMCache')
++        mock_get_vg_stats = self.stubout('LVMSR.lvutil._getVGstats', autospec=True)
++        mock_scsi_get_size = self.stubout('LVMSR.scsiutil.getsize', autospec=True)
++        mock_cowutil_getAllInfoFromVG = self.stubout("cowutil.CowUtil.getAllInfoFromVG", autospec=True)
++        mock_sr_util_pathexists = self.stubout('LVMSR.util.pathexists', autospec=True)
++        mock_sr_util_gen_uuid = self.stubout('LVMSR.util.gen_uuid', autospec=True)
++        mock_cleanup.SR.TMP_RENAME_PREFIX = cleanup.SR.TMP_RENAME_PREFIX
++
++        device_size = 100 * 1024 * 1024
++        device_free = 10 * 1024 * 1024
++        mock_get_vg_stats.return_value = {
++            'physical_size': device_size,
++            'physical_utilisation': device_free,
++            'freespace': device_size - device_free}
++        mock_scsi_get_size.return_value = device_size
++        mock_lvm_cache.return_value.checkLV.return_value = False
++        mock_lvm_cache.return_value.getSize.return_value = 10240
++
++        mock_session = mock_xenapi.xapi_local.return_value
++        mock_session.xenapi.SR.get_sm_config.return_value = {
++            'allocation': 'thick',
++            'use_vhd': 'true'
++        }
++        vdi_data = {
++            'vdi1_ref': {
++                'uuid': str(uuid.uuid4()),
++                'name_label': "VDI1",
++                'name_description': "First VDI",
++                'is_a_snapshot': False,
++                'snapshot_of': None,
++                'snapshot_time': None,
++                'type': 'User',
++                'metadata-of-pool': None,
++                'sm-config': {
++                    'vdi_type': 'vhd'
++                }
++            }
++        }
++        metadata = {}
++
++        def get_vdis(sr_ref):
++            return list(vdi_data.keys())
++
++        def get_vdi_data(vdi_key, vdi_ref):
++            return vdi_data[vdi_ref][vdi_key]
++
++        def get_vdi_by_uuid(vdi_uuid):
++            return [v for v in vdi_data if vdi_data[v]['uuid'] == vdi_uuid][0]
++
++        def db_introduce(uuid, label, description, sr_ref, ty, shareable, read_only, other_config, location, xenstore_data, sm_config, managed, size, utilisation, metadata_of_pool, is_a_snapshot, snapshot_time, snapshot_of, cbt_enabled):
++            vdi_data.update({
++                'vdi3_ref': {
++                    'uuid': uuid,
++                    'name_label': label,
++                    'name_description': description,
++                    'is_a_snapshot': is_a_snapshot,
++                    'snapshot_of': snapshot_of,
++                    'snapshot_time': snapshot_time,
++                    'type': ty,
++                    'metadata-of-pool': metadata_of_pool,
++                    'sm-config': {
++                        'vdi_type': 'vhd'
++                    }
++                }})
++            return 'vdi3_ref'
++
++        mock_session.xenapi.VDI.get_uuid.side_effect = (
++            lambda x: get_vdi_data('uuid', x))
++        mock_session.xenapi.VDI.get_name_label.side_effect = (
++            lambda x: get_vdi_data('name_label', x))
++        mock_session.xenapi.VDI.get_name_description.side_effect = (
++            lambda x: get_vdi_data('name_description', x))
++        mock_session.xenapi.VDI.get_is_a_snapshot.side_effect = (
++            lambda x: get_vdi_data('is_a_snapshot', x))
++        mock_session.xenapi.VDI.get_snapshot_of.side_effect = (
++            lambda x: get_vdi_data('snapshot_of', x))
++        mock_session.xenapi.VDI.get_snapshot_time.side_effect = (
++            lambda x: get_vdi_data('snapshot_time', x))
++        mock_session.xenapi.VDI.get_type.side_effect = (
++            lambda x: get_vdi_data('type', x))
++        mock_session.xenapi.VDI.get_metadata_of_pool.side_effect = (
++            lambda x: get_vdi_data('metadata-of-pool', x))
++        mock_session.xenapi.VDI.get_sm_config.side_effect = (
++            lambda x: get_vdi_data('sm-config', x))
++        mock_session.xenapi.SR.get_VDIs.side_effect = get_vdis
++        mock_session.xenapi.VDI.get_by_uuid.side_effect = get_vdi_by_uuid
++        mock_session.xenapi.VDI.db_introduce.side_effect = db_introduce
++
++        sr = self.create_LVMSR(master=True, command='sr_attach',
++                                sr_uuid=sr_uuid,
++                                extra_params={'driver_params': {'type': 'double'}, 'vdi_ref': 'vdi1_ref'})
++        os.makedirs(sr.path)
++
++        # Act (1)
++        # This introduces the metadata volume
++        sr.attach(sr.uuid)
++
++        # Create and check snapshot in metadata
++        vdis_info = {}
++        def addVdi(vdi_info):
++            uuid = vdi_info['uuid']
++            metadata[uuid] = {
++                'uuid': uuid,
++                'is_a_snapshot': vdi_info['is_a_snapshot'],
++                'snapshot_of': vdi_info['snapshot_of'],
++                'vdi_type':  vdi_info['vdi_type'],
++                'name_label': vdi_info['name_label'],
++                'name_description': vdi_info['name_description'],
++                'type': vdi_info['type'],
++                'read_only':  False,
++                'managed': True
++                }
++            vdi_data['vdi3_ref']['snapshot_of'] = 'vdi3_ref'
++            vdi_data['vdi3_ref']['is_a_snapshot'] = vdi_info['is_a_snapshot']
++            vdis_info.update({uuid: lvmcowutil.VDIInfo(uuid)})
++
++        def write_metadata(sr_info, vdi_info):
++            for item in vdi_info.items():
++                metadata[item[0]] = {
++                    'uuid': item[1]['uuid'],
++                    'is_a_snapshot': item[1]['is_a_snapshot'],
++                    'snapshot_of': item[1]['snapshot_of'],
++                    'vdi_type': item[1]['vdi_type'],
++                    'name_label': item[1]['name_label'],
++                    'name_description': item[1]['name_description'],
++                    'type': item[1]['type'],
++                    'read_only': False,
++                    'managed': True,
++                }
++            return metadata
++
++        mock_metadata = self.stubout('LVMSR.LVMMetadataHandler')
++        mock_metadata.return_value.addVdi.side_effect = addVdi
++        mock_metadata.return_value.writeMetadata.side_effect = write_metadata
++
++        self.stubout('journaler.Journaler.create')
++        self.stubout('journaler.Journaler.remove')
++        self.stubout('LVMSR.RefCounter.set')
++        self.stubout('LVMSR.RefCounter.put')
++
++        vdi_uuid = get_vdi_data('uuid', 'vdi1_ref')
++
++        for vdi_meta in vdi_data.values():
++            vdis_info.update({vdi_meta['uuid']: lvmcowutil.VDIInfo(vdi_meta['uuid'])})
++        mock_getVDIInfo.return_value = vdis_info
++
++        mock_lv = lvutil.LVInfo('test-lv')
++        mock_lv.size = 10240
++        mock_lv.active = True
++        mock_lv.hidden = False
++        mock_lv.vdiType = VdiType.VHD
++
++        mock_getVolumeInfo.return_value = {vdi_uuid: mock_lv}
++
++        vdiInfo = cowutil.CowImageInfo(vdi_uuid)
++        vdiInfo.hidden = False
++
++        mock_getCowUtil = self.stubout('LVMSR.getCowUtil')
++        mock_cowutil = mock_getCowUtil.return_value
++        mock_cowutil.getInfo.return_value = vdiInfo
++
++        mock_cowutil_getAllInfoFromVG.return_value = {vdiInfo.uuid: vdiInfo}
++
++        vdi = sr.vdi(vdi_uuid)
++        vdi.vdi_type = VdiType.VHD
++        mock_sr_util_pathexists.return_value = True
++        def gen_uuid():
++            return str(uuid.uuid4())
++        mock_sr_util_gen_uuid.side_effect = gen_uuid
++        mock_cowutil.getDepth.return_value = 1
++        mock_cowutil.getMaxChainLength.return_value = 30
++        mock_cowutil.getDefaultPreallocationSizeVirt.return_value = 0
++        mock_cowutil.calcOverheadEmpty.return_value = 0
++        mock_cowutil.calcOverheadBitmap.return_value = 0
++        mock_cowutil.getSizePhys.return_value = 10240
++        mock_cowutil.getParentChain.return_value = {vdi_uuid: 'test-lv'}
++        self.stubout('LVMSR.LVMSR._ensureSpaceAvailable')
++
++        snap = vdi.snapshot(sr.uuid, vdi_uuid)
++        snapshot_of = metadata[get_vdi_data('uuid', 'vdi3_ref')]['snapshot_of']
++        self.assertEqual(snapshot_of.startswith('OpaqueRef:'), False)
++
++        # Update SR metadata and recheck snapshot field
++        metadata = {}
++        sr.updateSRMetadata('thick')
++        snapshot_of = metadata[get_vdi_data('uuid', 'vdi3_ref')]['snapshot_of']
++        self.assertEqual(snapshot_of.startswith('OpaqueRef:'), False)
+ 
+ class TestLVMVDI(unittest.TestCase, Stubs):
+     @override

--- a/SOURCES/0159-fix-FileSR-preserve-image-format-during-DB-update-14.patch
+++ b/SOURCES/0159-fix-FileSR-preserve-image-format-during-DB-update-14.patch
@@ -1,0 +1,33 @@
+From b67f4ab5b8de5ea056c7d6c854c14414e7fa8c9f Mon Sep 17 00:00:00 2001
+From: Erwan Croze <erwan.croze@vates.tech>
+Date: Wed, 10 Jun 2026 00:08:49 +0200
+Subject: [PATCH] fix(FileSR): preserve `image-format` during DB update (#140)
+
+This field can be removed during VDI actions like `resize`.
+Fixed using `_override_sm_config` to keep the value like for `vhd-parent`
+
+Signed-off-by: Erwan Croze <erwan.croze@vates.tech>
+---
+ drivers/FileSR.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/FileSR.py b/drivers/FileSR.py
+index 2259f914..47ae04bc 100755
+--- a/drivers/FileSR.py
++++ b/drivers/FileSR.py
+@@ -543,6 +543,7 @@ class FileVDI(VDI.VDI):
+                 self.sm_config_override = {'vhd-parent': self.parent}
+             else:
+                 self.sm_config_override = {'vhd-parent': None}
++            self.sm_config_override["image-format"] = getImageStringFromVdiType(self.vdi_type)
+             return
+ 
+         try:
+@@ -593,6 +594,7 @@ class FileVDI(VDI.VDI):
+                 else:
+                     self.parent = ""
+                     self.sm_config_override = {'vhd-parent': None}
++                self.sm_config_override["image-format"] = getImageStringFromVdiType(self.vdi_type)
+                 self.size = image_info.sizeVirt
+                 self.hidden = image_info.hidden
+                 if self.hidden:

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -249,6 +249,7 @@ Patch1155: 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
 Patch1156: 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
 Patch1157: 0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
 Patch1158: 0158-test_LVMSR.py-check-that-the-snapshot_of-field-is-no.patch
+Patch1159: 0159-fix-FileSR-preserve-image-format-during-DB-update-14.patch
 
 %description
 This package contains storage backends used in XCP
@@ -580,6 +581,7 @@ fi
 - Add 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
 - Add 0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
 - Add 0158-test_LVMSR.py-check-that-the-snapshot_of-field-is-no.patch
+- Add 0159-fix-FileSR-preserve-image-format-during-DB-update-14.patch
 
 * Tue May 26 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-21.1
 - Rebase on 3.2.12-21

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -247,6 +247,7 @@ Patch1153: 0153-fix-qcow2-online-coalesce-on-LVMSR.patch
 Patch1154: 0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
 Patch1155: 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
 Patch1156: 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
+Patch1157: 0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
 
 
 %description
@@ -577,6 +578,8 @@ fi
 - Add 0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
 - Add 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
 - Add 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
+- Add 0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
+
 
 * Tue May 26 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-21.1
 - Rebase on 3.2.12-21

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.9%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -242,6 +242,11 @@ Patch1148: 0148-fix-cleanup-online-coalesce-would-crash.patch
 Patch1149: 0149-fix-linstor-add-backward-compatibility-for-getInfo.patch
 Patch1150: 0150-fix-linstor-add-backward-compatibility-for-manager-p.patch
 Patch1151: 0151-fix-LVMSR-scan-with-cbt_metadata.patch
+Patch1152: 0152-feat-qcow2-live-leaf-coalesce.patch
+Patch1153: 0153-fix-qcow2-online-coalesce-on-LVMSR.patch
+Patch1154: 0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
+Patch1155: 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
+Patch1156: 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
 
 
 %description
@@ -566,6 +571,13 @@ then
 fi
 
 %changelog
+* Fri Jun 05 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-21.2
+- Add 0152-feat-qcow2-live-leaf-coalesce.patch
+- Add 0153-fix-qcow2-online-coalesce-on-LVMSR.patch
+- Add 0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
+- Add 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
+- Add 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
+
 * Tue May 26 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-21.1
 - Rebase on 3.2.12-21
 - Remove patches merged upstream:

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -248,7 +248,7 @@ Patch1154: 0154-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
 Patch1155: 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
 Patch1156: 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
 Patch1157: 0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
-
+Patch1158: 0158-test_LVMSR.py-check-that-the-snapshot_of-field-is-no.patch
 
 %description
 This package contains storage backends used in XCP
@@ -579,7 +579,7 @@ fi
 - Add 0155-fix-cleanup-fix-for-live-leaf-coalesce.patch
 - Add 0156-fix-LVMSR-added-a-missing-call-to-_setType.patch
 - Add 0157-LVHDSR-convert-refvdi-retured-by-get_snapshot_of-to-.patch
-
+- Add 0158-test_LVMSR.py-check-that-the-snapshot_of-field-is-no.patch
 
 * Tue May 26 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-21.1
 - Rebase on 3.2.12-21


### PR DESCRIPTION
Added patches for QCOW2 support:
- Added live leaf coalesce
- Added an optimization for scan on LVMSR using qcow2_helper
- Added a fix for the image_format choice in load of LVMSR that introduced a regression

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-XXXX or N/A

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

ANSWER, or N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

ANSWER

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

TARGET, or remove this line.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

ANSWER

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

ANSWER, or N/A

#### Documentation update needed

- [ ] Yes
- [ ] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

EXPLANATIONS

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: LINKS, TODO, or N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

ANSWER

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

ANSWER

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

ANSWER

#### What tests have been or will be added to CI for this change? If none, explain why.

ANSWER

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [ ] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
