### PR TITLE
Release 3.2.12-23.4

### DIFF
--- a/SOURCES/0154-fix-cleanup-fix-for-live-leaf-coalesce.patch
+++ b/SOURCES/0154-fix-cleanup-fix-for-live-leaf-coalesce.patch
@@ -1,4 +1,4 @@
-From e1b94cb363612f50c1b8b0303e6243e3dffa4705 Mon Sep 17 00:00:00 2001
+From d858cf5c198e648d270f5e8a945a6974c05e3404 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Thu, 28 May 2026 16:15:22 +0200
 Subject: [PATCH] fix(cleanup): fix for live leaf coalesce
@@ -26,31 +26,17 @@ Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index bc2ba837..dfc9a09c 100755
+index bc2ba837..d559efd1 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
-@@ -2854,6 +2854,7 @@ class SR(object):
- 
-     def _liveLeafCoalesce(self, vdi: VDI, coalesce_on_remote: bool = False) -> bool:
-         util.fistpoint.activate("LVHDRT_coaleaf_delay_3", self.uuid)
-+        need_refresh = False
-         self.lock()
-         try:
-             self.scan()
-@@ -2872,6 +2873,7 @@ class SR(object):
-                     self._create_running_file(vdi)
-                     # "vdi" object will no longer be valid after this call
-                     self._doCoalesceLeaf(vdi, coalesce_on_remote)
-+                    need_refresh = True
-                 except:
-                     Util.logException("_doCoalesceLeaf")
-                     self._handleInterruptedCoalesceLeaf()
-@@ -2880,6 +2882,8 @@ class SR(object):
-                 vdi = self.getVDI(uuid)
-                 if vdi:
-                     vdi.ensureUnpaused()
-+                    if need_refresh:
-+                        vdi.refresh()
-                 self._delete_running_file(vdi)
-                 vdiOld = self.getVDI(self.TMP_RENAME_PREFIX + uuid)
-                 if vdiOld:
+@@ -2905,6 +2905,10 @@ class SR(object):
+             _, host_ref = next(iter(host_refs.items()))
+             vdi._coalesceCowImageOnHost(host_ref, vdi) # vdi is the leaf for the online coalesce
+             util.fistpoint.activate("LVHDRT_coaleaf_after_coalesce", self.uuid)
++            vdi.pause(failfast=True)
++            # We make a pause here after the online coalesce but before the rename so we can refresh the chain for tapdisk. 
++            # It's also needed to be paused for the rename on slaves with LVMSR.
++            # We let the caller `_liveLeafCoalesce` do the unpause with the call to `vdi.ensureUnpaused()`
+         else:
+             vdi.validate(True)
+             vdi.parent.validate(True)

--- a/SOURCES/0155-fix-LVMSR-added-a-missing-call-to-_setType.patch
+++ b/SOURCES/0155-fix-LVMSR-added-a-missing-call-to-_setType.patch
@@ -1,4 +1,4 @@
-From fb32d789b804c63e51dfc841c6d45bb86685194a Mon Sep 17 00:00:00 2001
+From abd3e9cc7a88de2d2ae72b4c6e277c6ebd1e7aeb Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Fri, 29 May 2026 16:02:29 +0200
 Subject: [PATCH] fix(LVMSR): added a missing call to _setType

--- a/SOURCES/0156-fix-linstor-don-t-load-VDIs-during-VDI.deactivate-ca.patch
+++ b/SOURCES/0156-fix-linstor-don-t-load-VDIs-during-VDI.deactivate-ca.patch
@@ -1,4 +1,4 @@
-From 4d3994efddcb1c9cac23029dbd7fced231eaecd6 Mon Sep 17 00:00:00 2001
+From b666173fd0a6615210e071c8a0e40f0f2041ee1b Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.tech>
 Date: Fri, 5 Jun 2026 11:29:52 +0200
 Subject: [PATCH] fix(linstor): don't load VDIs during `VDI.deactivate` call

--- a/SOURCES/0157-fix-linstor-ensure-journaler-is-created-in-a-lock-co.patch
+++ b/SOURCES/0157-fix-linstor-ensure-journaler-is-created-in-a-lock-co.patch
@@ -1,4 +1,4 @@
-From 13d88f5a730ab0a4d066cf919a9b5d8d48cdaa73 Mon Sep 17 00:00:00 2001
+From d8f1af99cea104fcd2944037606b026e03af6021 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.tech>
 Date: Mon, 8 Jun 2026 11:48:48 +0200
 Subject: [PATCH] fix(linstor): ensure journaler is created in a lock context

