### PR TITLE
Release 3.2.12-23.5

### DIFF
--- a/SOURCES/0167-fix-display-image-format-as-its-string-value-in-erro.patch
+++ b/SOURCES/0167-fix-display-image-format-as-its-string-value-in-erro.patch
@@ -1,0 +1,34 @@
+From 602b7acf67ccb920204a3622a39f4b86859d7601 Mon Sep 17 00:00:00 2001
+From: Mathieu Labourier <mathieu.labourier@vates.tech>
+Date: Mon, 10 Aug 2026 11:24:44 +0200
+Subject: [PATCH] fix: display image format as its string value in error
+ message (#154)
+
+Signed-off-by: Mathieu Labourier <mathieu.labourier@vates.tech>
+---
+ drivers/SR.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/SR.py b/drivers/SR.py
+index e23edaad..6888c36d 100755
+--- a/drivers/SR.py
++++ b/drivers/SR.py
+@@ -36,7 +36,8 @@ from cowutil import (
+     getVdiTypeFromImageFormat,
+     ImageFormat,
+     parseImageFormats,
+-    STR_TO_IMAGE_FORMAT
++    STR_TO_IMAGE_FORMAT,
++    IMAGE_FORMAT_TO_STR,
+ )
+ 
+ from vditype import VdiType
+@@ -565,7 +566,7 @@ class SR(object):
+     def _resolve_vdi_type_from_image_format(self, image_format: ImageFormat) -> str:
+         if image_format in self.supported_image_formats:
+             return getVdiTypeFromImageFormat(image_format)
+-        raise xs_errors.XenError('VDIType', opterr=f'Unsupported image format `{image_format}`')
++        raise xs_errors.XenError('VDIType', opterr=f'Unsupported image format `{IMAGE_FORMAT_TO_STR[image_format]}`')
+ 
+     def _get_snap_vdi_type(self, vdi_type: str, size: int) -> str:
+         if VdiType.isCowImage(vdi_type):

--- a/SOURCES/0168-fix-LVMSR-set-QCOW2-chain-RW-from-the-master-on-vdi_.patch
+++ b/SOURCES/0168-fix-LVMSR-set-QCOW2-chain-RW-from-the-master-on-vdi_.patch
@@ -1,0 +1,144 @@
+From b48856127e9d2d8ac92740584ee12c47a2bf5c1c Mon Sep 17 00:00:00 2001
+From: Damien Thenot <damien.thenot@vates.tech>
+Date: Mon, 24 Aug 2026 15:33:00 +0200
+Subject: [PATCH] fix(LVMSR): set QCOW2 chain RW from the master on vdi_attach
+ (#155)
+
+Changing LVs to RW on coalesce on a remote host can clash with the master doing
+LVM commands.  It might even lead to LVM metadata corruption.  With this
+change, the `vdi_attach` will check if the chain is coalesceable on remote, if
+so it will ask the master to change the status before continuing.  It's copying
+the behavior of changing LV sizes in `_prepareThin`.
+
+Signed-off-by: Damien Thenot <damien.thenot@vates.tech>
+---
+ drivers/LVMSR.py    | 31 +++++++++++++++++++++++++++++++
+ drivers/on_slave.py | 45 +++++++++++++++++++++++++--------------------
+ 2 files changed, 56 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/LVMSR.py b/drivers/LVMSR.py
+index d3d5008c..fc72defc 100755
+--- a/drivers/LVMSR.py
++++ b/drivers/LVMSR.py
+@@ -1534,6 +1534,10 @@ class LVMVDI(VDI.VDI):
+                 util.logException("attach")
+                 raise xs_errors.XenError('LVMProvisionAttach')
+ 
++        if self.cowutil.isCoalesceableOnRemote():
++            # We make the chain RW before it's used so it can be coalesced online
++            self._make_chain_rw()
++
+         try:
+             return self._attach()
+         finally:
+@@ -2259,6 +2263,33 @@ class LVMVDI(VDI.VDI):
+             self.session.xenapi.SR.set_physical_utilisation(self.sr.sr_ref,
+                     str(sr_utilisation))
+ 
++    def _make_chain_rw(self):
++        """
++        In the case of QCOW2, we need the chain to be RW for the coalesce to be done by tapdisk.
++        Setting the chain to be RW early avoids having to stop the tapdisk so LVM can acknowledge the chain RW on the slave.
++        And while making the change to RW from the slave works without the refresh, it can cause LVM metadata corruption.
++        """
++        # TODO(XCPNG-3689): We could check if any VDI on the chain is RO before doing the call to master to change this
++        if self.sr.isMaster:
++            lvmcache = self.sr.lvmCache
++            for uuid, lvName in self.cowutil.getParentChain(self.lvname, LvmCowUtil.extractUuid, self.sr.vgname).items():
++                lvmcache.setReadonly(lvName, False)
++        else:
++            master = util.get_master_ref(self.session)
++            response = self.session.xenapi.host.call_plugin(
++                master,
++                self.sr.PLUGIN_ON_SLAVE,
++                "make_chain_rw",
++                {
++                    "vgName": self.sr.vgname,
++                    "lvName": self.lvname,
++                    "vdiType": self.vdi_type
++                }
++            )
++            util.SMlog(f"call-plugin returned: {response}")
++            if not response:
++                raise Exception(f"plugin {self.sr.PLUGIN_ON_SLAVE} failed")
++
+     @override
+     def update(self, sr_uuid, vdi_uuid) -> None:
+         if self.sr.legacyMode:
+diff --git a/drivers/on_slave.py b/drivers/on_slave.py
+index 3844684d..b903ecd8 100755
+--- a/drivers/on_slave.py
++++ b/drivers/on_slave.py
+@@ -162,22 +162,6 @@ def refresh_lun_size_by_SCSIid(session, args):
+         util.SMlog("on-slave.refresh_lun_size_by_SCSIid with %s failed" % args)
+         return "False"
+ 
+-def _make_chain_RW(cowutil, leaf_path, write: bool):
+-    def set_RW(path):
+-        try:
+-            util.pread2(["lvchange", "-p", "rw", path])
+-        except:
+-            pass
+-
+-    # if path.startswith("/dev/"):
+-    #     set_RW(leaf_path) # Not needed since it's a leaf
+-
+-    parent = cowutil.getParentNoCheck(leaf_path)
+-    while parent:
+-        if parent.startswith("/dev/"):
+-            set_RW(parent)
+-        parent = cowutil.getParentNoCheck(parent)
+-
+ def commit_tapdisk(session, args):
+     path: str = args["path"]
+     vdi_type = args["vdi_type"]
+@@ -186,12 +170,9 @@ def commit_tapdisk(session, args):
+     from cowutil import getCowUtil
+     cowutil = getCowUtil(vdi_type)
+     try:
+-        if path.startswith("/dev/"):
+-            # We need to make children RW or tapdisk will crash trying to do it
+-            _make_chain_RW(cowutil, leaf_path, True)
+         return str(cowutil.coalesceOnline(path))
+     except:
+-        util.logException("Couldn't coalesce online")
++        util.logException(f"Couldn't coalesce online: `{path}`")
+         raise
+ 
+ def commit_cancel(session, args):
+@@ -249,6 +230,29 @@ def is_openers(session, args):
+     openers_pid= util.get_openers_pid(path)
+     return str(bool(openers_pid))
+ 
++def make_chain_rw(session, args):
++    from cowutil import getCowUtil
++    from lvmcowutil import LvmCowUtil
++    from lvutil import MASTER_LVM_CONF
++
++    if util.is_master(session):
++        os.environ['LVM_SYSTEM_DIR'] = MASTER_LVM_CONF
++
++    vgName = args["vgName"]
++    lvName = args["lvName"]
++    vdi_type = args["vdiType"]
++
++    cowutil = getCowUtil(vdi_type)
++    lvmcache = LVMCache(vgName)
++
++    for uuid, lvName in cowutil.getParentChain(lvName, LvmCowUtil.extractUuid, vgName).items():
++        try:
++            lvmcache.setReadonly(lvName, False)
++        except util.CommandException as e:
++            util.SMlog(f"on-slave:make_chain_rw: {e}")
++
++    return "True"
++
+ if __name__ == "__main__":
+     import XenAPIPlugin
+     XenAPIPlugin.dispatch({
+@@ -259,4 +263,5 @@ if __name__ == "__main__":
+         "commit_tapdisk": commit_tapdisk,
+         "commit_cancel": commit_cancel,
+         "cancel_coalesce_master": cancel_coalesce_master,
++        "make_chain_rw": make_chain_rw,
+         })

--- a/SPECS/sm.spec
+++ b/SPECS/sm.spec
@@ -9,7 +9,7 @@
 Summary: sm - XCP storage managers
 Name:    sm
 Version: 3.2.12
-Release: %{?xsrel}.4%{?dist}
+Release: %{?xsrel}.5%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
 Source0: sm-3.2.12.tar.gz
@@ -263,6 +263,8 @@ Patch1163: 0163-fix-qcow2-read-FileSR-allocated-size-only-when-neede.patch
 Patch1164: 0164-fix-linstor-use-quotes-on-linstor-type-annotations-1.patch
 Patch1165: 0165-fix-RAWVDI-define-vdi_type-for-RAWVDI-151.patch
 Patch1166: 0166-Add-IO-import-in-sm_typing-152.patch
+Patch1167: 0167-fix-display-image-format-as-its-string-value-in-erro.patch
+Patch1168: 0168-fix-LVMSR-set-QCOW2-chain-RW-from-the-master-on-vdi_.patch
 
 %description
 This package contains storage backends used in XCP
@@ -586,6 +588,11 @@ then
 fi
 
 %changelog
+* Mon Aug 24 2026 Damien Thenot <damien.thenot@vates.tech> - 3.2.12-23.5
+- Add new patches:
+  - 0167-fix-display-image-format-as-its-string-value-in-erro.patch
+  - 0168-fix-LVMSR-set-QCOW2-chain-RW-from-the-master-on-vdi_.patch
+
 * Thu Aug 13 2026 Alexandre Sollier <alexandre.sollier@vates.tech> - 3.2.12-23.4
 - Add new patches:
   - 0165-fix-RAWVDI-define-vdi_type-for-RAWVDI-151.patch


### PR DESCRIPTION
Add new patches:
 - 0167-fix-display-image-format-as-its-string-value-in-erro.patch
 - 0168-fix-LVMSR-set-QCOW2-chain-RW-from-the-master-on-vdi_.patch

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3675

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

This introduce two changes: 
- A little fix for an error message
- A fix for the LVMSR VDI activation to be made RW on the master, the current call is done on the slave and it can causes issues when LVM commands are done on multiple hosts

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Fix a bug where the coalesce on a secondary host of a QCOW2 VDI on LVMSR could corrupt LVM metadata and would need manual intervention to restore them.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

ANSWER, or N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

EXPLANATIONS

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Manual tests were done on VDI activation from the master and the secondary hosts.
Existing coalesce tests from xcp-ng-tests were run.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

N/A

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Coalesce on LVMoISCSI

#### What tests have been or will be added to CI for this change? If none, explain why.

Tests for coalesce on hostA2 will be added in the future.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->

Koji build(v8.3-incoming, scratch): https://koji.xcp-ng.org/taskinfo?taskID=111615