### PR TITLE
Release 3.2.12-23.2

### DIFF
--- a/SOURCES/0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
+++ b/SOURCES/0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
@@ -1,0 +1,32 @@
+From 82c3f5227a45521905c22dc60978dd3642345c28 Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.tech>
+Date: Thu, 30 Jul 2026 17:40:31 +0200
+Subject: [PATCH] fix(linstor): use quotes on linstor type annotations (#150)
+
+Without that and if LINSTOR python package is not installed we can have
+issues to register our drivers. `AttributeError` is raised and not catched by
+other modules during imports...
+
+Trace:
+```
+Jul 30 17:11:36 hpm1c20 xapi: [error||0 |Registering SMAPIv1 plugins D:6829eea78bbd|sm_exec] Rejecting SM plugin: LVM because of exception: Storage_error ([S(Backend_error);[S(SR_BACKEND_FAILURE);[S(non-zero exit);S();S(Traceback (most recent call last):\x0A  File "/opt/xensource/sm/LVMSR", line 23, in <module>\x0A    import SR\x0A  File "/opt/xensource/sm/SR.py", line 23, in <module>\x0A    import VDI\x0A  File "/opt/xensource/sm/VDI.py", line 21, in <module>\x0A    import cleanup\x0A  File "/opt/xensource/sm/cleanup.py", line 44, in <module>\x0A    import blktap2\x0A  File "/opt/xensource/sm/blktap2.py", line 60, in <module>\x0A    from linstorvolumemanager import get_controller_uri, get_all_volume_openers, LinstorVolumeManager\x0A  File "/opt/xensource/sm/linstorvolumemanager.py", line 262, in <module>\x0A    class LinstorVolumeManager(object):\x0A  File "/opt/xensource/sm/linstorvolumemanager.py", line 420, in LinstorVolumeManager\x0A    def native_client(self) -> linstor.Linstor:\x0AAttributeError: module 'linstor' has no attribute 'Linstor'\x0A)]]]) (executable)
+```
+
+Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.tech>
+---
+ drivers/linstorvolumemanager.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/linstorvolumemanager.py b/drivers/linstorvolumemanager.py
+index 9373569a..24cfbad1 100755
+--- a/drivers/linstorvolumemanager.py
++++ b/drivers/linstorvolumemanager.py
+@@ -417,7 +417,7 @@ class LinstorVolumeManager(object):
+         return self._uri
+ 
+     @property
+-    def native_client(self) -> linstor.Linstor:
++    def native_client(self) -> "linstor.Linstor":
+         return self._linstor
+ 
+     @property

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -258,6 +258,7 @@ Patch1160: 0160-fix-linstor-abort-GC-for-slave-if-VHD-chain-is-open-.patch
 Patch1161: 0161-refactor-merge-timeout-and-timeout_call-functions-13.patch
 Patch1162: 0162-fix-qcow2-verify-and-limit-raw-snapshot-size-147.patch
 Patch1163: 0163-fix-qcow2-read-FileSR-allocated-size-only-when-neede.patch
+Patch1164: 0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
 
 %description
 This package contains storage backends used in XCP
@@ -581,6 +582,9 @@ then
 fi
 
 %changelog
+* Mon Aug 03 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 3.2.12-23.2
+- Add 0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
+
 * Mon Jul 13 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-23.1
 - Rebase on 3.2.12-23
 - Sync patches with our latest 3.2.12-8.3 branch


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3599

#### Related changes (optional)

N/A

#### Context & Motivation

Without that and if LINSTOR python package is not installed we can have issues to register our drivers. `AttributeError` is raised and not catched by other modules during imports.
To be clear: we can't release previous RPM without this additional fix.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

---

### Release Notes and Documentation

#### Explain the change to users

No release note, because it fixes the previous build that is not released.

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

N/A

#### What tests have you performed?

Manual tests on a pool with LINSTOR not installed.

#### What manual tests should be performed after the build, and by whom?

Update and XAPI restart without LINSTOR packages and by storage team.

#### What's covered by the xcp-ng-tests test suite?

The detection of this issue even the problem was detected late by the tests.

#### What tests have been or will be added to CI for this change? If none, explain why.

Nothing to add. See previous answer.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