--- a/SOURCES/0158-feat-linstor-use-client-when-possible-to-construct-j.patch
+++ b/SOURCES/0158-feat-linstor-use-client-when-possible-to-construct-j.patch
@@ -1,4 +1,4 @@
-From fe72e63ee63bfd276236c5f90524ac949c22bd12 Mon Sep 17 00:00:00 2001
+From 00fcdf11fcc6e68ff7626fe6edd243ee63aaecd3 Mon Sep 17 00:00:00 2001
 From: Alexandre Sollier <github@kuruyia.net>
 Date: Fri, 19 Jun 2026 15:59:47 +0200
 Subject: [PATCH] feat(linstor): use client when possible to construct
@@ -42,7 +42,7 @@ index 39ac083d..9ac4de88 100755
          return self._journaler
  
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index dfc9a09c..5442309a 100755
+index d559efd1..fb0eb7e0 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
 @@ -3627,6 +3627,7 @@ class LinstorSR(SR):

--- a/SOURCES/0159-fix-cleanup-check-earlier-for-chain-attached-on-seve.patch
+++ b/SOURCES/0159-fix-cleanup-check-earlier-for-chain-attached-on-seve.patch
@@ -1,4 +1,4 @@
-From c4dce9ee7df6c4b95b489700eb39167f877d1420 Mon Sep 17 00:00:00 2001
+From b2005960fb2ddf00087b97d4cff37b0d34047475 Mon Sep 17 00:00:00 2001
 From: Anthoine <anthoine.bourgeois@vates.tech>
 Date: Wed, 1 Jul 2026 17:10:25 +0200
 Subject: [PATCH] fix(cleanup): check earlier for chain attached on several
@@ -13,7 +13,7 @@ Signed-off-by: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
  1 file changed, 22 insertions(+), 11 deletions(-)
 
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index 5442309a..74d06e68 100755
+index fb0eb7e0..7e21767b 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
 @@ -666,11 +666,20 @@ class VDI(object):
@@ -69,7 +69,7 @@ index 5442309a..74d06e68 100755
  
              try:
                  if host_refs and vdi.cowutil.isCoalesceableOnRemote():
-@@ -2903,7 +2914,7 @@ class SR(object):
+@@ -2899,7 +2910,7 @@ class SR(object):
          self._prepareCoalesceLeaf(vdi)
          vdi.parent._setHidden(False)
          vdi.parent._increaseSizeVirt(vdi.sizeVirt, False)

--- a/SOURCES/0160-fix-linstor-abort-GC-for-slave-if-VHD-chain-is-open-.patch
+++ b/SOURCES/0160-fix-linstor-abort-GC-for-slave-if-VHD-chain-is-open-.patch
@@ -1,4 +1,4 @@
-From 6d1130d761eff0c9b801f00f18319e05ee04e195 Mon Sep 17 00:00:00 2001
+From eda3099a3b49a32b9b77073da3afecf05f8e42a0 Mon Sep 17 00:00:00 2001
 From: Mathieu Labourier <mathieu.labourier@vates.tech>
 Date: Mon, 18 May 2026 12:24:33 +0200
 Subject: [PATCH] fix(linstor): abort GC for slave if VHD chain is open on
@@ -251,7 +251,7 @@ index 7c983db6..681bdd5b 100755
                      try:
                          tapdisk = cls.__from_blktap(blktap)
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index 74d06e68..ec8527c3 100755
+index 7e21767b..4393cfd3 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
 @@ -18,7 +18,7 @@

--- a/SOURCES/0161-refactor-merge-timeout-and-timeout_call-functions-13.patch
+++ b/SOURCES/0161-refactor-merge-timeout-and-timeout_call-functions-13.patch
@@ -1,4 +1,4 @@
-From 9f2a9046aa8f65b7a944b2e6e18226d43c36a9d2 Mon Sep 17 00:00:00 2001
+From 848aefcb95bdb3af9a0d48da917296bf3ab2e7fa Mon Sep 17 00:00:00 2001
 From: Mathieu Labourier <mathieu.labourier@vates.tech>
 Date: Wed, 20 May 2026 18:10:29 +0200
 Subject: [PATCH] refactor: merge timeout and timeout_call functions (#137)

--- a/SOURCES/0162-fix-qcow2-verify-and-limit-raw-snapshot-size-147.patch
+++ b/SOURCES/0162-fix-qcow2-verify-and-limit-raw-snapshot-size-147.patch
@@ -1,4 +1,4 @@
-From 88c5c79f6e5eb2d8352a5ed7e7249dd7bb5a0819 Mon Sep 17 00:00:00 2001
+From 87165f0587acc71cd19b6d42ced93066179b8b41 Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Thu, 9 Jul 2026 18:37:47 +0200
 Subject: [PATCH] fix(qcow2): verify and limit raw snapshot size (#147)

--- a/SOURCES/0163-fix-qcow2-read-FileSR-allocated-size-only-when-neede.patch
+++ b/SOURCES/0163-fix-qcow2-read-FileSR-allocated-size-only-when-neede.patch
@@ -1,4 +1,4 @@
-From bd75a44e387a24a099ecef44bbbd8ef67a90e264 Mon Sep 17 00:00:00 2001
+From 4d068baaa646450ebc3774b5e81c23374a8a2c0e Mon Sep 17 00:00:00 2001
 From: Damien Thenot <damien.thenot@vates.tech>
 Date: Thu, 9 Jul 2026 18:52:02 +0200
 Subject: [PATCH] fix(qcow2): read FileSR allocated size only when needed

--- a/SOURCES/0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
+++ b/SOURCES/0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
@@ -1,4 +1,4 @@
-From 82c3f5227a45521905c22dc60978dd3642345c28 Mon Sep 17 00:00:00 2001
+From 4a0a1e5a66967bc5fdf7672888d0fd3eae86ad63 Mon Sep 17 00:00:00 2001
 From: Ronan Abhamon <ronan.abhamon@vates.tech>
 Date: Thu, 30 Jul 2026 17:40:31 +0200
 Subject: [PATCH] fix(linstor): use quotes on linstor type annotations (#150)

--- a/SOURCES/0165-fix-RAWVDI-define-vdi_type-for-RAWVDI-151.patch
+++ b/SOURCES/0165-fix-RAWVDI-define-vdi_type-for-RAWVDI-151.patch
@@ -1,0 +1,63 @@
+From eaece9cae18ffb07c44b08064fcd431a8755905b Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Tue, 4 Aug 2026 18:27:14 +0200
+Subject: [PATCH] fix(RAWVDI): define vdi_type for RAWVDI (#151)
+
+Add `vdi_type` as `phy` for `drivers/LUNperVDI.py:RAWVDI.load()`.
+If we don't define a vdi_type, the VDI activation in blktap2.py will fail with error:
+```
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread] ***** generic exception: vdi_attach: EXCEPTION <class 'blktap2.VDI.UnexpectedVDIType'>, Target <class '__ma
+in__.ISCSIVDI'> has unexpected VDI type ''
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 113, in run
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     return self._run_locked(sr)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 163, in _run_locked
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     rv = self._run(sr, target)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 260, in _run
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     writable, caching_params=caching_params)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1616, in attach
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     {"rdonly": not writable})
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1854, in _activate
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     if self.tap_wanted():
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1154, in tap_wanted
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     vdi_type = self.target.get_vdi_type()
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1207, in get_vdi_type
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     raise VDI.UnexpectedVDIType(_type, self.vdi)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread] ***** iSCSI: EXCEPTION <class 'blktap2.VDI.UnexpectedVDIType'>, Target <class '__main__.ISCSIVDI'> has unex
+pected VDI type ''
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 392, in run
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     ret = cmd.run(sr)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 113, in run
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     return self._run_locked(sr)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 163, in _run_locked
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     rv = self._run(sr, target)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/SRCommand.py", line 260, in _run
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     writable, caching_params=caching_params)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1616, in attach
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     {"rdonly": not writable})
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1854, in _activate
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     if self.tap_wanted():
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1154, in tap_wanted
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     vdi_type = self.target.get_vdi_type()
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]   File "/opt/xensource/sm/blktap2.py", line 1207, in get_vdi_type
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]     raise VDI.UnexpectedVDIType(_type, self.vdi)
+Aug  4 17:21:28 r620-x1 SM: [202712][MainThread]
+```
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LUNperVDI.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/LUNperVDI.py b/drivers/LUNperVDI.py
+index 070c6711..fb59cb20 100755
+--- a/drivers/LUNperVDI.py
++++ b/drivers/LUNperVDI.py
+@@ -38,6 +38,7 @@ class RAWVDI(VDI.VDI):
+         self.uuid = vdi_uuid
+         self.location = vdi_uuid
+         self.managed = False
++        self.vdi_type = "phy"
+         try:
+             vdi_ref = self.sr.session.xenapi.VDI.get_by_uuid(vdi_uuid)
+             self.managed = self.sr.session.xenapi.VDI.get_managed(vdi_ref)

--- a/SOURCES/0166-Add-IO-import-in-sm_typing-152.patch
+++ b/SOURCES/0166-Add-IO-import-in-sm_typing-152.patch
@@ -1,0 +1,31 @@
+From 441d074e270b4a1046a3b50b6324a336ce88578c Mon Sep 17 00:00:00 2001
+From: Mathieu Labourier <mathieu.labourier@vates.tech>
+Date: Wed, 5 Aug 2026 17:19:01 +0200
+Subject: [PATCH] Add IO import in sm_typing (#152)
+
+Fixes an issue where IO was not imported with the
+global import statement, since IO is not in `typing.__all__`
+in python 3.6.
+
+This causes an issue when trying to import IO from sm_typing.
+
+Signed-off-by: Mathieu Labourier <mathieu.labourier@vates.tech>
+---
+ sm_typing/__init__.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/sm_typing/__init__.py b/sm_typing/__init__.py
+index 2b842871..4d58cd53 100644
+--- a/sm_typing/__init__.py
++++ b/sm_typing/__init__.py
+@@ -1,6 +1,10 @@
+ import typing
+ from typing import *
+ 
++# Manually importing `IO` for python 3.6 because it is not in `typing.__all__`
++# and so, not imported by the statement above.
++from typing import IO
++
+ if not hasattr(typing, 'override'):
+     def override(method): # type: ignore
+         try:

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.4%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -95,6 +95,8 @@ Obsoletes: sm-additional-drivers
 # XCP-ng patches
 # Generated from our sm repository
 # git format-patch v3.2.12-23-xcpng..HEAD --no-signature --no-numbered --grep='^chore(ci):' --invert-grep
+# WARNING: Patch `0153-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch` is currently disabled due to a
+# regression, so we're delaying the release of that feature.
 Patch1001: 0001-Update-xs-sm.service-s-description-for-XCP-ng.patch
 Patch1002: 0002-feat-drivers-add-CephFS-and-GlusterFS-drivers.patch
 Patch1003: 0003-feat-drivers-add-XFS-driver.patch
@@ -247,7 +249,7 @@ Patch1149: 0149-fix-linstor-add-backward-compatibility-for-manager-p.patch
 Patch1150: 0150-fix-LVMSR-scan-with-cbt_metadata.patch
 Patch1151: 0151-feat-qcow2-live-leaf-coalesce.patch
 Patch1152: 0152-fix-qcow2-online-coalesce-on-LVMSR.patch
-Patch1153: 0153-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
+# Patch1153: 0153-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
 Patch1154: 0154-fix-cleanup-fix-for-live-leaf-coalesce.patch
 Patch1155: 0155-fix-LVMSR-added-a-missing-call-to-_setType.patch
 Patch1156: 0156-fix-linstor-don-t-load-VDIs-during-VDI.deactivate-ca.patch
@@ -259,6 +261,8 @@ Patch1161: 0161-refactor-merge-timeout-and-timeout_call-functions-13.patch
 Patch1162: 0162-fix-qcow2-verify-and-limit-raw-snapshot-size-147.patch
 Patch1163: 0163-fix-qcow2-read-FileSR-allocated-size-only-when-neede.patch
 Patch1164: 0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
+Patch1165: 0165-fix-RAWVDI-define-vdi_type-for-RAWVDI-151.patch
+Patch1166: 0166-Add-IO-import-in-sm_typing-152.patch
 
 %description
 This package contains storage backends used in XCP
@@ -582,6 +586,15 @@ then
 fi
 
 %changelog
+* Thu Aug 13 2026 Alexandre Sollier <alexandre.sollier@vates.tech> - 3.2.12-23.4
+- Add new patches:
+  - 0165-fix-RAWVDI-define-vdi_type-for-RAWVDI-151.patch
+  - 0166-Add-IO-import-in-sm_typing-152.patch
+- Removed patches:
+  - 0153-feat-qcow2_helper-Added-a-scan-command-to-qcow2_help.patch
+- Updated patches:
+  - 0154-fix-cleanup-fix-for-live-leaf-coalesce.patch
+
 * Tue Aug 04 2026 Gaëtan Lehmann <gaetan.lehmann@vates.tech> - 3.2.12-23.3
 - Rebuild against OpenSSL 3.0
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3637

#### Related changes (optional)

N/A

#### Context & Motivation

This includes an important fix to a bug that prevents LINSTOR SRs from working, and another fix to a bug in blktap2 VDI activation.

Previous RPMs of this version cannot be released without those fixes.

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

---

### Release Notes and Documentation

#### Explain the change to users

No release note, because it fixes the previous build that is not released.

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

#### What tests have you performed?

Manual import tests.

#### What manual tests should be performed after the build, and by whom?

None, CI tests should be enough.

#### What's covered by the xcp-ng-tests test suite?

LINSTOR SR creation, VM creation/start on this SR.

#### What tests have been or will be added to CI for this change? If none, explain why.

None, the problem was already caught by the CI.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No